### PR TITLE
댓글 삭제 방식 변경

### DIFF
--- a/backend/src/docs/asciidoc/fragments/comment.adoc
+++ b/backend/src/docs/asciidoc/fragments/comment.adoc
@@ -59,6 +59,7 @@ include::{snippets}/comment-controller-test/comment-modify-not-comment-owner/htt
 ===== 404 Not Found
 
 include::{snippets}/comment-controller-test/comment-modify-not-found-comment/http-response.adoc[]
+include::{snippets}/comment-controller-test/comment-modify-already-delete-comment/http-response.adoc[]
 
 === 4.4. 댓글 삭제
 
@@ -81,6 +82,7 @@ include::{snippets}/comment-controller-test/comment-delete-not-comment-onwer/htt
 ===== 404 Not Found
 
 include::{snippets}/comment-controller-test/comment-delete-not-found-comment/http-response.adoc[]
+include::{snippets}/comment-controller-test/comment-delete-already-delete-comment/http-response.adoc[]
 
 === 4.5. 대댓글 작성
 

--- a/backend/src/main/java/com/board/domain/comment/entity/Comment.java
+++ b/backend/src/main/java/com/board/domain/comment/entity/Comment.java
@@ -38,6 +38,9 @@ public class Comment extends BaseEntity {
     @Column(nullable = false)
     private String content;
 
+    @Column(nullable = false)
+    private boolean delete;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
@@ -59,6 +62,7 @@ public class Comment extends BaseEntity {
         this.content = content;
         this.member = member;
         this.reference = reference;
+        this.delete = false;
         setPost(post);
     }
 
@@ -69,6 +73,10 @@ public class Comment extends BaseEntity {
 
     public void modify(String content) {
         this.content = content;
+    }
+
+    public void delete() {
+        this.delete = true;
     }
 
     public boolean isOwner(String loginUsername) {

--- a/backend/src/main/java/com/board/domain/comment/exception/AlreadyDeleteCommentException.java
+++ b/backend/src/main/java/com/board/domain/comment/exception/AlreadyDeleteCommentException.java
@@ -1,0 +1,12 @@
+package com.board.domain.comment.exception;
+
+import com.board.global.error.ErrorType;
+import com.board.global.error.exception.BaseException;
+
+public class AlreadyDeleteCommentException extends BaseException {
+
+    public AlreadyDeleteCommentException() {
+        super(ErrorType.ALREADY_COMMENT_DELETE);
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/board/domain/comment/service/CommentService.java
@@ -4,6 +4,7 @@ import com.board.domain.comment.dto.CommentListResponse;
 import com.board.domain.comment.dto.CommentModifyRequest;
 import com.board.domain.comment.dto.CommentWriteRequest;
 import com.board.domain.comment.entity.Comment;
+import com.board.domain.comment.exception.AlreadyDeleteCommentException;
 import com.board.domain.comment.exception.CommentDeleteAccessDeniedException;
 import com.board.domain.comment.exception.CommentModifyAccessDeniedException;
 import com.board.domain.comment.exception.NotFoundCommentException;
@@ -78,6 +79,9 @@ public class CommentService {
         if (!comment.isOwner(loginUsername)) {
             throw new CommentModifyAccessDeniedException();
         }
+        if (comment.isDelete()) {
+            throw new AlreadyDeleteCommentException();
+        }
         comment.modify(commentModifyRequest.getContent());
     }
 
@@ -88,7 +92,10 @@ public class CommentService {
         if (!comment.isOwner(loginUsername)) {
             throw new CommentDeleteAccessDeniedException();
         }
-        commentRepository.delete(comment);
+        if (comment.isDelete()) {
+            throw new AlreadyDeleteCommentException();
+        }
+        comment.delete();
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/board/global/error/ErrorType.java
+++ b/backend/src/main/java/com/board/global/error/ErrorType.java
@@ -22,6 +22,7 @@ public enum ErrorType {
     NOT_FOUND_MEMBER("E404001", HttpStatus.NOT_FOUND.value(), "회원을 찾을 수 없습니다."),
     NOT_FOUND_POST("E404002", HttpStatus.NOT_FOUND.value(), "게시글을 찾을 수 없습니다."),
     NOT_FOUND_COMMENT("E404003", HttpStatus.NOT_FOUND.value(), "댓글을 찾을 수 없습니다."),
+    ALREADY_COMMENT_DELETE("E404004", HttpStatus.NOT_FOUND.value(), "이미 삭제된 댓글입니다."),
     DUPLICATE_NICKNAME("E409001", HttpStatus.CONFLICT.value(), "사용 중인 닉네임입니다."),
     DUPLICATE_USERNAME("E409002", HttpStatus.CONFLICT.value(), "사용 중인 아이디입니다.");
 

--- a/backend/src/test/java/com/board/domain/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/board/domain/comment/controller/CommentControllerTest.java
@@ -4,6 +4,7 @@ import com.board.domain.comment.dto.CommentListItem;
 import com.board.domain.comment.dto.CommentListResponse;
 import com.board.domain.comment.dto.CommentModifyRequest;
 import com.board.domain.comment.dto.CommentWriteRequest;
+import com.board.domain.comment.exception.AlreadyDeleteCommentException;
 import com.board.domain.comment.exception.CommentDeleteAccessDeniedException;
 import com.board.domain.comment.exception.CommentModifyAccessDeniedException;
 import com.board.domain.comment.exception.NotFoundCommentException;
@@ -477,6 +478,42 @@ class CommentControllerTest extends RestDocsTestSupport {
     }
 
     @Test
+    @DisplayName("이미 삭제된 댓글에 수정을 시도할 경우 예외가 발생한다")
+    void commentModifyAlreadyDeleteComment() throws Exception {
+        CommentModifyRequest commentModifyRequest = new CommentModifyRequest("댓글");
+
+        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
+        willThrow(new AlreadyDeleteCommentException()).given(commentService).commentModify(anyLong(), anyLong(), any(CommentModifyRequest.class), anyString());
+
+        mockMvc.perform(put("/api/posts/{postNumber}/comments/{commentNumber}", 1, 1)
+                        .header("Authorization", "Bearer access-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(commentModifyRequest))
+                )
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.result.path").value("/api/posts/1/comments/1"))
+                .andExpect(jsonPath("$.result.error.code").value("E404004"))
+                .andExpect(jsonPath("$.result.error.message").value("이미 삭제된 댓글입니다."))
+                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
+                .andDo(restDocs.document(
+                        pathParameters(
+                                parameterWithName("postNumber").description("게시글 번호"),
+                                parameterWithName("commentNumber").description("댓글 번호")
+                        ),
+                        requestHeaders(
+                                headerWithName("Authorization").description("Access Token")
+                        ),
+                        requestFields(
+                                fieldWithPath("content").type(STRING).description("수정 댓글")
+                        ),
+                        responseFields(
+                                commonErrorResponse()
+                        )
+                ));
+    }
+
+    @Test
     @DisplayName("댓글을 삭제한다")
     void commentDelete() throws Exception {
         given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
@@ -543,6 +580,34 @@ class CommentControllerTest extends RestDocsTestSupport {
                 .andExpect(jsonPath("$.result.path").value("/api/posts/1/comments/1"))
                 .andExpect(jsonPath("$.result.error.code").value("E403004"))
                 .andExpect(jsonPath("$.result.error.message").value("댓글 삭제는 작성자만 할 수 있습니다."))
+                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
+                .andDo(restDocs.document(
+                        pathParameters(
+                                parameterWithName("postNumber").description("게시글 번호"),
+                                parameterWithName("commentNumber").description("댓글 번호")
+                        ),
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
+                        responseFields(
+                                commonErrorResponse()
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("이미 삭제된 댓글에 삭제를 시도할 경우 예외가 발생한다")
+    void commentDeleteAlreadyDeleteComment() throws Exception {
+        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
+        willThrow(new AlreadyDeleteCommentException()).given(commentService).commentDelete(anyLong(), anyLong(), anyString());
+
+        mockMvc.perform(delete("/api/posts/{postNumber}/comments/{commentNumber}", 1, 1)
+                        .header("Authorization", "Bearer access-token"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.result.path").value("/api/posts/1/comments/1"))
+                .andExpect(jsonPath("$.result.error.code").value("E404004"))
+                .andExpect(jsonPath("$.result.error.message").value("이미 삭제된 댓글입니다."))
                 .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
                 .andDo(restDocs.document(
                         pathParameters(

--- a/backend/src/test/java/com/board/domain/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/comment/repository/CommentRepositoryTest.java
@@ -120,9 +120,9 @@ class CommentRepositoryTest {
         Comment saveComment = commentRepository.save(comment);
         Comment findComment = commentRepository.findCommentJoinFetchMember(post.getId(), saveComment.getId()).get();
 
-        commentRepository.delete(findComment);
+        findComment.delete();
 
-        assertThat(commentRepository.findCommentJoinFetchMember(post.getId(), saveComment.getId())).isEmpty();
+        assertThat(findComment.isDelete()).isTrue();
     }
 
     @Test

--- a/backend/src/test/java/com/board/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/board/domain/comment/service/CommentServiceTest.java
@@ -3,6 +3,7 @@ package com.board.domain.comment.service;
 import com.board.domain.comment.dto.CommentModifyRequest;
 import com.board.domain.comment.dto.CommentWriteRequest;
 import com.board.domain.comment.entity.Comment;
+import com.board.domain.comment.exception.AlreadyDeleteCommentException;
 import com.board.domain.comment.exception.CommentDeleteAccessDeniedException;
 import com.board.domain.comment.exception.CommentModifyAccessDeniedException;
 import com.board.domain.comment.exception.NotFoundCommentException;
@@ -36,7 +37,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 
@@ -192,6 +192,25 @@ class CommentServiceTest {
     }
 
     @Test
+    @DisplayName("이미 삭제된 댓글에 수정을 시도할 경우 예외가 발생한다")
+    void commentModifyAlreadyCommentDelete() {
+        CommentModifyRequest commentModifyRequest = new CommentModifyRequest("댓글");
+        Comment comment = Comment.builder()
+                .content("댓글")
+                .member(member)
+                .post(post)
+                .build();
+        comment.delete();
+
+        given(commentRepository.findCommentJoinFetchMember(anyLong(), anyLong())).willReturn(Optional.of(comment));
+
+        assertThatThrownBy(() -> commentService.commentModify(1L, 1L, commentModifyRequest, "yoon1234"))
+                .isInstanceOf(AlreadyDeleteCommentException.class);
+
+        then(commentRepository).should().findCommentJoinFetchMember(anyLong(), anyLong());
+    }
+
+    @Test
     @DisplayName("댓글을 삭제한다")
     void commentDelete() {
         Comment comment = Comment.builder()
@@ -201,12 +220,10 @@ class CommentServiceTest {
                 .build();
 
         given(commentRepository.findCommentJoinFetchMember(anyLong(), anyLong())).willReturn(Optional.of(comment));
-        willDoNothing().given(commentRepository).delete(any(Comment.class));
 
         commentService.commentDelete(1L, 1L, "yoon1234");
 
         then(commentRepository).should().findCommentJoinFetchMember(anyLong(), anyLong());
-        then(commentRepository).should().delete(any(Comment.class));
     }
 
     @Test
@@ -218,7 +235,6 @@ class CommentServiceTest {
                 .isInstanceOf(NotFoundCommentException.class);
 
         then(commentRepository).should().findCommentJoinFetchMember(anyLong(), anyLong());
-        then(commentRepository).should(never()).delete(any(Comment.class));
     }
 
     @Test
@@ -236,7 +252,24 @@ class CommentServiceTest {
                 .isInstanceOf(CommentDeleteAccessDeniedException.class);
 
         then(commentRepository).should().findCommentJoinFetchMember(anyLong(), anyLong());
-        then(commentRepository).should(never()).delete(any(Comment.class));
+    }
+
+    @Test
+    @DisplayName("이미 삭제된 댓글에 삭제를 시도할 경우 예외가 발생한다")
+    void commentDeleteAlreadyDeleteComment() {
+        Comment comment = Comment.builder()
+                .content("댓글")
+                .member(member)
+                .post(post)
+                .build();
+        comment.delete();
+
+        given(commentRepository.findCommentJoinFetchMember(anyLong(), anyLong())).willReturn(Optional.of(comment));
+
+        assertThatThrownBy(() -> commentService.commentDelete(1L, 1L, "yoon1234"))
+                .isInstanceOf(AlreadyDeleteCommentException.class);
+
+        then(commentRepository).should().findCommentJoinFetchMember(anyLong(), anyLong());
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용

댓글(Comment) 엔티티에 댓글의 삭제 여부를 판단하는 필드를 추가해 삭제 여부를 확인합니다.

댓글 수정 및 삭제 시 해당 댓글의 삭제 여부를 검증하는 로직을 추가했습니다. 

- 이미 삭제된 댓글에 대해 수정 및 삭제를 시도할 경우 예외가 발생하게 변경했습니다.

API 문서에 이미 삭제된 댓글에 대해 수정 및 삭제를 시도할 경우 응답 형식에 대한 내용을 추가했습니다.

## 관련 이슈

- close #69 
