### PR TITLE
로그아웃 기능 구현

### DIFF
--- a/backend/src/main/java/com/board/domain/token/repository/TokenRepository.java
+++ b/backend/src/main/java/com/board/domain/token/repository/TokenRepository.java
@@ -3,6 +3,14 @@ package com.board.domain.token.repository;
 import com.board.domain.token.entity.Token;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface TokenRepository extends JpaRepository<Token, Long> {
+
+    @Query("SELECT t FROM Token AS t WHERE t.member.username = :username")
+    Optional<Token> findByMemberUsername(@Param("username") String username);
+
 }

--- a/backend/src/main/java/com/board/domain/token/service/TokenService.java
+++ b/backend/src/main/java/com/board/domain/token/service/TokenService.java
@@ -3,6 +3,7 @@ package com.board.domain.token.service;
 import com.board.domain.member.entity.Member;
 import com.board.domain.token.dto.TokenResponse;
 import com.board.domain.token.entity.Token;
+import com.board.domain.token.exception.InvalidTokenException;
 import com.board.domain.token.repository.TokenRepository;
 import com.board.domain.token.util.JwtUtil;
 
@@ -12,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +33,15 @@ public class TokenService {
                 .build();
         tokenRepository.save(token);
         return new TokenResponse(accessToken, refreshToken);
+    }
+
+    @Transactional
+    public void tokenDelete(String username) {
+        Optional<Token> token = tokenRepository.findByMemberUsername(username);
+        if (token.isEmpty()) {
+            throw new InvalidTokenException();
+        }
+        tokenRepository.delete(token.get());
     }
 
     public Claims tokenPayload(String token) {

--- a/backend/src/main/java/com/board/global/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/board/global/error/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.board.global.error.dto.ErrorResponse;
 import com.board.global.error.exception.BaseException;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -21,6 +22,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException() {
         final ErrorResponse errorResponse = ErrorResponse.of(ErrorType.INVALID_INPUT_VALUE);
         return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException e) {
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorType.of(e.getMessage()));
+        return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
     }
 
 }

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.board.global.security.filter.JwtAuthenticationFilter;
 import com.board.global.security.handler.JwtAuthenticationEntryPoint;
 import com.board.global.security.handler.MemberLoginFailureHandler;
 import com.board.global.security.handler.MemberLoginSuccessHandler;
+import com.board.global.security.handler.MemberLogoutSuccessHandler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -24,6 +25,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 
 @EnableWebSecurity
 @Configuration
@@ -53,6 +55,11 @@ public class SecurityConfig {
                         .failureHandler(memberLoginFailureHandler())
                         .permitAll()
                 )
+                .logout(logout -> logout
+                        .logoutUrl("/api/members/logout")
+                        .logoutSuccessHandler(logoutSuccessHandler())
+                        .permitAll(false)
+                )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET,
                                 "/api/members/nickname/*",
@@ -77,6 +84,11 @@ public class SecurityConfig {
     @Bean
     public AuthenticationFailureHandler memberLoginFailureHandler() {
         return new MemberLoginFailureHandler(objectMapper);
+    }
+
+    @Bean
+    public LogoutSuccessHandler logoutSuccessHandler() {
+        return new MemberLogoutSuccessHandler(tokenService);
     }
 
     @Bean

--- a/backend/src/main/java/com/board/global/security/handler/MemberLogoutSuccessHandler.java
+++ b/backend/src/main/java/com/board/global/security/handler/MemberLogoutSuccessHandler.java
@@ -1,0 +1,27 @@
+package com.board.global.security.handler;
+
+import com.board.domain.token.service.TokenService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+
+@RequiredArgsConstructor
+public class MemberLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    private final TokenService tokenService;
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request,
+                                HttpServletResponse response,
+                                Authentication authentication) {
+        tokenService.tokenDelete(authentication.getName());
+        response.setStatus(HttpStatus.OK.value());
+    }
+
+}

