### PR TITLE
토큰 검증 필터 구현

### DIFF
--- a/backend/src/main/java/com/board/domain/token/exception/ExpiredTokenException.java
+++ b/backend/src/main/java/com/board/domain/token/exception/ExpiredTokenException.java
@@ -1,0 +1,13 @@
+package com.board.domain.token.exception;
+
+import com.board.global.error.ErrorType;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class ExpiredTokenException extends AuthenticationException {
+
+    public ExpiredTokenException() {
+        super(ErrorType.EXPIRED_TOKEN.getErrorCode());
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/token/exception/InvalidTokenException.java
+++ b/backend/src/main/java/com/board/domain/token/exception/InvalidTokenException.java
@@ -1,0 +1,13 @@
+package com.board.domain.token.exception;
+
+import com.board.global.error.ErrorType;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class InvalidTokenException extends AuthenticationException {
+
+    public InvalidTokenException() {
+        super(ErrorType.INVALID_TOKEN.getErrorCode());
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/token/service/TokenService.java
+++ b/backend/src/main/java/com/board/domain/token/service/TokenService.java
@@ -6,6 +6,8 @@ import com.board.domain.token.entity.Token;
 import com.board.domain.token.repository.TokenRepository;
 import com.board.domain.token.util.JwtUtil;
 
+import io.jsonwebtoken.Claims;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -28,6 +30,10 @@ public class TokenService {
                 .build();
         tokenRepository.save(token);
         return new TokenResponse(accessToken, refreshToken);
+    }
+
+    public Claims tokenPayload(String token) {
+        return jwtUtil.getPayload(token);
     }
 
 }

--- a/backend/src/main/java/com/board/domain/token/util/JwtUtil.java
+++ b/backend/src/main/java/com/board/domain/token/util/JwtUtil.java
@@ -1,5 +1,11 @@
 package com.board.domain.token.util;
 
+import com.board.domain.token.exception.ExpiredTokenException;
+import com.board.domain.token.exception.InvalidTokenException;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 
@@ -49,6 +55,20 @@ public class JwtUtil {
                 .expiration(exp)
                 .signWith(secretKey, Jwts.SIG.HS256)
                 .compact();
+    }
+
+    public Claims getPayload(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredTokenException();
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new InvalidTokenException();
+        }
     }
 
 }

--- a/backend/src/main/java/com/board/global/error/ErrorType.java
+++ b/backend/src/main/java/com/board/global/error/ErrorType.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 
 import org.springframework.http.HttpStatus;
 
+import java.util.Arrays;
+
 @Getter
 public enum ErrorType {
 
@@ -11,6 +13,8 @@ public enum ErrorType {
     INVALID_INPUT_VALUE("E400001", HttpStatus.BAD_REQUEST.value(), "입력값이 잘못되었습니다."),
     PASSWORD_MISMATCH("E400002", HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),
     BAD_CREDENTIALS("E401001", HttpStatus.UNAUTHORIZED.value(), "아이디 또는 비밀번호가 일치하지 않습니다."),
+    INVALID_TOKEN("E401002", HttpStatus.UNAUTHORIZED.value(), "토큰이 유효하지 않습니다."),
+    EXPIRED_TOKEN("E401003", HttpStatus.UNAUTHORIZED.value(), "토큰이 만료되었습니다."),
     DUPLICATE_NICKNAME("E409001", HttpStatus.CONFLICT.value(), "사용 중인 닉네임입니다."),
     DUPLICATE_USERNAME("E409002", HttpStatus.CONFLICT.value(), "사용 중인 아이디입니다.");
 
@@ -22,6 +26,13 @@ public enum ErrorType {
         this.errorCode = errorCode;
         this.status = status;
         this.message = message;
+    }
+
+    public static ErrorType of(String erroCode) {
+        return Arrays.stream(ErrorType.values())
+                .filter(errorType -> errorType.errorCode.equals(erroCode))
+                .findFirst()
+                .orElse(ErrorType.UN_SUPPORT_ERROR_TYPE);
     }
 
 }

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.board.global.security.config;
 
 import com.board.domain.token.service.TokenService;
+import com.board.global.security.filter.JwtAuthenticationFilter;
+import com.board.global.security.handler.JwtAuthenticationEntryPoint;
 import com.board.global.security.handler.MemberLoginFailureHandler;
 import com.board.global.security.handler.MemberLoginSuccessHandler;
 
@@ -17,9 +19,11 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 
 @EnableWebSecurity
 @Configuration
@@ -34,8 +38,12 @@ public class SecurityConfig {
         httpSecurity
                 .csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
+                .addFilterBefore(jwtAuthenticationFilter(), LogoutFilter.class)
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .exceptionHandling(e -> e
+                        .authenticationEntryPoint(authenticationEntryPoint())
                 )
                 .formLogin(form -> form
                         .loginProcessingUrl("/api/members/login")
@@ -69,6 +77,16 @@ public class SecurityConfig {
     @Bean
     public AuthenticationFailureHandler memberLoginFailureHandler() {
         return new MemberLoginFailureHandler(objectMapper);
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        return new JwtAuthenticationEntryPoint(objectMapper);
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(tokenService, authenticationEntryPoint());
     }
 
 }

--- a/backend/src/main/java/com/board/global/security/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/board/global/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,95 @@
+package com.board.global.security.filter;
+
+import com.board.domain.token.service.TokenService;
+
+import io.jsonwebtoken.Claims;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.springframework.security.core.authority.AuthorityUtils.createAuthorityList;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final TokenService tokenService;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String token = extractToken(request);
+            Claims payload = tokenService.tokenPayload(token);
+            Authentication authentication = createAuthentication(payload);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            filterChain.doFilter(request, response);
+        } catch (AuthenticationException e) {
+            authenticationEntryPoint.commence(request, response, e);
+        }
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (StringUtils.hasText(header) && header.startsWith("Bearer")) {
+            return header.substring("Bearer".length()).trim();
+        }
+        return null;
+    }
+
+    private Authentication createAuthentication(Claims payload) {
+        String username = payload.getSubject();
+        String authority = payload.get("authority", String.class);
+        return UsernamePasswordAuthenticationToken.authenticated(username, null, createAuthorityList(authority));
+    }
+
+    @Override
+    protected boolean shouldNotFilter(@NonNull HttpServletRequest request) {
+        return ExcludeRequest.isExcludeRequest(request.getMethod(), request.getRequestURI());
+    }
+
+    @Getter
+    private enum ExcludeRequest {
+
+        MEMBER_NICKNAME_EXISTS("GET", "/api/members/nickname/*"),
+        MEMBER_USERNAME_EXISTS("GET", "/api/members/username/*"),
+        MEMBER_SIGNUP("POST", "/api/members/signup"),
+        MEMBER_LOGIN("POST", "/api/members/login");
+
+        private final String method;
+        private final String pattern;
+
+        ExcludeRequest(String method, String pattern) {
+            this.method = method;
+            this.pattern = pattern;
+        }
+
+        private static final AntPathMatcher ANT_PATH_MATCHER = new AntPathMatcher();
+
+        public static boolean isExcludeRequest(String requestMethod, String requestURI) {
+            return Arrays.stream(ExcludeRequest.values())
+                    .anyMatch(e -> e.method.equals(requestMethod) && ANT_PATH_MATCHER.match(e.pattern, requestURI));
+        }
+
+    }
+
+}

--- a/backend/src/main/java/com/board/global/security/handler/JwtAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/board/global/security/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,36 @@
+package com.board.global.security.handler;
+
+import com.board.global.error.ErrorType;
+import com.board.global.error.dto.ErrorResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        String errorCode = authException.getMessage();
+        ErrorType errorType = ErrorType.of(errorCode);
+        ErrorResponse errorResponse = ErrorResponse.of(errorType);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(errorResponse.getStatus());
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+
+}

