### PR TITLE
게시글 목록조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/board/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/board/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.board.domain.post.controller;
 
 import com.board.domain.post.dto.PostDetailResponse;
+import com.board.domain.post.dto.PostListResponse;
 import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.service.PostService;
@@ -40,6 +41,13 @@ public class PostController {
     public ResponseEntity<PostDetailResponse> postDetail(@PathVariable("postNumber") Long postNumber) {
         PostDetailResponse postDetailResponse = postService.postDetail(postNumber);
         return ResponseEntity.ok().body(postDetailResponse);
+    }
+
+    @GetMapping("/page/{pageNumber}")
+    public ResponseEntity<PostListResponse> postList(@PathVariable("pageNumber") int pageNumber) {
+        pageNumber = pageNumber <= 0 ? 0 : pageNumber - 1;
+        PostListResponse postListResponse = postService.postList(pageNumber);
+        return ResponseEntity.ok().body(postListResponse);
     }
 
     @Secured("ROLE_MEMBER")

--- a/backend/src/main/java/com/board/domain/post/dto/PostListItem.java
+++ b/backend/src/main/java/com/board/domain/post/dto/PostListItem.java
@@ -1,0 +1,29 @@
+package com.board.domain.post.dto;
+
+import com.board.domain.post.entity.Post;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class PostListItem {
+
+    private final Long postNumber;
+    private final String title;
+    private final String writer;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
+    private final LocalDateTime createdAt;
+
+    public PostListItem(Post post) {
+        this.postNumber = post.getId();
+        this.title = post.getTitle();
+        this.writer = post.getWriter();
+        this.createdAt = post.getCreatedAt();
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/post/dto/PostListResponse.java
+++ b/backend/src/main/java/com/board/domain/post/dto/PostListResponse.java
@@ -1,0 +1,39 @@
+package com.board.domain.post.dto;
+
+import com.board.domain.post.entity.Post;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class PostListResponse {
+
+    private final List<PostListItem> posts;
+    private final int pageNumber;
+    private final int totalPages;
+    private final long totalElements;
+    private final boolean prev;
+    private final boolean next;
+    private final boolean first;
+    private final boolean last;
+
+    public PostListResponse(Page<Post> postPage) {
+        this.posts = postPage.getContent().stream()
+                .map(PostListItem::new)
+                .collect(Collectors.toList());
+        this.pageNumber = postPage.getNumber() + 1;
+        this.totalPages = postPage.getTotalPages();
+        this.totalElements = postPage.getTotalElements();
+        this.prev = postPage.hasPrevious();
+        this.next = postPage.hasNext();
+        this.first = postPage.isFirst();
+        this.last = postPage.isLast();
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/board/domain/post/service/PostService.java
@@ -4,6 +4,7 @@ import com.board.domain.member.entity.Member;
 import com.board.domain.member.exception.NotFoundMemberException;
 import com.board.domain.member.repository.MemberRepository;
 import com.board.domain.post.dto.PostDetailResponse;
+import com.board.domain.post.dto.PostListResponse;
 import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.entity.Post;
@@ -14,12 +15,19 @@ import com.board.domain.post.repository.PostRepository;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
+
+    private static final int PAGE_SIZE = 10;
+    private static final String PROPERTIES = "id";
 
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
@@ -41,6 +49,13 @@ public class PostService {
         Post post = postRepository.findById(postNumber)
                 .orElseThrow(NotFoundPostException::new);
         return new PostDetailResponse(post);
+    }
+
+    @Transactional
+    public PostListResponse postList(int pageNumber) {
+        Pageable pageable = PageRequest.of(pageNumber, PAGE_SIZE, Sort.Direction.DESC, PROPERTIES);
+        Page<Post> postPage = postRepository.findAll(pageable);
+        return new PostListResponse(postPage);
     }
 
     @Transactional

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -68,7 +68,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET,
                                 "/api/members/nickname/*",
                                 "/api/members/username/*",
-                                "/api/posts/*").permitAll()
+                                "/api/posts/*",
+                                "/api/posts/page/*").permitAll()
                         .requestMatchers(HttpMethod.POST,
                                 "/api/members/signup").permitAll()
                         .requestMatchers(HttpMethod.POST,

--- a/backend/src/main/java/com/board/global/security/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/board/global/security/filter/JwtAuthenticationFilter.java
@@ -74,7 +74,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         MEMBER_USERNAME_EXISTS("GET", "/api/members/username/*"),
         MEMBER_SIGNUP("POST", "/api/members/signup"),
         MEMBER_LOGIN("POST", "/api/members/login"),
-        POST_DETAIL("GET", "/api/posts/*");
+        POST_DETAIL("GET", "/api/posts/*"),
+        POST_LIST("GET", "/api/posts/page/*");
 
         private final String method;
         private final String pattern;

--- a/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
@@ -2,6 +2,8 @@ package com.board.domain.post.controller;
 
 import com.board.domain.member.exception.NotFoundMemberException;
 import com.board.domain.post.dto.PostDetailResponse;
+import com.board.domain.post.dto.PostListItem;
+import com.board.domain.post.dto.PostListResponse;
 import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.exception.NotFoundPostException;
@@ -31,8 +33,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.Date;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -159,6 +163,25 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.status").value(404))
                 .andExpect(jsonPath("$.message").value("게시글을 찾을 수 없습니다."))
                 .andDo(print());
+    }
+
+    @Test
+    @DisplayName("게시글 목록을 조회한다")
+    void postList() throws Exception {
+        List<PostListItem> posts = List.of(
+                new PostListItem(5L, "제목5", "작성자5", LocalDateTime.now()),
+                new PostListItem(4L, "제목4", "작성자4", LocalDateTime.now()),
+                new PostListItem(3L, "제목3", "작성자3", LocalDateTime.now()),
+                new PostListItem(2L, "제목2", "작성자2", LocalDateTime.now()),
+                new PostListItem(1L, "제목1", "작성자1", LocalDateTime.now())
+        );
+        PostListResponse postListResponse = new PostListResponse(posts, 0, 1, 5, false, false, true, true);
+
+        given(postService.postList(anyInt())).willReturn(postListResponse);
+
+        mockMvc.perform(get("/api/posts/page/1"))
+                .andDo(print())
+                .andExpect(status().isOk());
     }
 
     @Test

--- a/backend/src/test/java/com/board/domain/post/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/post/repository/PostRepositoryTest.java
@@ -12,6 +12,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -82,6 +88,30 @@ class PostRepositoryTest {
         assertThat(findPost.getContent()).isEqualTo("내용");
         assertThat(findPost.getMember().getNickname()).isEqualTo("yoonkun");
         assertThat(findPost.getMember().getUsername()).isEqualTo("yoon1234");
+    }
+
+    @Test
+    @DisplayName("게시글 목록을 조회한다")
+    void postFindAll() {
+        List<Post> content = List.of(
+                Post.builder().title("제목").content("내용").member(member).build(),
+                Post.builder().title("제목").content("내용").member(member).build(),
+                Post.builder().title("제목").content("내용").member(member).build(),
+                Post.builder().title("제목").content("내용").member(member).build(),
+                Post.builder().title("제목").content("내용").member(member).build()
+        );
+        postRepository.saveAll(content);
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.Direction.DESC, "id");
+        Page<Post> postPage = postRepository.findAll(pageable);
+
+        assertThat(postPage.getNumber()).isEqualTo(0);
+        assertThat(postPage.getTotalPages()).isEqualTo(1);
+        assertThat(postPage.getTotalElements()).isEqualTo(5);
+        assertThat(postPage.hasPrevious()).isFalse();
+        assertThat(postPage.hasNext()).isFalse();
+        assertThat(postPage.isFirst()).isTrue();
+        assertThat(postPage.isLast()).isTrue();
     }
 
     @Test

--- a/backend/src/test/java/com/board/domain/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/board/domain/post/service/PostServiceTest.java
@@ -19,7 +19,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -113,6 +116,25 @@ class PostServiceTest {
                 .isInstanceOf(NotFoundPostException.class);
 
         then(postRepository).should().findById(anyLong());
+    }
+
+    @Test
+    @DisplayName("게시글 목록을 조회한다")
+    void postList() {
+        List<Post> content = List.of(
+                Post.builder().title("제목").member(member).build(),
+                Post.builder().title("제목").member(member).build(),
+                Post.builder().title("제목").member(member).build(),
+                Post.builder().title("제목").member(member).build(),
+                Post.builder().title("제목").member(member).build()
+        );
+        PageImpl<Post> postPage = new PageImpl<>(content);
+
+        given(postRepository.findAll(any(Pageable.class))).willReturn(postPage);
+
+        postService.postList(1);
+
+        then(postRepository).should().findAll(any(Pageable.class));
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용

게시글 목록조회 기능 추가

- 요청 경로: `GET /api/posts/page/{page_number}`

#

#### 관련 이슈

- close #21
