### PR TITLE
게시글 작성 기능 구현

### DIFF
--- a/backend/src/main/java/com/board/domain/member/exception/NotFoundMemberException.java
+++ b/backend/src/main/java/com/board/domain/member/exception/NotFoundMemberException.java
@@ -1,0 +1,12 @@
+package com.board.domain.member.exception;
+
+import com.board.global.error.ErrorType;
+import com.board.global.error.exception.BaseException;
+
+public class NotFoundMemberException extends BaseException {
+
+    public NotFoundMemberException() {
+        super(ErrorType.NOT_FOUND_MEMBER);
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/board/domain/post/controller/PostController.java
@@ -1,0 +1,33 @@
+package com.board.domain.post.controller;
+
+import com.board.domain.post.dto.PostWriteRequest;
+import com.board.domain.post.service.PostService;
+
+import jakarta.validation.Valid;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @Secured("ROLE_MEMBER")
+    @PostMapping("/write")
+    public ResponseEntity<Void> postWrite(@RequestBody @Valid PostWriteRequest postWriteRequest,
+                                          @AuthenticationPrincipal String username) {
+        postService.postWrite(postWriteRequest, username);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/post/dto/PostWriteRequest.java
+++ b/backend/src/main/java/com/board/domain/post/dto/PostWriteRequest.java
@@ -1,0 +1,20 @@
+package com.board.domain.post.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostWriteRequest {
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String content;
+
+}

--- a/backend/src/main/java/com/board/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/board/domain/post/entity/Post.java
@@ -1,0 +1,50 @@
+package com.board.domain.post.entity;
+
+import com.board.domain.member.entity.Member;
+import com.board.global.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String writer;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private Member member;
+
+    @Builder
+    public Post(String title, String content, Member member) {
+        this.title = title;
+        this.writer = member.getNickname();
+        this.content = content;
+        this.member = member;
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/board/domain/post/repository/PostRepository.java
@@ -1,0 +1,8 @@
+package com.board.domain.post.repository;
+
+import com.board.domain.post.entity.Post;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/backend/src/main/java/com/board/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/board/domain/post/service/PostService.java
@@ -1,0 +1,34 @@
+package com.board.domain.post.service;
+
+import com.board.domain.member.entity.Member;
+import com.board.domain.member.exception.NotFoundMemberException;
+import com.board.domain.member.repository.MemberRepository;
+import com.board.domain.post.dto.PostWriteRequest;
+import com.board.domain.post.entity.Post;
+import com.board.domain.post.repository.PostRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void postWrite(PostWriteRequest postWriteRequest, String username) {
+        Member member = memberRepository.findMemberByUsername(username)
+                .orElseThrow(NotFoundMemberException::new);
+        Post post = Post.builder()
+                .title(postWriteRequest.getTitle())
+                .content(postWriteRequest.getContent())
+                .member(member)
+                .build();
+        postRepository.save(post);
+    }
+
+}

--- a/backend/src/main/java/com/board/global/error/ErrorType.java
+++ b/backend/src/main/java/com/board/global/error/ErrorType.java
@@ -15,6 +15,7 @@ public enum ErrorType {
     BAD_CREDENTIALS("E401001", HttpStatus.UNAUTHORIZED.value(), "아이디 또는 비밀번호가 일치하지 않습니다."),
     INVALID_TOKEN("E401002", HttpStatus.UNAUTHORIZED.value(), "토큰이 유효하지 않습니다."),
     EXPIRED_TOKEN("E401003", HttpStatus.UNAUTHORIZED.value(), "토큰이 만료되었습니다."),
+    NOT_FOUND_MEMBER("E404001", HttpStatus.NOT_FOUND.value(), "회원을 찾을 수 없습니다."),
     DUPLICATE_NICKNAME("E409001", HttpStatus.CONFLICT.value(), "사용 중인 닉네임입니다."),
     DUPLICATE_USERNAME("E409002", HttpStatus.CONFLICT.value(), "사용 중인 아이디입니다.");
 

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -28,9 +29,12 @@ import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 
 @EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private static final String ROLE_MEMBER = "MEMBER";
 
     private final ObjectMapper objectMapper;
     private final TokenService tokenService;
@@ -66,6 +70,8 @@ public class SecurityConfig {
                                 "/api/members/username/*").permitAll()
                         .requestMatchers(HttpMethod.POST,
                                 "/api/members/signup").permitAll()
+                        .requestMatchers(HttpMethod.POST,
+                                "/api/posts/write").hasRole(ROLE_MEMBER)
                         .anyRequest().denyAll()
                 );
         return httpSecurity.build();

--- a/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
@@ -1,0 +1,146 @@
+package com.board.domain.post.controller;
+
+import com.board.domain.member.exception.NotFoundMemberException;
+import com.board.domain.post.dto.PostWriteRequest;
+import com.board.domain.post.service.PostService;
+import com.board.domain.token.service.TokenService;
+import com.board.global.security.config.SecurityConfig;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = PostController.class)
+@Import(SecurityConfig.class)
+class PostControllerTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TokenService tokenService;
+
+    @MockBean
+    private PostService postService;
+
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+
+    @Value("${jwt.access-token.expire}")
+    private long accessTokenExpire;
+
+    @Test
+    @DisplayName("게시글을 작성한다")
+    void postWrite() throws Exception {
+        PostWriteRequest postWriteRequest = new PostWriteRequest("제목", "내용");
+        String accessToken = createAccessToken();
+        Claims payload = getPayload(accessToken);
+
+        given(tokenService.tokenPayload(anyString())).willReturn(payload);
+        willDoNothing().given(postService).postWrite(any(PostWriteRequest.class), anyString());
+
+        mockMvc.perform(post("/api/posts/write")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(postWriteRequest))
+                )
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("게시글 작성 시 입력값이 잘못되면 예외가 발생한다")
+    void postWrite_invalidInputValue() throws Exception {
+        PostWriteRequest invalidPostWriteRequest = new PostWriteRequest("", "내용");
+        String accessToken = createAccessToken();
+        Claims payload = getPayload(accessToken);
+
+        given(tokenService.tokenPayload(anyString())).willReturn(payload);
+        willDoNothing().given(postService).postWrite(any(PostWriteRequest.class), anyString());
+
+        mockMvc.perform(post("/api/posts/write")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidPostWriteRequest))
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("E400001"))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("입력값이 잘못되었습니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("게시글 작성 시 회원을 찾을 수 없으면 예외가 발생한다")
+    void postWrite_notFoundMember() throws Exception {
+        PostWriteRequest postWriteRequest = new PostWriteRequest("제목", "내용");
+        String accessToken = createAccessToken();
+        Claims payload = getPayload(accessToken);
+
+        given(tokenService.tokenPayload(anyString())).willReturn(payload);
+        willThrow(new NotFoundMemberException()).given(postService).postWrite(any(PostWriteRequest.class), anyString());
+
+        mockMvc.perform(post("/api/posts/write")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(postWriteRequest))
+                )
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("E404001"))
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("회원을 찾을 수 없습니다."))
+                .andDo(print());
+    }
+
+    private String createAccessToken() {
+        Date iat = new Date();
+        Date exp = new Date(iat.getTime() + accessTokenExpire);
+        return Jwts.builder()
+                .subject("yoon1234")
+                .claim("nickname", "yoonkun")
+                .claim("authority", "ROLE_MEMBER")
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)), Jwts.SIG.HS256)
+                .issuedAt(iat)
+                .expiration(exp)
+                .compact();
+    }
+
+    private Claims getPayload(String token) {
+        return Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)))
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+}