--- a/backend/src/test/java/com/board/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/board/domain/member/controller/MemberControllerTest.java
@@ -7,16 +7,22 @@ import com.board.domain.member.exception.DuplicateUsernameException;
 import com.board.domain.member.exception.PasswordMismatchException;
 import com.board.domain.member.service.MemberService;
 import com.board.domain.token.dto.TokenResponse;
+import com.board.domain.token.exception.InvalidTokenException;
 import com.board.domain.token.service.TokenService;
 import com.board.global.security.config.SecurityConfig;
 import com.board.global.security.dto.AuthPrincipal;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -24,6 +30,9 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -56,6 +65,12 @@ class MemberControllerTest {
 
     @MockBean
     private MemberService memberService;
+
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+
+    @Value("${jwt.access-token.expire}")
+    private long accessTokenExpire;
 
     @Test
     @DisplayName("닉네임 중복 확인을 한다")
@@ -201,6 +216,62 @@ class MemberControllerTest {
                 .andExpect(jsonPath("$.status").value(401))
                 .andExpect(jsonPath("$.message").value("아이디 또는 비밀번호가 일치하지 않습니다."))
                 .andDo(print());
+    }
+
+    @Test
+    @DisplayName("로그아웃을 한다")
+    void memberLogout() throws Exception {
+        String accessToken = createAccessToken();
+        Claims payload = getPayload(accessToken);
+
+        given(tokenService.tokenPayload(anyString())).willReturn(payload);
+        willDoNothing().given(tokenService).tokenDelete(anyString());
+
+        mockMvc.perform(post("/api/members/logout")
+                        .header("Authorization", "Bearer " + accessToken)
+                )
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("로그아웃 시 Refresh Token이 존재하지 않으면 예외가 발생한다")
+    void memberLogout_invalidToken() throws Exception {
+        String accessToken = createAccessToken();
+        Claims payload = getPayload(accessToken);
+
+        given(tokenService.tokenPayload(anyString())).willReturn(payload);
+        willThrow(new InvalidTokenException()).given(tokenService).tokenDelete(anyString());
+
+        mockMvc.perform(post("/api/members/logout")
+                        .header("Authorization", "Bearer " + accessToken)
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("E401002"))
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.message").value("토큰이 유효하지 않습니다."))
+                .andDo(print());
+    }
+
+    private String createAccessToken() {
+        Date iat = new Date();
+        Date exp = new Date(iat.getTime() + accessTokenExpire);
+        return Jwts.builder()
+                .subject("yoon1234")
+                .claim("nickname", "yoonkun")
+                .claim("authority", "ROLE_MEMBER")
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)), Jwts.SIG.HS256)
+                .issuedAt(iat)
+                .expiration(exp)
+                .compact();
+    }
+
+    private Claims getPayload(String token) {
+        return Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)))
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
     }
 
 }

--- a/backend/src/test/java/com/board/domain/token/repository/TokenRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/token/repository/TokenRepositoryTest.java
@@ -49,4 +49,34 @@ class TokenRepositoryTest {
         assertThat(saveToken.getId()).isNotNull();
     }
 
+    @Test
+    @DisplayName("회원 아이디로 토큰을 조회한다")
+    void tokenFindByMemberUsername() {
+        Token token = Token.builder()
+                .refreshToken("refresh-token")
+                .member(member)
+                .build();
+        tokenRepository.save(token);
+
+        Token findToken = tokenRepository.findByMemberUsername(member.getUsername()).get();
+
+        assertThat(findToken.getRefreshToken()).isEqualTo("refresh-token");
+    }
+
+    @Test
+    @DisplayName("토큰을 삭제한다")
+    void tokenDelete() {
+        Token token = Token.builder()
+                .refreshToken("refresh-token")
+                .member(member)
+                .build();
+        tokenRepository.save(token);
+
+        Token findToken = tokenRepository.findByMemberUsername(member.getUsername()).get();
+
+        tokenRepository.delete(findToken);
+
+        assertThat(tokenRepository.findByMemberUsername(member.getUsername())).isEmpty();
+    }
+
 }

