### PR TITLE
로그인 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/backend/src/main/java/com/board/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/board/domain/member/repository/MemberRepository.java
@@ -4,9 +4,12 @@ import com.board.domain.member.entity.Member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsMemberByNickname(String nickname);
     boolean existsMemberByUsername(String username);
+    Optional<Member> findMemberByUsername(String username);
 
 }

--- a/backend/src/main/java/com/board/domain/token/dto/TokenResponse.java
+++ b/backend/src/main/java/com/board/domain/token/dto/TokenResponse.java
@@ -1,0 +1,16 @@
+package com.board.domain.token.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TokenResponse {
+
+    private final String accessToken;
+    private final String refreshToken;
+
+    public TokenResponse(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/token/entity/Token.java
+++ b/backend/src/main/java/com/board/domain/token/entity/Token.java
@@ -1,0 +1,41 @@
+package com.board.domain.token.entity;
+
+import com.board.domain.member.entity.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Token {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "token_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String refreshToken;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public Token(String refreshToken, Member member) {
+        this.refreshToken = refreshToken;
+        this.member = member;
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/token/repository/TokenRepository.java
+++ b/backend/src/main/java/com/board/domain/token/repository/TokenRepository.java
@@ -1,0 +1,8 @@
+package com.board.domain.token.repository;
+
+import com.board.domain.token.entity.Token;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+}

--- a/backend/src/main/java/com/board/domain/token/service/TokenService.java
+++ b/backend/src/main/java/com/board/domain/token/service/TokenService.java
@@ -1,0 +1,33 @@
+package com.board.domain.token.service;
+
+import com.board.domain.member.entity.Member;
+import com.board.domain.token.dto.TokenResponse;
+import com.board.domain.token.entity.Token;
+import com.board.domain.token.repository.TokenRepository;
+import com.board.domain.token.util.JwtUtil;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final TokenRepository tokenRepository;
+    private final JwtUtil jwtUtil;
+
+    @Transactional
+    public TokenResponse tokenSave(Member member) {
+        String accessToken = jwtUtil.createAccessToken(member.getUsername(), member.getNickname(), member.getRole().getAuthority());
+        String refreshToken = jwtUtil.createRefreshToken(member.getUsername());
+        Token token = Token.builder()
+                .refreshToken(refreshToken)
+                .member(member)
+                .build();
+        tokenRepository.save(token);
+        return new TokenResponse(accessToken, refreshToken);
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/token/util/JwtUtil.java
+++ b/backend/src/main/java/com/board/domain/token/util/JwtUtil.java
@@ -1,0 +1,54 @@
+package com.board.domain.token.util;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+    private final long accessTokenExpire;
+    private final long refreshTokenExpire;
+
+    public JwtUtil(@Value("${jwt.secret-key}") String secretKey,
+                   @Value("${jwt.access-token.expire}") long accessTokenExpire,
+                   @Value("${jwt.refresh-token.expire}") long refreshTokenExpire) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpire = accessTokenExpire;
+        this.refreshTokenExpire = refreshTokenExpire;
+    }
+
+    public String createAccessToken(String username, String nickname, String authority) {
+        Date iat = new Date();
+        Date exp = new Date(iat.getTime() + accessTokenExpire);
+        return Jwts.builder()
+                .subject(username)
+                .claim("nickname", nickname)
+                .claim("authority", authority)
+                .issuedAt(iat)
+                .expiration(exp)
+                .signWith(secretKey, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    public String createRefreshToken(String username) {
+        Date iat = new Date();
+        Date exp = new Date(iat.getTime() + refreshTokenExpire);
+        return Jwts.builder()
+                .subject(username)
+                .issuedAt(iat)
+                .expiration(exp)
+                .signWith(secretKey, Jwts.SIG.HS256)
+                .compact();
+    }
+
+}

--- a/backend/src/main/java/com/board/global/error/ErrorType.java
+++ b/backend/src/main/java/com/board/global/error/ErrorType.java
@@ -10,6 +10,7 @@ public enum ErrorType {
     UN_SUPPORT_ERROR_TYPE("E000000", HttpStatus.NOT_FOUND.value(), "지원하지 않는 예외 유형입니다."),
     INVALID_INPUT_VALUE("E400001", HttpStatus.BAD_REQUEST.value(), "입력값이 잘못되었습니다."),
     PASSWORD_MISMATCH("E400002", HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),
+    BAD_CREDENTIALS("E401001", HttpStatus.UNAUTHORIZED.value(), "아이디 또는 비밀번호가 일치하지 않습니다."),
     DUPLICATE_NICKNAME("E409001", HttpStatus.CONFLICT.value(), "사용 중인 닉네임입니다."),
     DUPLICATE_USERNAME("E409002", HttpStatus.CONFLICT.value(), "사용 중인 아이디입니다.");
 

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -1,23 +1,50 @@
 package com.board.global.security.config;
 
+import com.board.domain.token.service.TokenService;
+import com.board.global.security.handler.MemberLoginFailureHandler;
+import com.board.global.security.handler.MemberLoginSuccessHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 
 @EnableWebSecurity
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final ObjectMapper objectMapper;
+    private final TokenService tokenService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
                 .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .formLogin(form -> form
+                        .loginProcessingUrl("/api/members/login")
+                        .usernameParameter("username")
+                        .passwordParameter("password")
+                        .successHandler(memberLoginSuccessHandler())
+                        .failureHandler(memberLoginFailureHandler())
+                        .permitAll()
+                )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET,
                                 "/api/members/nickname/*",
@@ -32,6 +59,16 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationSuccessHandler memberLoginSuccessHandler() {
+        return new MemberLoginSuccessHandler(objectMapper, tokenService);
+    }
+
+    @Bean
+    public AuthenticationFailureHandler memberLoginFailureHandler() {
+        return new MemberLoginFailureHandler(objectMapper);
     }
 
 }

--- a/backend/src/main/java/com/board/global/security/dto/AuthPrincipal.java
+++ b/backend/src/main/java/com/board/global/security/dto/AuthPrincipal.java
@@ -1,0 +1,21 @@
+package com.board.global.security.dto;
+
+import com.board.domain.member.entity.Member;
+
+import lombok.Getter;
+
+import org.springframework.security.core.userdetails.User;
+
+import static org.springframework.security.core.authority.AuthorityUtils.createAuthorityList;
+
+@Getter
+public class AuthPrincipal extends User {
+
+    private final Member member;
+
+    public AuthPrincipal(Member member) {
+        super(member.getUsername(), member.getPassword(), createAuthorityList(member.getRole().getAuthority()));
+        this.member = member;
+    }
+
+}

--- a/backend/src/main/java/com/board/global/security/handler/MemberLoginFailureHandler.java
+++ b/backend/src/main/java/com/board/global/security/handler/MemberLoginFailureHandler.java
@@ -1,0 +1,39 @@
+package com.board.global.security.handler;
+
+import com.board.global.error.ErrorType;
+import com.board.global.error.dto.ErrorResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class MemberLoginFailureHandler implements AuthenticationFailureHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        ErrorType errorType = ErrorType.UN_SUPPORT_ERROR_TYPE;
+        if (exception instanceof BadCredentialsException) {
+            errorType = ErrorType.BAD_CREDENTIALS;
+        }
+        ErrorResponse errorResponse = ErrorResponse.of(errorType);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(errorResponse.getStatus());
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+
+}

--- a/backend/src/main/java/com/board/global/security/handler/MemberLoginSuccessHandler.java
+++ b/backend/src/main/java/com/board/global/security/handler/MemberLoginSuccessHandler.java
@@ -1,0 +1,38 @@
+package com.board.global.security.handler;
+
+import com.board.domain.token.dto.TokenResponse;
+import com.board.domain.token.service.TokenService;
+import com.board.global.security.dto.AuthPrincipal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class MemberLoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final ObjectMapper objectMapper;
+    private final TokenService tokenService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+        AuthPrincipal authPrincipal = (AuthPrincipal) authentication.getPrincipal();
+        TokenResponse tokenResponse = tokenService.tokenSave(authPrincipal.getMember());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.OK.value());
+        objectMapper.writeValue(response.getOutputStream(), tokenResponse);
+    }
+
+}