--- a/backend/src/test/java/com/board/domain/post/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/post/repository/PostRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.board.domain.post.repository;
+
+import com.board.domain.member.entity.Member;
+import com.board.domain.member.repository.MemberRepository;
+import com.board.domain.post.entity.Post;
+import com.board.global.common.config.JpaAuditConfig;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(JpaAuditConfig.class)
+class PostRepositoryTest {
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = memberRepository.save(Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .password("12345678")
+                .build());
+    }
+
+    @Test
+    @DisplayName("게시글을 저장한다")
+    void postSave() {
+        Post post = Post.builder()
+                .title("제목")
+                .content("내용")
+                .member(member)
+                .build();
+
+        Post savePost = postRepository.save(post);
+
+        assertThat(savePost.getId()).isNotNull();
+    }
+
+}

--- a/backend/src/test/java/com/board/domain/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/board/domain/post/service/PostServiceTest.java
@@ -1,0 +1,85 @@
+package com.board.domain.post.service;
+
+import com.board.domain.member.entity.Member;
+import com.board.domain.member.exception.NotFoundMemberException;
+import com.board.domain.member.repository.MemberRepository;
+import com.board.domain.post.dto.PostWriteRequest;
+import com.board.domain.post.entity.Post;
+import com.board.domain.post.repository.PostRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private PostService postService;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .build();
+    }
+
+    @Test
+    @DisplayName("게시글을 작성한다")
+    void postWrite() {
+        PostWriteRequest postWriteRequest = new PostWriteRequest("제목", "내용");
+        Post post = Post.builder()
+                .title(postWriteRequest.getTitle())
+                .content(postWriteRequest.getContent())
+                .member(member)
+                .build();
+
+        given(memberRepository.findMemberByUsername(anyString())).willReturn(Optional.of(member));
+        given(postRepository.save(any(Post.class))).willReturn(post);
+
+        postService.postWrite(postWriteRequest, "yoon1234");
+
+        then(memberRepository).should().findMemberByUsername(anyString());
+        then(postRepository).should().save(any(Post.class));
+    }
+
+    @Test
+    @DisplayName("게시글 작성 시 회원을 찾을 수 없으면 예외가 발생한다")
+    void postWrite_notFoundPost() {
+        PostWriteRequest postWriteRequest = new PostWriteRequest("제목", "내용");
+
+        willThrow(new NotFoundMemberException()).given(memberRepository).findMemberByUsername(anyString());
+
+        assertThatThrownBy(() -> postService.postWrite(postWriteRequest, "yoon1234"))
+                .isInstanceOf(NotFoundMemberException.class);
+
+        then(memberRepository).should().findMemberByUsername(anyString());
+        then(postRepository).should(never()).save(any(Post.class));
+    }
+
+}


### PR DESCRIPTION
## 작업 내용

### 게시글 작성 기능 구현

게시글 작성 요청은 `POST /api/post/write`로 할 수 있으며 로그인 상태의 회원만 할 수 있다.

게시글(Post) 엔티티는 기본키(id), 제목(title), 작성자(writer), 내용(content) 회원(member) 필드를 가진다.

- 기본키, 제목, 작성자, 내용 필드는 null을 허용하지 않는다.
- 게시글과 회원의 연관관계는 다대일(N:1) 관계로 설정했다.

게시글 작성 시 회원을 찾을 수 없으면 NotFoundMemberException이 발생한다.

- E404001(404, 회원을 찾을 수 없습니다.)

#

#### 관련 이슈

- close #10
