### PR TITLE
게시글 전체 목록 조회 URI 리팩토링

### DIFF
--- a/backend/src/main/java/com/board/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/board/domain/post/controller/PostController.java
@@ -44,8 +44,8 @@ public class PostController {
         return ResponseEntity.ok().body(postDetailResponse);
     }
 
-    @GetMapping("/page/{pageNumber}")
-    public ResponseEntity<PostListResponse> postList(@PathVariable("pageNumber") int pageNumber) {
+    @GetMapping
+    public ResponseEntity<PostListResponse> postList(@RequestParam(value = "page", defaultValue = "0") int pageNumber) {
         pageNumber = pageNumber <= 0 ? 0 : pageNumber - 1;
         PostListResponse postListResponse = postService.postList(pageNumber);
         return ResponseEntity.ok().body(postListResponse);

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -70,7 +70,7 @@ public class SecurityConfig {
                                 "/api/members/nickname/*",
                                 "/api/members/username/*",
                                 "/api/posts/*",
-                                "/api/posts/page/*",
+                                "/api/posts",
                                 "/api/posts/search",
                                 "/api/posts/*/comments/page/*").permitAll()
                         .requestMatchers(HttpMethod.POST,

--- a/backend/src/main/java/com/board/global/security/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/board/global/security/filter/JwtAuthenticationFilter.java
@@ -76,7 +76,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         MEMBER_SIGNUP("POST", "/api/members/signup"),
         MEMBER_LOGIN("POST", "/api/members/login"),
         POST_DETAIL("GET", "/api/posts/*"),
-        POST_LIST("GET", "/api/posts/page/*"),
+        POST_LIST("GET", "/api/posts"),
         POST_LIST_SEARCH("GET", "/api/posts/search"),
         COMMENT_LIST("GET", "/api/posts/*/comments/page/*"),
         REISSUE_ACCESS_TOKEN("POST", "/api/tokens/reissue");

--- a/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
@@ -222,11 +222,13 @@ class PostControllerTest extends RestDocsTestSupport {
 
         given(postService.postList(anyInt())).willReturn(postListResponse);
 
-        mockMvc.perform(get("/api/posts/page/{pageNumber}", 1))
+        mockMvc.perform(get("/api/posts")
+                        .param("page", "1")
+                )
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("pageNumber").description("페이지 번호")
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호")
                         ),
                         responseFields(
                                 fieldWithPath("posts").type(ARRAY).description("게시글 목록"),


### PR DESCRIPTION
# 개요

게시글 전체 목록을 조회하는 URI에서 페이지 번호를 받는 부분을 경로 변수에서 쿼리 파라미터로 변경했습니다.

### 변경 전

```text
~/api/posts/page/{page}
```

### 변경 후

```text
~/api/posts?page={page}
```

#### 관련 이슈

close #48 

## 작업 유형

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 코드 포맷팅(오타 수정, 변수명 변경 등)
- [ ] 문서 작성 및 수정
- [ ] 테스트 추가 및 리팩토링
- [ ] 빌드 및 패키지 매니지 수정
