### PR TITLE
게시글 검색 기능 구현

### DIFF
--- a/backend/src/main/java/com/board/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/board/domain/post/controller/PostController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -47,6 +48,15 @@ public class PostController {
     public ResponseEntity<PostListResponse> postList(@PathVariable("pageNumber") int pageNumber) {
         pageNumber = pageNumber <= 0 ? 0 : pageNumber - 1;
         PostListResponse postListResponse = postService.postList(pageNumber);
+        return ResponseEntity.ok().body(postListResponse);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<PostListResponse> postListSearch(@RequestParam("page") int page,
+                                                           @RequestParam("type") String type,
+                                                           @RequestParam("keyword") String keyword) {
+        page = page <= 0 ? 0 : page - 1;
+        PostListResponse postListResponse = postService.postListSearch(page, type, keyword);
         return ResponseEntity.ok().body(postListResponse);
     }
 

--- a/backend/src/main/java/com/board/domain/post/repository/PostCustomRepository.java
+++ b/backend/src/main/java/com/board/domain/post/repository/PostCustomRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Pageable;
 public interface PostCustomRepository {
 
     Page<PostListItem> findPosts(Pageable pageable);
-
+    Page<PostListItem> findPostsSearch(Pageable pageable, String type, String keyword);
 }

--- a/backend/src/main/java/com/board/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/board/domain/post/repository/PostCustomRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.board.domain.post.repository;
 
 import com.board.domain.post.dto.PostListItem;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -43,6 +44,39 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .select(post.count())
                 .from(post);
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Page<PostListItem> findPostsSearch(Pageable pageable, String type, String keyword) {
+        List<PostListItem> content = jpaQueryFactory
+                .select(constructor(PostListItem.class,
+                        post.id,
+                        post.title,
+                        post.writer,
+                        comment.count().intValue(),
+                        post.createdAt))
+                .from(post)
+                .leftJoin(post.comments, comment)
+                .groupBy(post.id)
+                .orderBy(post.id.desc())
+                .having(contanins(type, keyword))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        JPAQuery<Long> countQuery = jpaQueryFactory
+                .select(post.count())
+                .from(post)
+                .where();
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression contanins(String type, String keyword) {
+        if (type.equals("title")) {
+            return post.title.contains(keyword);
+        } else if (type.equals("writer")) {
+            return post.writer.contains(keyword);
+        }
+        return null;
     }
 
 }

--- a/backend/src/main/java/com/board/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/board/domain/post/service/PostService.java
@@ -59,6 +59,13 @@ public class PostService {
         return new PostListResponse(postPage);
     }
 
+    @Transactional(readOnly = true)
+    public PostListResponse postListSearch(int page, String type, String keyword) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.Direction.DESC, PROPERTIES);
+        Page<PostListItem> postPage = postRepository.findPostsSearch(pageable, type, keyword);
+        return new PostListResponse(postPage);
+    }
+
     @Transactional
     public void postModify(Long postNumber, PostModifyRequest postModifyRequest, String loginUsername) {
         Post post = postRepository.findPostJoinFetch(postNumber)

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -71,6 +71,7 @@ public class SecurityConfig {
                                 "/api/members/username/*",
                                 "/api/posts/*",
                                 "/api/posts/page/*",
+                                "/api/posts/search",
                                 "/api/posts/*/comments/page/*").permitAll()
                         .requestMatchers(HttpMethod.POST,
                                 "/api/members/signup").permitAll()

--- a/backend/src/main/java/com/board/global/security/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/board/global/security/filter/JwtAuthenticationFilter.java
@@ -77,6 +77,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         MEMBER_LOGIN("POST", "/api/members/login"),
         POST_DETAIL("GET", "/api/posts/*"),
         POST_LIST("GET", "/api/posts/page/*"),
+        POST_LIST_SEARCH("GET", "/api/posts/search"),
         COMMENT_LIST("GET", "/api/posts/*/comments/page/*");
 
         private final String method;

--- a/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
@@ -46,9 +46,10 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -226,6 +227,50 @@ class PostControllerTest extends RestDocsTestSupport {
                 .andDo(restDocs.document(
                         pathParameters(
                                 parameterWithName("pageNumber").description("페이지 번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("posts").type(ARRAY).description("게시글 목록"),
+                                fieldWithPath("posts[].postNumber").type(NUMBER).description("게시글 번호"),
+                                fieldWithPath("posts[].title").type(STRING).description("게시글 제목"),
+                                fieldWithPath("posts[].writer").type(STRING).description("게시글 제목"),
+                                fieldWithPath("posts[].createdAt").type(STRING).description("게시글 제목"),
+                                fieldWithPath("posts[].commentCount").type(NUMBER).description("댓글 개수"),
+                                fieldWithPath("pageNumber").type(NUMBER).description("페이지 번호"),
+                                fieldWithPath("totalPages").type(NUMBER).description("전체 페이지 개수"),
+                                fieldWithPath("totalElements").type(NUMBER).description("전체 게시글 개수"),
+                                fieldWithPath("prev").type(BOOLEAN).description("이전 페이지 이동 가능 여부"),
+                                fieldWithPath("next").type(BOOLEAN).description("다음 페이지 이동 가능 여부"),
+                                fieldWithPath("first").type(BOOLEAN).description("첫 번째 페이지 여부"),
+                                fieldWithPath("last").type(BOOLEAN).description("마지막 페이지 여부")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("게시글을 검색한다")
+    void postListSearch() throws Exception {
+        List<PostListItem> posts = List.of(
+                new PostListItem(5L, "제목5", "작성자5", 0, LocalDateTime.now()),
+                new PostListItem(4L, "제목4", "작성자4", 0, LocalDateTime.now()),
+                new PostListItem(3L, "제목3", "작성자3", 0, LocalDateTime.now()),
+                new PostListItem(2L, "제목2", "작성자2", 0, LocalDateTime.now()),
+                new PostListItem(1L, "제목1", "작성자1", 0, LocalDateTime.now())
+        );
+        PostListResponse postListResponse = new PostListResponse(posts, 0, 1, 5, false, false, true, true);
+
+        given(postService.postListSearch(anyInt(), anyString(), anyString())).willReturn(postListResponse);
+
+        mockMvc.perform(get("/api/posts/search")
+                        .param("page", "1")
+                        .param("type", "title")
+                        .param("keyword", "제목")
+                )
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호"),
+                                parameterWithName("type").description("검색 기준"),
+                                parameterWithName("keyword").description("검색 단어")
                         ),
                         responseFields(
                                 fieldWithPath("posts").type(ARRAY).description("게시글 목록"),

--- a/backend/src/test/java/com/board/domain/post/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/post/repository/PostRepositoryTest.java
@@ -117,6 +117,30 @@ class PostRepositoryTest {
     }
 
     @Test
+    @DisplayName("특정 단어가 포함된 게시글 목록을 조회한다")
+    void findPostsSearch() {
+        List<Post> content = List.of(
+                Post.builder().title("독수리").content("내용").member(member).build(),
+                Post.builder().title("기러기").content("내용").member(member).build(),
+                Post.builder().title("호랑이").content("내용").member(member).build(),
+                Post.builder().title("거북이").content("내용").member(member).build(),
+                Post.builder().title("코끼리").content("내용").member(member).build()
+        );
+        postRepository.saveAll(content);
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.Direction.DESC, "id");
+        Page<PostListItem> postPage = postRepository.findPostsSearch(pageable, "title", "이");
+
+        assertThat(postPage.getNumber()).isEqualTo(0);
+        assertThat(postPage.getTotalPages()).isEqualTo(1);
+        assertThat(postPage.getTotalElements()).isEqualTo(2);
+        assertThat(postPage.hasPrevious()).isFalse();
+        assertThat(postPage.hasNext()).isFalse();
+        assertThat(postPage.isFirst()).isTrue();
+        assertThat(postPage.isLast()).isTrue();
+    }
+
+    @Test
     @DisplayName("게시글을 삭제한다")
     void postDelete() {
         Post post = Post.builder()

--- a/backend/src/test/java/com/board/domain/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/board/domain/post/service/PostServiceTest.java
@@ -140,6 +140,25 @@ class PostServiceTest {
     }
 
     @Test
+    @DisplayName("게시글을 검색한다")
+    void postListSearch() {
+        List<PostListItem> content = List.of(
+                new PostListItem(5L, "제목5", "작성자5", 0, LocalDateTime.now()),
+                new PostListItem(4L, "제목4", "작성자4", 0, LocalDateTime.now()),
+                new PostListItem(3L, "제목3", "작성자3", 0, LocalDateTime.now()),
+                new PostListItem(2L, "제목2", "작성자2", 0, LocalDateTime.now()),
+                new PostListItem(1L, "제목1", "작성자1", 0, LocalDateTime.now())
+        );
+        PageImpl<PostListItem> postPage = new PageImpl<>(content);
+
+        given(postRepository.findPostsSearch(any(Pageable.class), anyString(), anyString())).willReturn(postPage);
+
+        postService.postListSearch(1, "title", "제목");
+
+        then(postRepository).should().findPostsSearch(any(Pageable.class), anyString(), anyString());
+    }
+
+    @Test
     @DisplayName("게시글을 수정한다")
     void postModify() {
         PostModifyRequest postModifyRequest = new PostModifyRequest("제목", "내용");


### PR DESCRIPTION
# 개요

게시글 제목 또는 작성자로 게시글을 검색하는 기능을 추가했습니다.

```text
/api/posts/search?page={page}&type={type}&keyword={keyword}
```

- `page`: 페이지 번호
- `type`: 검색 유형(제목, 작성자)
- `keyword`: 검색 내용

close #39 

## 작업 유형

- [X] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 코드 포맷팅(오타 수정, 변수명 변경 등)
- [ ] 문서 작성 및 수정
- [ ] 테스트 추가 및 리팩토링
- [ ] 빌드 및 패키지 매니지 수정