--- a/backend/src/main/java/com/board/global/security/service/UserDetailsServiceImpl.java
+++ b/backend/src/main/java/com/board/global/security/service/UserDetailsServiceImpl.java
@@ -1,0 +1,25 @@
+package com.board.global.security.service;
+
+import com.board.domain.member.entity.Member;
+import com.board.domain.member.repository.MemberRepository;
+import com.board.global.security.dto.AuthPrincipal;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findMemberByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("회원이 존재하지 않습니다."));
+        return new AuthPrincipal(member);
+    }
+
+}

--- a/backend/src/test/java/com/board/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/board/domain/member/controller/MemberControllerTest.java
@@ -1,11 +1,15 @@
 package com.board.domain.member.controller;
 
 import com.board.domain.member.dto.MemberSignupRequest;
+import com.board.domain.member.entity.Member;
 import com.board.domain.member.exception.DuplicateNicknameException;
 import com.board.domain.member.exception.DuplicateUsernameException;
 import com.board.domain.member.exception.PasswordMismatchException;
 import com.board.domain.member.service.MemberService;
+import com.board.domain.token.dto.TokenResponse;
+import com.board.domain.token.service.TokenService;
 import com.board.global.security.config.SecurityConfig;
+import com.board.global.security.dto.AuthPrincipal;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -17,10 +21,13 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 
@@ -42,16 +49,20 @@ class MemberControllerTest {
     private MockMvc mockMvc;
 
     @MockBean
+    private UserDetailsService userDetailsService;
+
+    @MockBean
+    private TokenService tokenService;
+
+    @MockBean
     private MemberService memberService;
 
     @Test
     @DisplayName("닉네임 중복 확인을 한다")
     void memberNicknameExists() throws Exception {
-        String targetNickname = "yoonkun";
-
         willDoNothing().given(memberService).memberNicknameExists(anyString());
 
-        mockMvc.perform(get("/api/members/nickname/" + targetNickname))
+        mockMvc.perform(get("/api/members/nickname/yoonkun"))
                 .andExpect(status().isOk())
                 .andExpect(content().string("ok"))
                 .andDo(print());
@@ -60,11 +71,9 @@ class MemberControllerTest {
     @Test
     @DisplayName("닉네임 중복 시 예외가 발생한다")
     void memberNicknameExists_duplicateNickname() throws Exception {
-        String targetNickname = "yoonkun";
-
         willThrow(new DuplicateNicknameException()).given(memberService).memberNicknameExists(anyString());
 
-        mockMvc.perform(get("/api/members/nickname/" + targetNickname))
+        mockMvc.perform(get("/api/members/nickname/yoonkun"))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.errorCode").value("E409001"))
                 .andExpect(jsonPath("$.status").value(409))
@@ -75,11 +84,9 @@ class MemberControllerTest {
     @Test
     @DisplayName("아이디 중복 확인을 한다")
     void memberUsernameExists() throws Exception {
-        String targetUsername = "yoon1234";
-
         willDoNothing().given(memberService).memberUsernameExists(anyString());
 
-        mockMvc.perform(get("/api/members/username/" + targetUsername))
+        mockMvc.perform(get("/api/members/username/yoon1234"))
                 .andExpect(status().isOk())
                 .andExpect(content().string("ok"))
                 .andDo(print());
@@ -88,11 +95,9 @@ class MemberControllerTest {
     @Test
     @DisplayName("아이디 중복 시 예외가 발생한다")
     void memberUsernameExists_duplicateUsername() throws Exception {
-        String targetUsername = "yoon1234";
-
         willThrow(new DuplicateUsernameException()).given(memberService).memberUsernameExists(anyString());
 
-        mockMvc.perform(get("/api/members/username/" + targetUsername))
+        mockMvc.perform(get("/api/members/username/yoon1234"))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.errorCode").value("E409002"))
                 .andExpect(jsonPath("$.status").value(409))
@@ -148,6 +153,53 @@ class MemberControllerTest {
                 .andExpect(jsonPath("$.errorCode").value("E400002"))
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.message").value("비밀번호가 일치하지 않습니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("로그인을 한다")
+    void memberLogin() throws Exception {
+        Member member = Member.builder()
+                .username("yoon1234")
+                .password(new BCryptPasswordEncoder().encode("12345678"))
+                .build();
+        AuthPrincipal authPrincipal = new AuthPrincipal(member);
+        TokenResponse tokenResponse = new TokenResponse("access-token", "refresh-token");
+
+        given(userDetailsService.loadUserByUsername(anyString())).willReturn(authPrincipal);
+        given(tokenService.tokenSave(any(Member.class))).willReturn(tokenResponse);
+
+        mockMvc.perform(post("/api/members/login")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .param("username", "yoon1234")
+                        .param("password", "12345678")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("access-token"))
+                .andExpect(jsonPath("$.refreshToken").value("refresh-token"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("로그인 시 아이디 또는 비밀번호가 일치하지 않으면 예외가 발생한다")
+    void memberLogin_badCredentials() throws Exception {
+        Member member = Member.builder()
+                .username("yoon1234")
+                .password(new BCryptPasswordEncoder().encode("12345678"))
+                .build();
+        AuthPrincipal authPrincipal = new AuthPrincipal(member);
+
+        given(userDetailsService.loadUserByUsername(anyString())).willReturn(authPrincipal);
+
+        mockMvc.perform(post("/api/members/login")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .param("username", "yoon1234")
+                        .param("password", "87654321")
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("E401001"))
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.message").value("아이디 또는 비밀번호가 일치하지 않습니다."))
                 .andDo(print());
     }
 

--- a/backend/src/test/java/com/board/domain/token/repository/TokenRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/token/repository/TokenRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.board.domain.token.repository;
+
+import com.board.domain.member.entity.Member;
+import com.board.domain.member.repository.MemberRepository;
+import com.board.domain.token.entity.Token;
+import com.board.global.common.config.JpaAuditConfig;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(JpaAuditConfig.class)
+class TokenRepositoryTest {
+
+    @Autowired
+    private TokenRepository tokenRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = memberRepository.save(Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .password("12345678")
+                .build());
+    }
+
+    @Test
+    @DisplayName("토큰을 저장한다")
+    void tokenSave() {
+        Token token = Token.builder()
+                .refreshToken("refresh-token")
+                .member(member)
+                .build();
+
+        Token saveToken = tokenRepository.save(token);
+
+        assertThat(saveToken.getId()).isNotNull();
+    }
+
+}

--- a/backend/src/test/java/com/board/domain/token/service/TokenServiceTest.java
+++ b/backend/src/test/java/com/board/domain/token/service/TokenServiceTest.java
@@ -1,0 +1,56 @@
+package com.board.domain.token.service;
+
+import com.board.domain.member.entity.Member;
+import com.board.domain.token.entity.Token;
+import com.board.domain.token.repository.TokenRepository;
+import com.board.domain.token.util.JwtUtil;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class TokenServiceTest {
+
+    @Mock
+    private TokenRepository tokenRepository;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @InjectMocks
+    private TokenService tokenService;
+
+    @Test
+    @DisplayName("토큰을 저장한다")
+    void tokenSave() {
+        Member member = Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .build();
+        Token token = Token.builder()
+                .refreshToken("refresh-token")
+                .member(member)
+                .build();
+
+        given(jwtUtil.createAccessToken(anyString(), anyString(), anyString())).willReturn("access-token");
+        given(jwtUtil.createRefreshToken(anyString())).willReturn("refresh-token");
+        given(tokenRepository.save(any(Token.class))).willReturn(token);
+
+        tokenService.tokenSave(member);
+
+        then(jwtUtil).should().createAccessToken(anyString(), anyString(), anyString());
+        then(jwtUtil).should().createRefreshToken(anyString());
+        then(tokenRepository).should().save(any(Token.class));
+    }
+
+}

--- a/backend/src/test/java/com/board/domain/token/util/JwtUtilTest.java
+++ b/backend/src/test/java/com/board/domain/token/util/JwtUtilTest.java
@@ -1,0 +1,33 @@
+package com.board.domain.token.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class JwtUtilTest {
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Test
+    @DisplayName("Access Token을 생성한다")
+    void createAccessToken() {
+        String accessToken = jwtUtil.createAccessToken("yoon1234", "yoonKun", "ROLE_MEMBER");
+
+        assertThat(accessToken).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Refresh Token을 생성한다")
+    void createRefreshToken() {
+        String refreshToken = jwtUtil.createRefreshToken("yoon1234");
+
+        assertThat(refreshToken).isNotNull();
+    }
+
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,0 +1,20 @@
+spring:
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: false
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+jwt:
+  secret-key: c3ByaW5nLXNlY3VyaXR5LXdpdGgtand0LXNlY3JldC1rZXk=
+  access-token:
+    expire: 300000
+  refresh-token:
+    expire: 86400000


### PR DESCRIPTION
## 작업 내용

스프링 시큐리티의 formLogin() 기능을 사용해 로그인 기능 구현

### 추가사항

#### # 토큰 엔티티 추가(7a1ed6f03bbf759e0707507ff5b7921ea8a571c2)

- 기본키(id), 리프레시 토큰(refresh token), 회원(member) 필드를 가진다.
- 모든 필드는 null을 허용하지 않는다.
- 리프레시 토큰은 중복을 허용하지 않는다.
- 토큰과 회원의 연관관계는 일대일 관계로 설정

#### # 토큰 저장 기능 추가(316f412659e4eeb42059fe52815d54dc2da9e541)

- 로그인 성공 후 Refresh Token을 DB에 저장한다.
- Access Token, Refresh Token 생성 기능 추가(3e2cf42a2afd131a25a642452a50b1c882e99024)
- 토큰 생성 및 저장 기능 테스트 수행(b4a66157ffb3ddb4197507c6891951ded8c64f65, 1cc112188d33c1aec949abb9cfef1c8bddb5a87c)

#### # 로그인 성공, 실패 핸들러 추가(1ec7cb7bd528f49b32584deda7a28cffd3c22eb3)

- 로그인 성공 실패에 따른 작업을 처리하기 위한 핸들러 추가
- 로그인 성공 시 토큰을 저장하고 클라이언트에 Access Token과 Refresh Token을 응답한다.
- 아이디 또는 비밀번호가 일치하지 않을 시 실패 핸들러에서 예외 메세지를 응답한다.(cb48c8c68645ed44e00a77dae101a37a58f19c35)

#### # 로그인 기능 추가(83a788c6a61ce195a440c2b3f4ef1bc900d90b19)

- 스프링 시큐리티의 formLogin() 기능을 사용해 로그인 기능을 구현했다.
- 로그인 기능 테스트 수행(a9eb43fbf30a1127673a599cfd67a020c0700f71)

#### # jjwt 의존성 추가(8c7591d77f02504db9043fc3afc1ff57762bda1d)

- JWT 생성을 도와주는 라이브러리 추가
- https://github.com/jwtk/jjwt?tab=readme-ov-file#secret-keys

#### # 테스트시 사용하는 프로퍼티 설정 작성(8d6f7139b007dc7c08740654d4eec07032d29b03)

### 변경사항

없음

#

#### 관련 이슈

- close #7
