### PR TITLE
댓글 테이블이 생성되지 않는 버그 수정

### DIFF
--- a/backend/src/main/java/com/board/domain/comment/entity/Comment.java
+++ b/backend/src/main/java/com/board/domain/comment/entity/Comment.java
@@ -39,7 +39,7 @@ public class Comment extends BaseEntity {
     private String content;
 
     @Column(nullable = false)
-    private boolean delete;
+    private boolean isDelete;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
@@ -62,7 +62,7 @@ public class Comment extends BaseEntity {
         this.content = content;
         this.member = member;
         this.reference = reference;
-        this.delete = false;
+        this.isDelete = false;
         setPost(post);
     }
 
@@ -76,7 +76,7 @@ public class Comment extends BaseEntity {
     }
 
     public void delete() {
-        this.delete = true;
+        this.isDelete = true;
     }
 
     public boolean isOwner(String loginUsername) {


### PR DESCRIPTION
## 작업 내용

서버 구동 시 댓글 테이블이 생성되지 않는 버그를 수정했습니다.

댓글 엔티티 컬럼 중 삭제 여부를 나타내는 delete 필드명이 DB 예약어로 지정되어 있어 서버 구동 시  테이블이 생성되지 않았습니다.

## 관련 이슈

- fix #79 