--- a/backend/src/test/java/com/board/domain/token/service/TokenServiceTest.java
+++ b/backend/src/test/java/com/board/domain/token/service/TokenServiceTest.java
@@ -2,9 +2,11 @@ package com.board.domain.token.service;
 
 import com.board.domain.member.entity.Member;
 import com.board.domain.token.entity.Token;
+import com.board.domain.token.exception.InvalidTokenException;
 import com.board.domain.token.repository.TokenRepository;
 import com.board.domain.token.util.JwtUtil;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,10 +15,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class TokenServiceTest {
@@ -30,13 +38,19 @@ class TokenServiceTest {
     @InjectMocks
     private TokenService tokenService;
 
-    @Test
-    @DisplayName("토큰을 저장한다")
-    void tokenSave() {
-        Member member = Member.builder()
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
                 .nickname("yoonkun")
                 .username("yoon1234")
                 .build();
+    }
+
+    @Test
+    @DisplayName("토큰을 저장한다")
+    void tokenSave() {
         Token token = Token.builder()
                 .refreshToken("refresh-token")
                 .member(member)
@@ -51,6 +65,35 @@ class TokenServiceTest {
         then(jwtUtil).should().createAccessToken(anyString(), anyString(), anyString());
         then(jwtUtil).should().createRefreshToken(anyString());
         then(tokenRepository).should().save(any(Token.class));
+    }
+
+    @Test
+    @DisplayName("토큰을 삭제한다")
+    void tokenDelete() {
+        Token token = Token.builder()
+                .refreshToken("refresh-token")
+                .member(member)
+                .build();
+
+        given(tokenRepository.findByMemberUsername(anyString())).willReturn(Optional.of(token));
+        willDoNothing().given(tokenRepository).delete(any(Token.class));
+
+        tokenService.tokenDelete("yoon1234");
+
+        then(tokenRepository).should().findByMemberUsername(anyString());
+        then(tokenRepository).should().delete(any(Token.class));
+    }
+
+    @Test
+    @DisplayName("토큰 삭제 시 토큰이 존재하지 않으면 예외가 발생한다")
+    void tokenDelete_invalidToken() {
+        given(tokenRepository.findByMemberUsername(anyString())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tokenService.tokenDelete("yoon1234"))
+                .isInstanceOf(InvalidTokenException.class);
+
+        then(tokenRepository).should().findByMemberUsername(anyString());
+        then(tokenRepository).should(never()).delete(any(Token.class));
     }
 
 }


### PR DESCRIPTION
## 작업 내용

스프링 시큐리티 로그아웃 기능을 사용해 로그아웃 기능 구현

로그아웃 요청은 `POST /api/members/logout` 경로로 요청할 수 있으며 로그인한 사용자만 요청할 수 있다.

로그아웃 성공 시 MemberLogoutSuccessHandler에서 토큰을 삭제하는 작업을 수행한다. MemberLogoutSuccessHandler에서는 로그인한 사용자의 아이디를 조회한 후 TokenService의 tokenDelete 메서드로 전달한다.

TokenRepository에서 회원의 아이디로 Refresh Token 정보를 조회하는데  Refresh Token 정보가 존재하지 않으면 InvalidTokenException이 발생한다. 

InvalidTokenException은 AuthenticationException을 상속받았다. 근데 GlobalExceptionHandler에는 AuthenticationException 예외를 처리하는 핸들러가 존재하지 않기 때문에 AuthenticationException을 상속받은 예외를 처리하는 핸들러를 추가했다.

Refresh Token 정보가 존재하면 해당 Refresh Token을 데이터베이스에서 삭제한다.

#

#### 관련 이슈

- close #9 
