### PR TITLE
게시글 삭제 기능 구현

### DIFF
--- a/backend/src/main/java/com/board/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/board/domain/post/controller/PostController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -47,6 +48,14 @@ public class PostController {
                                            @RequestBody @Valid PostModifyRequest postModifyRequest,
                                            @AuthenticationPrincipal String loginUsername) {
         postService.postModify(postNumber, postModifyRequest, loginUsername);
+        return ResponseEntity.ok().build();
+    }
+
+    @Secured("ROLE_MEMBER")
+    @DeleteMapping("/{postNumber}")
+    public ResponseEntity<Void> postDelete(@PathVariable("postNumber") Long postNumber,
+                                           @AuthenticationPrincipal String loginUsername) {
+        postService.postDelete(postNumber, loginUsername);
         return ResponseEntity.ok().build();
     }
 

--- a/backend/src/main/java/com/board/domain/post/exception/PostDeleteAccessDeniedException.java
+++ b/backend/src/main/java/com/board/domain/post/exception/PostDeleteAccessDeniedException.java
@@ -1,0 +1,12 @@
+package com.board.domain.post.exception;
+
+import com.board.global.error.ErrorType;
+import com.board.global.error.exception.BaseException;
+
+public class PostDeleteAccessDeniedException extends BaseException {
+
+    public PostDeleteAccessDeniedException() {
+        super(ErrorType.POST_DELETE_ACCESS_DENIED);
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/board/domain/post/service/PostService.java
@@ -8,6 +8,7 @@ import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.entity.Post;
 import com.board.domain.post.exception.NotFoundPostException;
+import com.board.domain.post.exception.PostDeleteAccessDeniedException;
 import com.board.domain.post.exception.PostModifyAccessDeniedException;
 import com.board.domain.post.repository.PostRepository;
 
@@ -50,6 +51,16 @@ public class PostService {
             throw new PostModifyAccessDeniedException();
         }
         post.modify(postModifyRequest.getTitle(), postModifyRequest.getContent());
+    }
+
+    @Transactional
+    public void postDelete(Long postNumber, String loginUsername) {
+        Post post = postRepository.findPostJoinFetch(postNumber)
+                .orElseThrow(NotFoundPostException::new);
+        if (!post.isOwner(loginUsername)) {
+            throw new PostDeleteAccessDeniedException();
+        }
+        postRepository.delete(post);
     }
 
 }

--- a/backend/src/main/java/com/board/global/error/ErrorType.java
+++ b/backend/src/main/java/com/board/global/error/ErrorType.java
@@ -16,6 +16,7 @@ public enum ErrorType {
     INVALID_TOKEN("E401002", HttpStatus.UNAUTHORIZED.value(), "토큰이 유효하지 않습니다."),
     EXPIRED_TOKEN("E401003", HttpStatus.UNAUTHORIZED.value(), "토큰이 만료되었습니다."),
     POST_MODIFY_ACCESS_DENIED("E403001", HttpStatus.FORBIDDEN.value(), "게시글 수정은 작성자만 할 수 있습니다."),
+    POST_DELETE_ACCESS_DENIED("E403002", HttpStatus.FORBIDDEN.value(), "게시글 삭제는 작성자만 할 수 있습니다."),
     NOT_FOUND_MEMBER("E404001", HttpStatus.NOT_FOUND.value(), "회원을 찾을 수 없습니다."),
     NOT_FOUND_POST("E404002", HttpStatus.NOT_FOUND.value(), "게시글을 찾을 수 없습니다."),
     DUPLICATE_NICKNAME("E409001", HttpStatus.CONFLICT.value(), "사용 중인 닉네임입니다."),

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -75,6 +75,8 @@ public class SecurityConfig {
                                 "/api/posts/write").hasRole(ROLE_MEMBER)
                         .requestMatchers(HttpMethod.PUT,
                                 "/api/posts/*").hasRole(ROLE_MEMBER)
+                        .requestMatchers(HttpMethod.DELETE,
+                                "/api/posts/*").hasRole(ROLE_MEMBER)
                         .anyRequest().denyAll()
                 );
         return httpSecurity.build();

--- a/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
@@ -5,6 +5,7 @@ import com.board.domain.post.dto.PostDetailResponse;
 import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.exception.NotFoundPostException;
+import com.board.domain.post.exception.PostDeleteAccessDeniedException;
 import com.board.domain.post.exception.PostModifyAccessDeniedException;
 import com.board.domain.post.service.PostService;
 import com.board.domain.token.service.TokenService;
