### PR TITLE
게시글 삭제 시 댓글도 같이 삭제하는 기능 구현

### DIFF
--- a/backend/src/main/java/com/board/domain/comment/entity/Comment.java
+++ b/backend/src/main/java/com/board/domain/comment/entity/Comment.java
@@ -46,7 +46,7 @@ public class Comment extends BaseEntity {
         this.writer = member.getNickname();
         this.content = content;
         this.member = member;
-        this.post = post;
+        setPost(post);
     }
 
     public void modify(String content) {
@@ -55,6 +55,14 @@ public class Comment extends BaseEntity {
 
     public boolean isOwner(String loginUsername) {
         return member.getUsername().equals(loginUsername);
+    }
+
+    private void setPost(Post post) {
+        if (this.post != null) {
+            this.post.getComments().remove(this);
+        }
+        this.post = post;
+        post.getComments().add(this);
     }
 
 }

--- a/backend/src/main/java/com/board/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/board/domain/post/entity/Post.java
@@ -1,8 +1,10 @@
 package com.board.domain.post.entity;
 
+import com.board.domain.comment.entity.Comment;
 import com.board.domain.member.entity.Member;
 import com.board.global.common.entity.BaseEntity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,10 +13,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor
@@ -38,6 +44,9 @@ public class Post extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false)
     private Member member;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "post", cascade = CascadeType.REMOVE)
+    private List<Comment> comments = new ArrayList<>();
 
     @Builder
     public Post(String title, String content, Member member) {


### PR DESCRIPTION
## 작업 내용

게시글(Post) 엔티티와 댓글(Comment) 엔티티의 관계를 기존 다대일 단방향 관계에서 다대일 양방향 관계로 변경

CascadeType.REMOVE 영속성 전이 설정 추가

#

#### 관련 이슈

- close #35 
