### PR TITLE
회원가입 기능 구현

### DIFF
--- a/backend/src/main/java/com/board/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/board/domain/member/controller/MemberController.java
@@ -1,0 +1,43 @@
+package com.board.domain.member.controller;
+
+import com.board.domain.member.dto.MemberSignupRequest;
+import com.board.domain.member.service.MemberService;
+
+import jakarta.validation.Valid;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/nickname/{nickname}")
+    public ResponseEntity<String> memberNicknameExists(@PathVariable("nickname") String nickname) {
+        memberService.memberNicknameExists(nickname);
+        return ResponseEntity.ok().body("ok");
+    }
+
+    @GetMapping("/username/{username}")
+    public ResponseEntity<String> memberUsernameExists(@PathVariable("username") String username) {
+        memberService.memberUsernameExists(username);
+        return ResponseEntity.ok().body("ok");
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<Void> memberSignup(@RequestBody @Valid MemberSignupRequest memberSignupRequest) {
+        memberService.memberSignup(memberSignupRequest);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/member/dto/MemberSignupRequest.java
+++ b/backend/src/main/java/com/board/domain/member/dto/MemberSignupRequest.java
@@ -1,0 +1,26 @@
+package com.board.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberSignupRequest {
+
+    @NotBlank
+    private String nickname;
+
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String password;
+
+    @NotBlank
+    private String passwordConfirm;
+
+}

--- a/backend/src/main/java/com/board/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/board/domain/member/entity/Member.java
@@ -1,0 +1,48 @@
+package com.board.domain.member.entity;
+
+import com.board.global.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Builder
+    public Member(String nickname, String username, String password) {
+        this.nickname = nickname;
+        this.username = username;
+        this.password = password;
+        this.role = Role.MEMBER;
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/member/entity/Role.java
+++ b/backend/src/main/java/com/board/domain/member/entity/Role.java
@@ -1,0 +1,17 @@
+package com.board.domain.member.entity;
+
+public enum Role {
+
+    MEMBER("ROLE_MEMBER");
+
+    private final String authority;
+
+    Role(String authority) {
+        this.authority = authority;
+    }
+
+    public String getAuthority() {
+        return authority;
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/member/exception/DuplicateNicknameException.java
+++ b/backend/src/main/java/com/board/domain/member/exception/DuplicateNicknameException.java
@@ -1,0 +1,12 @@
+package com.board.domain.member.exception;
+
+import com.board.global.error.ErrorType;
+import com.board.global.error.exception.BaseException;
+
+public class DuplicateNicknameException extends BaseException {
+
+    public DuplicateNicknameException() {
+        super(ErrorType.DUPLICATE_NICKNAME);
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/member/exception/DuplicateUsernameException.java
+++ b/backend/src/main/java/com/board/domain/member/exception/DuplicateUsernameException.java
@@ -1,0 +1,12 @@
+package com.board.domain.member.exception;
+
+import com.board.global.error.ErrorType;
+import com.board.global.error.exception.BaseException;
+
+public class DuplicateUsernameException extends BaseException {
+
+    public DuplicateUsernameException() {
+        super(ErrorType.DUPLICATE_USERNAME);
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/member/exception/PasswordMismatchException.java
+++ b/backend/src/main/java/com/board/domain/member/exception/PasswordMismatchException.java
@@ -1,0 +1,12 @@
+package com.board.domain.member.exception;
+
+import com.board.global.error.ErrorType;
+import com.board.global.error.exception.BaseException;
+
+public class PasswordMismatchException extends BaseException {
+
+    public PasswordMismatchException() {
+        super(ErrorType.PASSWORD_MISMATCH);
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/board/domain/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.board.domain.member.repository;
+
+import com.board.domain.member.entity.Member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    boolean existsMemberByNickname(String nickname);
+    boolean existsMemberByUsername(String username);
+
+}

--- a/backend/src/main/java/com/board/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/board/domain/member/service/MemberService.java
@@ -1,0 +1,53 @@
+package com.board.domain.member.service;
+
+import com.board.domain.member.dto.MemberSignupRequest;
+import com.board.domain.member.entity.Member;
+import com.board.domain.member.exception.DuplicateNicknameException;
+import com.board.domain.member.exception.DuplicateUsernameException;
+import com.board.domain.member.exception.PasswordMismatchException;
+import com.board.domain.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void memberNicknameExists(String nickname) {
+        if (memberRepository.existsMemberByNickname(nickname)) {
+            throw new DuplicateNicknameException();
+        }
+    }
+
+    @Transactional
+    public void memberUsernameExists(String username) {
+        if (memberRepository.existsMemberByUsername(username)) {
+            throw new DuplicateUsernameException();
+        }
+    }
+
+    @Transactional
+    public void memberSignup(MemberSignupRequest memberSignupRequest) {
+        memberNicknameExists(memberSignupRequest.getNickname());
+        memberUsernameExists(memberSignupRequest.getUsername());
+        if (!memberSignupRequest.getPassword().equals(memberSignupRequest.getPasswordConfirm())) {
+            throw new PasswordMismatchException();
+        }
+        String enocoded = passwordEncoder.encode(memberSignupRequest.getPassword());
+        Member member = Member.builder()
+                .nickname(memberSignupRequest.getNickname())
+                .username(memberSignupRequest.getUsername())
+                .password(enocoded)
+                .build();
+        memberRepository.save(member);
+    }
+
+}

--- a/backend/src/main/java/com/board/global/common/config/JpaAuditConfig.java
+++ b/backend/src/main/java/com/board/global/common/config/JpaAuditConfig.java
@@ -1,0 +1,9 @@
+package com.board.global.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditConfig {
+}

--- a/backend/src/main/java/com/board/global/common/entity/BaseEntity.java
+++ b/backend/src/main/java/com/board/global/common/entity/BaseEntity.java
@@ -1,0 +1,28 @@
+package com.board.global.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+
+import lombok.Getter;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+}

--- a/backend/src/main/java/com/board/global/error/ErrorType.java
+++ b/backend/src/main/java/com/board/global/error/ErrorType.java
@@ -7,7 +7,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorType {
 
-    UN_SUPPORT_ERROR_TYPE("E000000", HttpStatus.NOT_FOUND.value(), "지원하지 않는 예외 유형입니다.");
+    UN_SUPPORT_ERROR_TYPE("E000000", HttpStatus.NOT_FOUND.value(), "지원하지 않는 예외 유형입니다."),
+    INVALID_INPUT_VALUE("E400001", HttpStatus.BAD_REQUEST.value(), "입력값이 잘못되었습니다."),
+    PASSWORD_MISMATCH("E400002", HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),
+    DUPLICATE_NICKNAME("E409001", HttpStatus.CONFLICT.value(), "사용 중인 닉네임입니다."),
+    DUPLICATE_USERNAME("E409002", HttpStatus.CONFLICT.value(), "사용 중인 아이디입니다.");
 
     private final String errorCode;
     private final int status;

--- a/backend/src/main/java/com/board/global/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/board/global/error/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.board.global.error.dto.ErrorResponse;
 import com.board.global.error.exception.BaseException;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -11,9 +12,15 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(BaseException.class)
-    ResponseEntity<ErrorResponse> handleBaseException(BaseException e) {
+    public ResponseEntity<ErrorResponse> handleBaseException(BaseException e) {
         final ErrorResponse errorResponse = ErrorResponse.of(e.getErrorType());
         return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException() {
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorType.INVALID_INPUT_VALUE);
+        return ResponseEntity.badRequest().body(errorResponse);
     }
 
 }

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -1,0 +1,37 @@
+package com.board.global.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/members/nickname/*",
+                                "/api/members/username/*").permitAll()
+                        .requestMatchers(HttpMethod.POST,
+                                "/api/members/signup").permitAll()
+                        .anyRequest().denyAll()
+                );
+        return httpSecurity.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/backend/src/test/java/com/board/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/board/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,154 @@
+package com.board.domain.member.controller;
+
+import com.board.domain.member.dto.MemberSignupRequest;
+import com.board.domain.member.exception.DuplicateNicknameException;
+import com.board.domain.member.exception.DuplicateUsernameException;
+import com.board.domain.member.exception.PasswordMismatchException;
+import com.board.domain.member.service.MemberService;
+import com.board.global.security.config.SecurityConfig;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = MemberController.class)
+@Import(SecurityConfig.class)
+class MemberControllerTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("닉네임 중복 확인을 한다")
+    void memberNicknameExists() throws Exception {
+        String targetNickname = "yoonkun";
+
+        willDoNothing().given(memberService).memberNicknameExists(anyString());
+
+        mockMvc.perform(get("/api/members/nickname/" + targetNickname))
+                .andExpect(status().isOk())
+                .andExpect(content().string("ok"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 시 예외가 발생한다")
+    void memberNicknameExists_duplicateNickname() throws Exception {
+        String targetNickname = "yoonkun";
+
+        willThrow(new DuplicateNicknameException()).given(memberService).memberNicknameExists(anyString());
+
+        mockMvc.perform(get("/api/members/nickname/" + targetNickname))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("E409001"))
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.message").value("사용 중인 닉네임입니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("아이디 중복 확인을 한다")
+    void memberUsernameExists() throws Exception {
+        String targetUsername = "yoon1234";
+
+        willDoNothing().given(memberService).memberUsernameExists(anyString());
+
+        mockMvc.perform(get("/api/members/username/" + targetUsername))
+                .andExpect(status().isOk())
+                .andExpect(content().string("ok"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("아이디 중복 시 예외가 발생한다")
+    void memberUsernameExists_duplicateUsername() throws Exception {
+        String targetUsername = "yoon1234";
+
+        willThrow(new DuplicateUsernameException()).given(memberService).memberUsernameExists(anyString());
+
+        mockMvc.perform(get("/api/members/username/" + targetUsername))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("E409002"))
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.message").value("사용 중인 아이디입니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("회원가입을 한다")
+    void memberSignup() throws Exception {
+        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonkun", "yoon1234", "12345678", "12345678");
+
+        willDoNothing().given(memberService).memberSignup(any(MemberSignupRequest.class));
+
+        mockMvc.perform(post("/api/members/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberSignupRequest))
+                )
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("회원가입 시 입력값이 잘못되면 예외가 발생한다")
+    void memberSignup_invalidInputValue() throws Exception {
+        MemberSignupRequest invalidMemberSignupRequest = new MemberSignupRequest("", "", "12345678", "12345678");
+
+        willDoNothing().given(memberService).memberSignup(any(MemberSignupRequest.class));
+
+        mockMvc.perform(post("/api/members/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidMemberSignupRequest))
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("E400001"))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("입력값이 잘못되었습니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("회원가입 시 비밀번호가 일치하지 않으면 예외가 발생한다")
+    void memberSignup_passwordMismatch() throws Exception {
+        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonkun", "yoon1234", "12345678", "12345679");
+
+        willThrow(new PasswordMismatchException()).given(memberService).memberSignup(any(MemberSignupRequest.class));
+
+        mockMvc.perform(post("/api/members/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberSignupRequest))
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("E400002"))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("비밀번호가 일치하지 않습니다."))
+                .andDo(print());
+    }
+
+}

--- a/backend/src/test/java/com/board/domain/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,70 @@
+package com.board.domain.member.repository;
+
+import com.board.domain.member.entity.Member;
+import com.board.global.common.config.JpaAuditConfig;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(JpaAuditConfig.class)
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("닉네임 존재 여부를 확인한다")
+    void memberNicknameExists() {
+        Member member = Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .password("12345678")
+                .build();
+        memberRepository.save(member);
+
+        boolean existsNickname = memberRepository.existsMemberByNickname("yoonkun");
+        boolean nonExistsNickname = memberRepository.existsMemberByNickname("yoonkong");
+
+        assertThat(existsNickname).isTrue();
+        assertThat(nonExistsNickname).isFalse();
+    }
+
+    @Test
+    @DisplayName("아이디 존재 여부를 확인한다")
+    void memberUsernameExists() {
+        Member member = Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .password("12345678")
+                .build();
+        memberRepository.save(member);
+
+        boolean existsUsername = memberRepository.existsMemberByUsername("yoon1234");
+        boolean nonExistsUsername = memberRepository.existsMemberByUsername("yoon5678");
+
+        assertThat(existsUsername).isTrue();
+        assertThat(nonExistsUsername).isFalse();
+    }
+
+    @Test
+    @DisplayName("회원을 저장한다")
+    void memberSave() {
+        Member member = Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .password("12345678")
+                .build();
+
+        Member saveMember = memberRepository.save(member);
+
+        assertThat(saveMember.getId()).isNotNull();
+    }
+
+}

--- a/backend/src/test/java/com/board/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/board/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,134 @@
+package com.board.domain.member.service;
+
+import com.board.domain.member.dto.MemberSignupRequest;
+import com.board.domain.member.entity.Member;
+import com.board.domain.member.exception.DuplicateNicknameException;
+import com.board.domain.member.exception.DuplicateUsernameException;
+import com.board.domain.member.exception.PasswordMismatchException;
+import com.board.domain.member.repository.MemberRepository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("닉네임 중복 확인을 한다")
+    void memberNicknameExists() {
+        String targetNickname = "yoonkun";
+
+        given(memberRepository.existsMemberByNickname(anyString())).willReturn(false);
+
+        memberService.memberNicknameExists(targetNickname);
+
+        then(memberRepository).should().existsMemberByNickname(anyString());
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 시 예외가 발생한다")
+    void memberNicknameExists_duplicateNickname() {
+        String targetNickname = "yoonkun";
+
+        given(memberRepository.existsMemberByNickname(anyString())).willReturn(true);
+
+        assertThatThrownBy(() -> memberService.memberNicknameExists(targetNickname))
+                        .isInstanceOf(DuplicateNicknameException.class);
+
+        then(memberRepository).should().existsMemberByNickname(anyString());
+    }
+
+    @Test
+    @DisplayName("아이디 중복 확인을 한다")
+    void memberUsernameExists() {
+        String targetUsername = "yoon1234";
+
+        given(memberRepository.existsMemberByUsername(anyString())).willReturn(false);
+
+        memberService.memberUsernameExists(targetUsername);
+
+        then(memberRepository).should().existsMemberByUsername(anyString());
+    }
+
+    @Test
+    @DisplayName("아이이 중복 시 예외가 발생한다")
+    void memberUsernameExists_duplicateUsername() {
+        String targetUsername = "yoon1234";
+
+        given(memberRepository.existsMemberByUsername(anyString())).willReturn(true);
+
+        assertThatThrownBy(() -> memberService.memberUsernameExists(targetUsername))
+                .isInstanceOf(DuplicateUsernameException.class);
+
+        then(memberRepository).should().existsMemberByUsername(anyString());
+    }
+
+    @Test
+    @DisplayName("회원가입을 한다")
+    void memberSignup() {
+        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonkun", "yoon1234", "12345678", "12345678");
+
+        String encoded = new BCryptPasswordEncoder().encode(memberSignupRequest.getPassword());
+
+        Member member = Member.builder()
+                .nickname(memberSignupRequest.getNickname())
+                .username(memberSignupRequest.getUsername())
+                .password(encoded)
+                .build();
+
+        given(memberRepository.existsMemberByNickname(anyString())).willReturn(false);
+        given(memberRepository.existsMemberByUsername(anyString())).willReturn(false);
+        given(passwordEncoder.encode(anyString())).willReturn(encoded);
+        given(memberRepository.save(any(Member.class))).willReturn(member);
+
+        memberService.memberSignup(memberSignupRequest);
+
+        then(memberRepository).should().existsMemberByNickname(anyString());
+        then(memberRepository).should().existsMemberByUsername(anyString());
+        then(passwordEncoder).should().encode(anyString());
+        then(memberRepository).should().save(any(Member.class));
+    }
+
+    @Test
+    @DisplayName("회원가입 시 비밀번호가 일치하지 않으면 예외가 발생한다")
+    void memberSignup_passwordMismatch() {
+        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonkun", "yoon1234", "12345678", "12345679");
+
+        given(memberRepository.existsMemberByNickname(anyString())).willReturn(false);
+        given(memberRepository.existsMemberByUsername(anyString())).willReturn(false);
+
+        assertThatThrownBy(() -> memberService.memberSignup(memberSignupRequest))
+                .isInstanceOf(PasswordMismatchException.class);
+
+        then(memberRepository).should().existsMemberByNickname(anyString());
+        then(memberRepository).should().existsMemberByUsername(anyString());
+        then(passwordEncoder).should(never()).encode(anyString());
+        then(memberRepository).should(never()).save(any(Member.class));
+    }
+
+}


### PR DESCRIPTION
## 작업 내용

### 추가사항

#### # 회원 엔티티 추가(0cec45558258e7611ee2113968c151800c0e3033)

- 기본키(id), 닉네임(nickname), 아이디(username), 비밀번호(password), 권한(role) 필드를 가진다.
- 모든 필드는 null을 허용하지 않는다.
- 닉네임과 아이디는 중복되지 않게 unique 설정을 true로 설정

#### # Jpa Auditing 설정 추가(7be39f992f05de1969aed86c78281f3681c77cdb)

- 엔티티의 생성 및 수정 시간을 기록하기 위한 BaseEntity 추가

#### # 닉네임, 아이디 중복 및 비밀번호 불일치 예외 추가(1e5196b7d2b8237f41feed61372f1909929905d6)

- 닉네임, 아이디 중복 발생 시 발생하는 예외 추가
- 회원가입 시 비밀번호가 일치하지 않을 때 발생하는 예외 추가

#### # 컨트롤러에서 유효성 예외가 발생 할 시 처리하는 핸들러 추가(d2a08725a7d484e749859dcd3d371c0342750b98)

- DTO를 받을 때 값이 비어있는 경우 또는 특정 정규표현식에 일치하지 않을 때 발생하는 예외를 처리하는 핸들러 추가

#### # 시큐리티 설정 추가(f2bd88bb437c545f15a3dc4dc53084d5e5db69b6)

- csrf 설정 비활성화
- `/api/members/nickname/*`, `/api/members/username/*`, `/api/members/signup` 경로에 대한 권한을 전부 허용으로 설정
- 그 외 경로는 전부 접근 제어 설정

#### # 회원가입 기능 추가(a63b19e5fc60c5836765c1ef1041df91efdcf666)

- 닉네임 중복 요청 API 추가
- 아이디 중복 요청 API 추가
- 회원가입 요청 API 추가

#### # 회원가입 기능 테스트 추가(989f1f40e41522e14ea916bfbe63ad429700046f)

- 닉네임, 아이디 중복 및 회원가입 요청 API 테스트 추가
- 닉네임, 아이디 중복 확인 및 회원가입 기능 테스트 추가
- 닉네임, 아이디 중복 여부 및 회원 엔티티 저장 기능 테스트 추가

### 변경사항

없음

#

#### 관련 이슈

- close #3 