--- a/backend/src/test/java/com/board/domain/token/util/JwtUtilTest.java
+++ b/backend/src/test/java/com/board/domain/token/util/JwtUtilTest.java
@@ -1,18 +1,33 @@
 package com.board.domain.token.util;
 
+import com.board.domain.token.exception.ExpiredTokenException;
+import com.board.domain.token.exception.InvalidTokenException;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+
+import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 class JwtUtilTest {
 
     @Autowired
     private JwtUtil jwtUtil;
+
+    @Value("${jwt.secret-key}")
+    private String secretKey;
 
     @Test
     @DisplayName("Access Token을 생성한다")
@@ -28,6 +43,67 @@ class JwtUtilTest {
         String refreshToken = jwtUtil.createRefreshToken("yoon1234");
 
         assertThat(refreshToken).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Access Token에서 Payload를 조회한다")
+    void getPayloadAccessToken() {
+        String accessToken = jwtUtil.createAccessToken("yoon1234", "yoonKun", "ROLE_MEMBER");
+
+        Claims payload = jwtUtil.getPayload(accessToken);
+
+        assertThat(payload.getSubject()).isEqualTo("yoon1234");
+        assertThat(payload.get("nickname", String.class)).isEqualTo("yoonKun");
+        assertThat(payload.get("authority", String.class)).isEqualTo("ROLE_MEMBER");
+    }
+
+    @Test
+    @DisplayName("Refresh Token에서 Payload를 조회한다")
+    void getPayloadRefreshToken() {
+        String refreshToken = jwtUtil.createRefreshToken("yoon1234");
+
+        Claims payload = jwtUtil.getPayload(refreshToken);
+
+        assertThat(payload.getSubject()).isEqualTo("yoon1234");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 Token에서 Payload를 조회하면 예외가 발생한다")
+    void getPayloadToken_invalidToken() {
+        assertThatThrownBy(() -> jwtUtil.getPayload(null))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+
+    @Test
+    @DisplayName("만료된 Token에서 Payload를 조회하면 예외가 발생한다")
+    void getPayloadToken_expiredToken() {
+        Date iat = new Date();
+        Date exp = new Date(iat.getTime() - 1);
+        String expiredToken = Jwts.builder()
+                .subject("yoon1234")
+                .issuedAt(iat)
+                .expiration(exp)
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)), Jwts.SIG.HS256)
+                .compact();
+
+        assertThatThrownBy(() -> jwtUtil.getPayload(expiredToken))
+                .isInstanceOf(ExpiredTokenException.class);
+    }
+
+    @Test
+    @DisplayName("잘못된 시크릿 키를 가진 Token에서 Payload를 조회하면 예외가 발생한다")
+    void getPayloadToken_wrongSecretKey() {
+        Date iat = new Date();
+        Date exp = new Date(iat.getTime() + 360000);
+        String wrongSecretKeyToken = Jwts.builder()
+                .subject("yoon1234")
+                .issuedAt(iat)
+                .expiration(exp)
+                .signWith(Keys.hmacShaKeyFor("wrongSecretKeywrongSecretKeywrongSecretKey".getBytes(StandardCharsets.UTF_8)), Jwts.SIG.HS256)
+                .compact();
+
+        assertThatThrownBy(() -> jwtUtil.getPayload(wrongSecretKeyToken))
+                .isInstanceOf(InvalidTokenException.class);
     }
 
 }


### PR DESCRIPTION
## 작업 내용

클라이언트 요청 시 헤더에 포함된 토큰을 검증하는 필터를 구현했습니다. 

필터에서는 Bearer 타입의 토큰을 Authorization 헤더에서 가져와 payload 추출합니다.

토큰의 payload 추출 시 토큰이 유효하지 않거나 만료되면 AuthenticationException이 발생합니다.

> InvalidTokenException과 ExpiredTokenException은 AuthenticationException을 상속했습니다.

발생한 예외는 AuthenticationEntryPoint를 구현한 JwtAuthenticationEntryPoint에서 처리됩니다.

상태 코드 401응답과 함께 에러 코드와 관련 메세지를 클라이언트에 응답합니다.

#

#### 관련 이슈

- close #11
