### PR TITLE
댓글 목록 조회 API 리팩토링

### DIFF
--- a/backend/src/main/java/com/board/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/board/domain/comment/controller/CommentController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -37,11 +38,11 @@ public class CommentController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/{postNumber}/comments/page/{pageNumber}")
+    @GetMapping("/{postNumber}/comments")
     public ResponseEntity<CommentListResponse> commentList(@PathVariable("postNumber") Long postNumber,
-                                                           @PathVariable("pageNumber") int pageNumber) {
-        pageNumber = pageNumber <= 0 ? 0 : pageNumber - 1;
-        CommentListResponse commentListResponse = commentService.commentList(postNumber, pageNumber);
+                                                           @RequestParam(value = "page", defaultValue = "0") int page) {
+        page = page <= 0 ? 0 : page - 1;
+        CommentListResponse commentListResponse = commentService.commentList(postNumber, page);
         return ResponseEntity.ok().body(commentListResponse);
     }
 

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -72,7 +72,7 @@ public class SecurityConfig {
                                 "/api/posts/*",
                                 "/api/posts",
                                 "/api/posts/search",
-                                "/api/posts/*/comments/page/*").permitAll()
+                                "/api/posts/*/comments").permitAll()
                         .requestMatchers(HttpMethod.POST,
                                 "/api/members/signup",
                                 "/api/tokens/reissue").permitAll()

--- a/backend/src/main/java/com/board/global/security/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/board/global/security/filter/JwtAuthenticationFilter.java
@@ -78,7 +78,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         POST_DETAIL("GET", "/api/posts/*"),
         POST_LIST("GET", "/api/posts"),
         POST_LIST_SEARCH("GET", "/api/posts/search"),
-        COMMENT_LIST("GET", "/api/posts/*/comments/page/*"),
+        COMMENT_LIST("GET", "/api/posts/*/comments"),
         REISSUE_ACCESS_TOKEN("POST", "/api/tokens/reissue");
 
         private final String method;

--- a/backend/src/test/java/com/board/domain/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/board/domain/comment/controller/CommentControllerTest.java
@@ -48,6 +48,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -212,13 +213,17 @@ class CommentControllerTest extends RestDocsTestSupport {
 
         given(commentService.commentList(anyLong(), anyInt())).willReturn(commentListResponse);
 
-        mockMvc.perform(get("/api/posts/{postNumber}/comments/page/{pageNumber}", 1, 1))
+        mockMvc.perform(get("/api/posts/{postNumber}/comments", 1)
+                        .param("page", "1")
+                )
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(
-                   pathParameters(
-                           parameterWithName("postNumber").description("게시글 번호"),
-                           parameterWithName("pageNumber").description("댓글 페이지 번호")
-                   ),
+                        pathParameters(
+                                parameterWithName("postNumber").description("게시글 번호")
+                        ),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호")
+                        ),
                         responseFields(
                                 fieldWithPath("comments").type(ARRAY).description("댓글 목록"),
                                 fieldWithPath("comments[].commentNum").type(NUMBER).description("댓글 번호"),


### PR DESCRIPTION
# 개요

특정 게시글에 속한 댓글 목록을 조회 API의 페이지 번호를 받는 부분을 경로 변수에서 쿼리 파라미터로 변경했습니다.

### 변경 전

```text
~/posts/{post_number}/comments/page/{page_number}
```

### 변경 후

```text
~/posts/{post_number}/comments?page={page_number}
```

#### 관련 이슈

close #49 

## 작업 유형

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 코드 포맷팅(오타 수정, 변수명 변경 등)
- [ ] 문서 작성 및 수정
- [ ] 테스트 추가 및 리팩토링
- [ ] 빌드 및 패키지 매니지 수정