@@ -38,6 +39,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -241,6 +243,60 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.errorCode").value("E403001"))
                 .andExpect(jsonPath("$.status").value(403))
                 .andExpect(jsonPath("$.message").value("게시글 수정은 작성자만 할 수 있습니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("게시글을 삭제한다")
+    void postDelete() throws Exception {
+        String accessToken = createAccessToken();
+        Claims payload = getPayload(accessToken);
+
+        given(tokenService.tokenPayload(anyString())).willReturn(payload);
+        willDoNothing().given(postService).postDelete(anyLong(), anyString());
+
+        mockMvc.perform(delete("/api/posts/1")
+                        .header("Authorization", "Bearer " + accessToken)
+                )
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("게시글 삭제 시 게시글을 찾을 수 없으면 예외가 발생한다")
+    void postDelete_notFoundPost() throws Exception {
+        String accessToken = createAccessToken();
+        Claims payload = getPayload(accessToken);
+
+        given(tokenService.tokenPayload(anyString())).willReturn(payload);
+        willThrow(new NotFoundPostException()).given(postService).postDelete(anyLong(), anyString());
+
+        mockMvc.perform(delete("/api/posts/1")
+                        .header("Authorization", "Bearer " + accessToken)
+                )
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("E404002"))
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("게시글을 찾을 수 없습니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("게시글 삭제 시 작성자가 아닌데 삭제를 시도할 경우 예외가 발생한다")
+    void postDelete_notPostOwner() throws Exception {
+        String accessToken = createAccessToken();
+        Claims payload = getPayload(accessToken);
+
+        given(tokenService.tokenPayload(anyString())).willReturn(payload);
+        willThrow(new PostDeleteAccessDeniedException()).given(postService).postDelete(anyLong(), anyString());
+
+        mockMvc.perform(delete("/api/posts/1")
+                        .header("Authorization", "Bearer " + accessToken)
+                )
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value("E403002"))
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.message").value("게시글 삭제는 작성자만 할 수 있습니다."))
                 .andDo(print());
     }
 

--- a/backend/src/test/java/com/board/domain/post/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/post/repository/PostRepositoryTest.java
@@ -84,4 +84,20 @@ class PostRepositoryTest {
         assertThat(findPost.getMember().getUsername()).isEqualTo("yoon1234");
     }
 
+    @Test
+    @DisplayName("게시글을 삭제한다")
+    void postDelete() {
+        Post post = Post.builder()
+                .title("제목")
+                .content("내용")
+                .member(member)
+                .build();
+        Post savePost = postRepository.save(post);
+        Post findPost = postRepository.findPostJoinFetch(savePost.getId()).get();
+
+        postRepository.delete(findPost);
+
+        assertThat(postRepository.findPostJoinFetch(savePost.getId())).isEmpty();
+    }
+
 }

--- a/backend/src/test/java/com/board/domain/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/board/domain/post/service/PostServiceTest.java
@@ -7,6 +7,7 @@ import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.entity.Post;
 import com.board.domain.post.exception.NotFoundPostException;
+import com.board.domain.post.exception.PostDeleteAccessDeniedException;
 import com.board.domain.post.exception.PostModifyAccessDeniedException;
 import com.board.domain.post.repository.PostRepository;
 
@@ -28,6 +29,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 
@@ -159,6 +161,54 @@ class PostServiceTest {
                 .isInstanceOf(PostModifyAccessDeniedException.class);
 
         then(postRepository).should().findPostJoinFetch(anyLong());
+    }
+
+    @Test
+    @DisplayName("게시글을 삭제한다")
+    void postDelete() {
+        Post post = Post.builder()
+                .title("제목")
+                .content("내용")
+                .member(member)
+                .build();
+
+        given(postRepository.findPostJoinFetch(anyLong())).willReturn(Optional.of(post));
+        willDoNothing().given(postRepository).delete(any(Post.class));
+
+        postService.postDelete(1L, "yoon1234");
+
+        then(postRepository).should().findPostJoinFetch(anyLong());
+        then(postRepository).should().delete(any(Post.class));
+    }
+
+    @Test
+    @DisplayName("게시글 삭제 시 게시글을 찾을 수 없으면 예외가 발생한다")
+    void postDelete_notFoundPost() {
+        willThrow(new NotFoundPostException()).given(postRepository).findPostJoinFetch(anyLong());
+
+        assertThatThrownBy(() -> postService.postDelete(1L, "yoon1234"))
+                .isInstanceOf(NotFoundPostException.class);
+
+        then(postRepository).should().findPostJoinFetch(anyLong());
+        then(postRepository).should(never()).delete(any(Post.class));
+    }
+
+    @Test
+    @DisplayName("게시글 삭제 시 작성자가 아닌데 삭제를 시도할 경우 예외가 발생한다")
+    void postDelete_notPostOwner() {
+        Post post = Post.builder()
+                .title("제목")
+                .content("내용")
+                .member(member)
+                .build();
+
+        given(postRepository.findPostJoinFetch(anyLong())).willReturn(Optional.of(post));
+
+        assertThatThrownBy(() -> postService.postDelete(1L, "unknown"))
+                .isInstanceOf(PostDeleteAccessDeniedException.class);
+
+        then(postRepository).should().findPostJoinFetch(anyLong());
+        then(postRepository).should(never()).delete(any(Post.class));
     }
 
 }


### PR DESCRIPTION
## 작업 내용

게시글 삭제 기능 추가

- 요청 경로: `DELETE /api/posts/1`

#

#### 관련 이슈

- close #17
