### PR TITLE
자신이 작성한 게시글 목록 조회 기능 변경

### DIFF
--- a/backend/src/main/java/com/board/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/board/domain/member/controller/MemberController.java
@@ -1,14 +1,11 @@
 package com.board.domain.member.controller;
 
-import com.board.domain.comment.dto.CommentListResponse;
-import com.board.domain.comment.service.CommentService;
 import com.board.domain.member.dto.MemberNicknameRequest;
 import com.board.domain.member.dto.MemberPasswordRequest;
 import com.board.domain.member.dto.MemberProfileResponse;
 import com.board.domain.member.dto.MemberSignupRequest;
 import com.board.domain.member.service.MemberService;
 import com.board.domain.post.dto.PostListResponse;
-import com.board.domain.post.service.PostService;
 import com.board.global.common.dto.ApiResponse;
 
 import jakarta.validation.Valid;
@@ -33,8 +30,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
-    private final PostService postService;
-    private final CommentService commentService;
 
     @GetMapping("/nickname/{nickname}")
     public ResponseEntity<ApiResponse<Void>> memberNicknameExists(@PathVariable("nickname") String nickname) {
@@ -55,43 +50,34 @@ public class MemberController {
     }
 
     @Secured("ROLE_MEMBER")
-    @GetMapping("/profile")
-    public ResponseEntity<ApiResponse<MemberProfileResponse>> memberProfile(@AuthenticationPrincipal String username) {
-        MemberProfileResponse memberProfileResponse = memberService.memberProfile(username);
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<MemberProfileResponse>> memberProfile(@AuthenticationPrincipal Long memberId) {
+        MemberProfileResponse memberProfileResponse = memberService.memberProfile(memberId);
         return ResponseEntity.ok().body(ApiResponse.success(memberProfileResponse));
     }
 
     @Secured("ROLE_MEMBER")
-    @GetMapping("/profile/posts")
-    public ResponseEntity<ApiResponse<PostListResponse>> memberProfilePostList(@RequestParam("page") int page,
-                                                                               @AuthenticationPrincipal String username) {
+    @GetMapping("/me/posts")
+    public ResponseEntity<ApiResponse<PostListResponse>> memberPostList(@RequestParam("page") int page,
+                                                                        @AuthenticationPrincipal Long memberId) {
         page = page <= 0 ? 0 : page - 1;
-        PostListResponse postListResponse = postService.postListFromMember(page, username);
+        PostListResponse postListResponse = memberService.memberPostList(page, memberId);
         return ResponseEntity.ok().body(ApiResponse.success(postListResponse));
     }
 
     @Secured("ROLE_MEMBER")
-    @GetMapping("/profile/comments")
-    public ResponseEntity<ApiResponse<CommentListResponse>> memberProfileCommentList(@RequestParam("page") int page,
-                                                                                     @AuthenticationPrincipal String username) {
-        page = page <= 0 ? 0 : page - 1;
-        CommentListResponse commentListResponse = commentService.commentListFromMember(page, username);
-        return ResponseEntity.ok().body(ApiResponse.success(commentListResponse));
-    }
-
-    @Secured("ROLE_MEMBER")
-    @GetMapping("/profile/nickname")
+    @PutMapping("/me/nickname")
     public ResponseEntity<ApiResponse<Void>> memberNicknameChange(@RequestBody @Valid MemberNicknameRequest memberNicknameRequest,
-                                                                  @AuthenticationPrincipal String username) {
-        memberService.memberNicknameChange(memberNicknameRequest, username);
+                                                                  @AuthenticationPrincipal Long memberId) {
+        memberService.memberNicknameChange(memberNicknameRequest, memberId);
         return ResponseEntity.ok(ApiResponse.success());
     }
 
     @Secured("ROLE_MEMBER")
-    @PutMapping("/profile/password")
+    @PutMapping("/me/password")
     public ResponseEntity<ApiResponse<Void>> memberPasswordChange(@RequestBody @Valid MemberPasswordRequest memberPasswordRequest,
-                                                                  @AuthenticationPrincipal String username) {
-        memberService.memberPasswordChange(memberPasswordRequest, username);
+                                                                  @AuthenticationPrincipal Long memberId) {
+        memberService.memberPasswordChange(memberPasswordRequest, memberId);
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 

--- a/backend/src/main/java/com/board/domain/member/dto/MemberNicknameRequest.java
+++ b/backend/src/main/java/com/board/domain/member/dto/MemberNicknameRequest.java
@@ -2,13 +2,16 @@ package com.board.domain.member.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberNicknameRequest {
 
     @NotBlank(message = "닉네임을 입력해 주세요.")

--- a/backend/src/main/java/com/board/domain/member/dto/MemberPasswordRequest.java
+++ b/backend/src/main/java/com/board/domain/member/dto/MemberPasswordRequest.java
@@ -2,13 +2,16 @@ package com.board.domain.member.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberPasswordRequest {
 
     @NotBlank(message = "현재 비밀번호를 입력해 주세요.")

--- a/backend/src/main/java/com/board/domain/member/dto/MemberProfileResponse.java
+++ b/backend/src/main/java/com/board/domain/member/dto/MemberProfileResponse.java
@@ -2,19 +2,26 @@ package com.board.domain.member.dto;
 
 import com.board.domain.member.entity.Member;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberProfileResponse {
 
-    private final String nickname;
-    private final String username;
+    private String nickname;
+    private String username;
 
-    public MemberProfileResponse(Member member) {
-        this.nickname = member.getNickname();
-        this.username = member.getUsername();
+    public static MemberProfileResponse of(Member member) {
+        return MemberProfileResponse.builder()
+                .nickname(member.getNickname())
+                .username(member.getUsername())
+                .build();
     }
 
 }

--- a/backend/src/main/java/com/board/domain/member/dto/MemberSignupRequest.java
+++ b/backend/src/main/java/com/board/domain/member/dto/MemberSignupRequest.java
@@ -2,13 +2,16 @@ package com.board.domain.member.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberSignupRequest {
 
     @NotBlank(message = "닉네임을 입력해 주세요.")

--- a/backend/src/main/java/com/board/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/board/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.board.domain.member.repository;
 
 import com.board.domain.member.entity.Member;
+import com.board.domain.member.exception.NotFoundMemberException;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,8 +9,13 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    boolean existsMemberByNickname(String nickname);
-    boolean existsMemberByUsername(String username);
-    Optional<Member> findMemberByUsername(String username);
+    boolean existsByNickname(String nickname);
+    boolean existsByUsername(String username);
+    Optional<Member> findByUsername(String username);
+
+    default Member findByMemberId(Long memberId) {
+        return findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+    }
 
 }

--- a/backend/src/main/java/com/board/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/board/domain/member/service/MemberService.java
@@ -7,12 +7,14 @@ import com.board.domain.member.dto.MemberSignupRequest;
 import com.board.domain.member.entity.Member;
 import com.board.domain.member.exception.DuplicateNicknameException;
 import com.board.domain.member.exception.DuplicateUsernameException;
-import com.board.domain.member.exception.NotFoundMemberException;
 import com.board.domain.member.exception.PasswordMismatchException;
 import com.board.domain.member.repository.MemberRepository;
+import com.board.domain.post.dto.PostListResponse;
+import com.board.domain.post.repository.PostRepository;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,19 +23,22 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
 
+    private static final int POST_PER_PAGE = 10;
+
     private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public void memberNicknameExists(String nickname) {
-        if (memberRepository.existsMemberByNickname(nickname)) {
+        if (memberRepository.existsByNickname(nickname)) {
             throw new DuplicateNicknameException();
         }
     }
 
     @Transactional
     public void memberUsernameExists(String username) {
-        if (memberRepository.existsMemberByUsername(username)) {
+        if (memberRepository.existsByUsername(username)) {
             throw new DuplicateUsernameException();
         }
     }
@@ -55,24 +60,26 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public MemberProfileResponse memberProfile(String username) {
-        Member member = memberRepository.findMemberByUsername(username)
-                .orElseThrow(NotFoundMemberException::new);
-        return new MemberProfileResponse(member);
+    public MemberProfileResponse memberProfile(Long memberId) {
+        Member member = memberRepository.findByMemberId(memberId);
+        return MemberProfileResponse.of(member);
+    }
+
+    @Transactional(readOnly = true)
+    public PostListResponse memberPostList(int page, Long memberId) {
+        return postRepository.findPostMemberList(PageRequest.of(page, POST_PER_PAGE), memberId);
     }
 
     @Transactional
-    public void memberNicknameChange(MemberNicknameRequest memberNicknameRequest, String username) {
+    public void memberNicknameChange(MemberNicknameRequest memberNicknameRequest, Long memberId) {
         memberNicknameExists(memberNicknameRequest.getNickname());
-        Member member = memberRepository.findMemberByUsername(username)
-                .orElseThrow(NotFoundMemberException::new);
+        Member member = memberRepository.findByMemberId(memberId);
         member.changeNickname(memberNicknameRequest.getNickname());
     }
 
     @Transactional
-    public void memberPasswordChange(MemberPasswordRequest memberPasswordRequest, String username) {
-        Member member = memberRepository.findMemberByUsername(username)
-                .orElseThrow(NotFoundMemberException::new);
+    public void memberPasswordChange(MemberPasswordRequest memberPasswordRequest, Long memberId) {
+        Member member = memberRepository.findByMemberId(memberId);
         if (notMatchCurPassword(memberPasswordRequest.getCurPassword(), member.getPassword())) {
             throw new PasswordMismatchException();
         }

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.board.global.security.handler.MemberLoginFailureHandler;
 import com.board.global.security.handler.MemberLoginSuccessHandler;
 import com.board.global.security.handler.MemberLogoutSuccessHandler;
 import com.board.global.security.support.JwtManager;
+import com.board.global.security.support.RequestURI;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -35,6 +36,8 @@ import org.springframework.security.web.authentication.logout.LogoutSuccessHandl
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private static final String LOGIN_USERNAME_PARAM = "username";
+    private static final String LOGIN_PASSWORD_PARAM = "password";
     private static final String ROLE_MEMBER = "MEMBER";
 
     private final ObjectMapper objectMapper;
@@ -54,46 +57,47 @@ public class SecurityConfig {
                         .authenticationEntryPoint(authenticationEntryPoint())
                 )
                 .formLogin(form -> form
-                        .loginProcessingUrl("/api/members/login")
-                        .usernameParameter("username")
-                        .passwordParameter("password")
+                        .loginProcessingUrl(RequestURI.MEMBER_LOGIN.pattern())
+                        .usernameParameter(LOGIN_USERNAME_PARAM)
+                        .passwordParameter(LOGIN_PASSWORD_PARAM)
                         .successHandler(memberLoginSuccessHandler())
                         .failureHandler(memberLoginFailureHandler())
                         .permitAll()
                 )
                 .logout(logout -> logout
-                        .logoutUrl("/api/members/logout")
+                        .logoutUrl(RequestURI.MEMBER_LOGOUT.pattern())
                         .logoutSuccessHandler(logoutSuccessHandler())
                         .permitAll(false)
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET,
-                                "/docs/board.html",
-                                "/api/members/nickname/*",
-                                "/api/members/username/*",
-                                "/api/posts/*",
-                                "/api/posts",
-                                "/api/posts/search",
-                                "/api/posts/*/comments").permitAll()
+                                RequestURI.MEMBER_NICKNAME_EXISTS.pattern(),
+                                RequestURI.MEMBER_USERNAME_EXISTS.pattern(),
+                                RequestURI.POST_DETAIL.pattern(),
+                                RequestURI.POST_LIST.pattern(),
+                                RequestURI.POST_SERACH_LIST.pattern(),
+                                RequestURI.COMMENT_LIST.pattern()).permitAll()
                         .requestMatchers(HttpMethod.POST,
-                                "/api/members/signup",
-                                "/api/token/reissue").permitAll()
+                                RequestURI.MEMBER_SIGNUP.pattern(),
+                                RequestURI.MEMBER_LOGIN.pattern(),
+                                RequestURI.REISSUE_ACCESS_TOKEN.pattern()).permitAll()
                         .requestMatchers(HttpMethod.GET,
-                                "/api/members/profile",
-                                "/api/members/profile/posts",
-                                "/api/members/profile/comments",
-                                "/api/members/profile/nickname").hasRole(ROLE_MEMBER)
+                                RequestURI.MEMBER_PROFILE.pattern(),
+                                RequestURI.MEMBER_POST_LIST.pattern(),
+                                RequestURI.MEMBER_COMMENT_LIST.pattern()).hasRole(ROLE_MEMBER)
                         .requestMatchers(HttpMethod.POST,
-                                "/api/posts",
-                                "/api/posts/*/comments",
-                                "/api/posts/*/comments/*/replies").hasRole(ROLE_MEMBER)
+                                RequestURI.POST_WRITE.pattern(),
+                                RequestURI.COMMENT_WRITE.pattern(),
+                                RequestURI.COMMENT_REPLRY_WRITE.pattern(),
+                                RequestURI.MEMBER_LOGOUT.pattern()).hasRole(ROLE_MEMBER)
                         .requestMatchers(HttpMethod.PUT,
-                                "/api/members/profile/password",
-                                "/api/posts/*",
-                                "/api/posts/*/comments/*").hasRole(ROLE_MEMBER)
+                                RequestURI.MEMBER_NICKNAME_CHANGE.pattern(),
+                                RequestURI.MEMBER_PASSWORD_CHANGE.pattern(),
+                                RequestURI.POST_MODIFY.pattern(),
+                                RequestURI.COMMENT_MODIFY.pattern()).hasRole(ROLE_MEMBER)
                         .requestMatchers(HttpMethod.DELETE,
-                                "/api/posts/*",
-                                "/api/posts/*/comments/*").hasRole(ROLE_MEMBER)
+                                RequestURI.POST_DELETE.pattern(),
+                                RequestURI.COMMENT_DELETE.pattern()).hasRole(ROLE_MEMBER)
                         .anyRequest().denyAll()
                 );
         return httpSecurity.build();

--- a/backend/src/main/java/com/board/global/security/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/board/global/security/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.board.global.security.filter;
 
 import com.board.global.security.support.JwtManager;
+import com.board.global.security.support.RequestURI;
 
 import io.jsonwebtoken.Claims;
 
@@ -9,7 +10,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
@@ -18,13 +18,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.AuthenticationEntryPoint;
-import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-
-import java.util.Arrays;
 
 import static org.springframework.security.core.authority.AuthorityUtils.createAuthorityList;
 
@@ -66,38 +63,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(@NonNull HttpServletRequest request) {
-        return ExcludeRequest.isExcludeRequest(request.getMethod(), request.getRequestURI());
-    }
-
-    @Getter
-    private enum ExcludeRequest {
-
-        REST_DOCS("GET", "/docs/board.html"),
-        MEMBER_NICKNAME_EXISTS("GET", "/api/members/nickname/*"),
-        MEMBER_USERNAME_EXISTS("GET", "/api/members/username/*"),
-        MEMBER_SIGNUP("POST", "/api/members/signup"),
-        MEMBER_LOGIN("POST", "/api/members/login"),
-        POST_DETAIL("GET", "/api/posts/*"),
-        POST_LIST("GET", "/api/posts"),
-        POST_LIST_SEARCH("GET", "/api/posts/search"),
-        COMMENT_LIST("GET", "/api/posts/*/comments"),
-        REISSUE_ACCESS_TOKEN("POST", "/api/token/reissue");
-
-        private final String method;
-        private final String pattern;
-
-        ExcludeRequest(String method, String pattern) {
-            this.method = method;
-            this.pattern = pattern;
-        }
-
-        private static final AntPathMatcher ANT_PATH_MATCHER = new AntPathMatcher();
-
-        public static boolean isExcludeRequest(String requestMethod, String requestURI) {
-            return Arrays.stream(ExcludeRequest.values())
-                    .anyMatch(e -> e.method.equals(requestMethod) && ANT_PATH_MATCHER.match(e.pattern, requestURI));
-        }
-
+        return RequestURI.sholdNotFilter(request);
     }
 
 }

--- a/backend/src/main/java/com/board/global/security/service/LoginService.java
+++ b/backend/src/main/java/com/board/global/security/service/LoginService.java
@@ -19,7 +19,7 @@ public class LoginService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member member = memberRepository.findMemberByUsername(username)
+        Member member = memberRepository.findByUsername(username)
                 .orElseThrow(() -> new UsernameNotFoundException("회원이 존재하지 않습니다."));
         return new LoginMember(member);
     }

--- a/backend/src/main/java/com/board/global/security/support/RequestURI.java
+++ b/backend/src/main/java/com/board/global/security/support/RequestURI.java
@@ -1,0 +1,56 @@
+package com.board.global.security.support;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.http.HttpMethod;
+
+import java.util.Arrays;
+
+import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
+
+public enum RequestURI {
+
+    MEMBER_NICKNAME_EXISTS(HttpMethod.GET, "/api/members/nickname/*", true),
+    MEMBER_USERNAME_EXISTS(HttpMethod.GET, "/api/members/username/*", true),
+    MEMBER_SIGNUP(HttpMethod.POST, "/api/members/signup", true),
+    MEMBER_LOGIN(HttpMethod.POST, "/api/auth/login", true),
+    MEMBER_LOGOUT(HttpMethod.POST, "/api/auth/logout", false),
+    MEMBER_PROFILE(HttpMethod.GET, "/api/members/me", false),
+    MEMBER_POST_LIST(HttpMethod.GET, "/api/members/me/posts", false),
+    MEMBER_COMMENT_LIST(HttpMethod.GET, "/api/members/me/comments", false),
+    MEMBER_NICKNAME_CHANGE(HttpMethod.PUT, "/api/members/me/nickname", false),
+    MEMBER_PASSWORD_CHANGE(HttpMethod.PUT, "/api/members/me/password", false),
+    POST_WRITE(HttpMethod.POST, "/api/posts", false),
+    POST_DETAIL(HttpMethod.GET, "/api/posts/*", true),
+    POST_LIST(HttpMethod.GET, "/api/posts", true),
+    POST_SERACH_LIST(HttpMethod.GET, "/api/posts/search", true),
+    POST_MODIFY(HttpMethod.PUT, "/api/posts/*", false),
+    POST_DELETE(HttpMethod.DELETE, "/api/posts/*", false),
+    COMMENT_WRITE(HttpMethod.POST, "/api/posts/*/comments", false),
+    COMMENT_REPLRY_WRITE(HttpMethod.POST, "/api/posts/*/comments/*/replies", false),
+    COMMENT_LIST(HttpMethod.GET, "/api/posts/*/comments", true),
+    COMMENT_MODIFY(HttpMethod.PUT, "/api/posts/*/comments/*", false),
+    COMMENT_DELETE(HttpMethod.DELETE, "/api/posts/*/comments/*", false),
+    REISSUE_ACCESS_TOKEN(HttpMethod.POST, "/api/token/reissue", true);
+
+    private final HttpMethod method;
+    private final String pattern;
+    private final boolean permitAll;
+
+    RequestURI(HttpMethod method, String pattern, boolean permitAll) {
+        this.method = method;
+        this.pattern = pattern;
+        this.permitAll = permitAll;
+    }
+
+    public static boolean sholdNotFilter(HttpServletRequest request) {
+
+        return Arrays.stream(RequestURI.values())
+                .anyMatch(uri -> uri.permitAll && antMatcher(uri.method, uri.pattern).matches(request));
+    }
+
+    public String pattern() {
+        return pattern;
+    }
+
+}

--- a/backend/src/test/java/com/board/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/board/domain/member/controller/MemberControllerTest.java
@@ -1,8 +1,5 @@
 package com.board.domain.member.controller;
 
-import com.board.domain.comment.dto.CommentListItem;
-import com.board.domain.comment.dto.CommentListResponse;
-import com.board.domain.comment.service.CommentService;
 import com.board.domain.member.dto.MemberNicknameRequest;
 import com.board.domain.member.dto.MemberPasswordRequest;
 import com.board.domain.member.dto.MemberProfileResponse;
@@ -13,21 +10,24 @@ import com.board.domain.member.exception.DuplicateUsernameException;
 import com.board.domain.member.exception.NotFoundMemberException;
 import com.board.domain.member.exception.PasswordMismatchException;
 import com.board.domain.member.service.MemberService;
-import com.board.domain.post.dto.PostListItem;
 import com.board.domain.post.dto.PostListResponse;
-import com.board.domain.post.service.PostService;
-import com.board.domain.token.dto.TokenResponse;
-import com.board.domain.token.exception.InvalidTokenException;
-import com.board.global.security.dto.AuthPrincipal;
+import com.board.global.security.exception.ExpiredTokenException;
+import com.board.global.security.exception.InvalidTokenException;
+import com.board.global.security.dto.LoginMember;
 
-import com.board.support.RestDocsTestSupport;
+import com.board.support.ControllerTest;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.time.LocalDateTime;
@@ -35,16 +35,14 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
-import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
-import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
-import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -61,727 +59,1350 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = MemberController.class)
-class MemberControllerTest extends RestDocsTestSupport {
+class MemberControllerTest extends ControllerTest {
 
     @MockBean
     private MemberService memberService;
 
-    @MockBean
-    private PostService postService;
+    @Nested
+    @DisplayName("닉네임 중복 확인 요청")
+    class MemberNicknameExistsTest {
 
-    @MockBean
-    private CommentService commentService;
+        @Test
+        @DisplayName("닉네임이 중복되지 않는다")
+        void memberNicknameExists() throws Exception {
+            willDoNothing().given(memberService).memberNicknameExists(anyString());
 
-    @Test
-    @DisplayName("닉네임 중복 확인을 한다")
-    void memberNicknameExists() throws Exception {
-        willDoNothing().given(memberService).memberNicknameExists(anyString());
+            mockMvc.perform(get("/api/members/nickname/{nickname}", "yoonkun"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("nickname").description("닉네임")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+        }
 
-        mockMvc.perform(get("/api/members/nickname/{nickname}", "yoonkun"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result").isEmpty())
-                .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("nickname").description("닉네임")
-                        ),
-                        responseFields(
-                                commonSuccessResponse()
-                        )
-                ));
+        @Test
+        @DisplayName("닉네임이 중복되면 예외가 발생한다")
+        void memberNicknameExistsDuplicateNickname() throws Exception {
+            willThrow(new DuplicateNicknameException()).given(memberService).memberNicknameExists(anyString());
+
+            mockMvc.perform(get("/api/members/nickname/{nickname}", "yoonkun"))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E409001"))
+                    .andExpect(jsonPath("$.error.message").value("사용 중인 닉네임입니다."))
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("nickname").description("닉네임")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+
+        }
+
     }
 
-    @Test
-    @DisplayName("닉네임 중복 시 예외가 발생한다")
-    void memberNicknameExistsDuplicateNickname() throws Exception {
-        willThrow(new DuplicateNicknameException()).given(memberService).memberNicknameExists(anyString());
+    @Nested
+    @DisplayName("아이디 중복 확인 요청")
+    class MemberUsernameExistsTest {
 
-        mockMvc.perform(get("/api/members/nickname/{nickname}", "yoonkun"))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(409))
-                .andExpect(jsonPath("$.result.path").value("/api/members/nickname/yoonkun"))
-                .andExpect(jsonPath("$.result.error.code").value("E409001"))
-                .andExpect(jsonPath("$.result.error.message").value("사용 중인 닉네임입니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("nickname").description("닉네임")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
+        @Test
+        @DisplayName("아이디가 중복되지 않는다")
+        void memberUsernameExists() throws Exception {
+            willDoNothing().given(memberService).memberUsernameExists(anyString());
+
+            mockMvc.perform(get("/api/members/username/{username}", "yoon1234"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("username").description("아이디")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("아이디가 중복되면 예외가 발생한다")
+        void memberUsernameExistsDuplicateUsername() throws Exception {
+            willThrow(new DuplicateUsernameException()).given(memberService).memberUsernameExists(anyString());
+
+            mockMvc.perform(get("/api/members/username/{username}", "yoon1234"))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E409002"))
+                    .andExpect(jsonPath("$.error.message").value("사용 중인 아이디입니다."))
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("username").description("아이디")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
     }
 
-    @Test
-    @DisplayName("아이디 중복 확인을 한다")
-    void memberUsernameExists() throws Exception {
-        willDoNothing().given(memberService).memberUsernameExists(anyString());
+    @Nested
+    @DisplayName("회원가입 요청")
+    class MemberSignupTest {
 
-        mockMvc.perform(get("/api/members/username/{username}", "yoon1234"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result").isEmpty())
-                .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("username").description("아이디")
-                        ),
-                        responseFields(
-                                commonSuccessResponse()
-                        )
-                ));
+        @Test
+        @DisplayName("회원가입을 한다")
+        void memberSignup() throws Exception {
+            MemberSignupRequest memberSignupRequest = MemberSignupRequest.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password("12345678")
+                    .passwordConfirm("12345678")
+                    .build();
+
+            willDoNothing().given(memberService).memberSignup(any(MemberSignupRequest.class));
+
+            mockMvc.perform(post("/api/members/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberSignupRequest))
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andDo(restDocs.document(
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("닉네임"),
+                                    fieldWithPath("username").type(STRING).description("아이디"),
+                                    fieldWithPath("password").type(STRING).description("비밀번호"),
+                                    fieldWithPath("passwordConfirm").type(STRING).description("비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("닉네임이 비어있으면 예외가 발생한다")
+        void memberSignupInvalidNicknameValue() throws Exception {
+            MemberSignupRequest memberSignupRequest = MemberSignupRequest.builder()
+                    .nickname("")
+                    .username("yoon1234")
+                    .password("12345678")
+                    .passwordConfirm("12345678")
+                    .build();
+
+            mockMvc.perform(post("/api/members/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberSignupRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("nickname"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value(""))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("닉네임을 입력해 주세요."))
+                    .andDo(restDocs.document(
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("닉네임"),
+                                    fieldWithPath("username").type(STRING).description("아이디"),
+                                    fieldWithPath("password").type(STRING).description("비밀번호"),
+                                    fieldWithPath("passwordConfirm").type(STRING).description("비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+
+        }
+
+        @Test
+        @DisplayName("아이디가 비어있으면 예외가 발생한다")
+        void memberSignupInvalidUsernameValue() throws Exception {
+            MemberSignupRequest memberSignupRequest = MemberSignupRequest.builder()
+                    .nickname("yoonkun")
+                    .username("")
+                    .password("12345678")
+                    .passwordConfirm("12345678")
+                    .build();
+
+            mockMvc.perform(post("/api/members/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberSignupRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("username"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value(""))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("아이디를 입력해 주세요."))
+                    .andDo(restDocs.document(
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("닉네임"),
+                                    fieldWithPath("username").type(STRING).description("아이디"),
+                                    fieldWithPath("password").type(STRING).description("비밀번호"),
+                                    fieldWithPath("passwordConfirm").type(STRING).description("비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("비밀번호가 비어있으면 예외가 발생한다")
+        void memberSignupInvalidPasswordValue() throws Exception {
+            MemberSignupRequest memberSignupRequest = MemberSignupRequest.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password("")
+                    .passwordConfirm("12345678")
+                    .build();
+
+            mockMvc.perform(post("/api/members/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberSignupRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("password"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value(""))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("비밀번호를 입력해 주세요."))
+                    .andDo(restDocs.document(
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("닉네임"),
+                                    fieldWithPath("username").type(STRING).description("아이디"),
+                                    fieldWithPath("password").type(STRING).description("비밀번호"),
+                                    fieldWithPath("passwordConfirm").type(STRING).description("비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("비밀번호 확인이 비어있으면 예외가 발생한다")
+        void memberSignupInvalidPasswordConfirmValue() throws Exception {
+            MemberSignupRequest memberSignupRequest = MemberSignupRequest.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password("12345678")
+                    .passwordConfirm("")
+                    .build();
+
+            mockMvc.perform(post("/api/members/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberSignupRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("passwordConfirm"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value(""))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("비밀번호를 한 번 더 입력해 주세요."))
+                    .andDo(restDocs.document(
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("닉네임"),
+                                    fieldWithPath("username").type(STRING).description("아이디"),
+                                    fieldWithPath("password").type(STRING).description("비밀번호"),
+                                    fieldWithPath("passwordConfirm").type(STRING).description("비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("닉네임이 중복되면 예외가 발생한다")
+        void memberSignupDuplicateNickname() throws Exception {
+            MemberSignupRequest memberSignupRequest = MemberSignupRequest.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password("12345678")
+                    .passwordConfirm("12345678")
+                    .build();
+
+            willThrow(new DuplicateNicknameException()).given(memberService).memberSignup(any(MemberSignupRequest.class));
+
+            mockMvc.perform(post("/api/members/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberSignupRequest))
+                    )
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E409001"))
+                    .andExpect(jsonPath("$.error.message").value("사용 중인 닉네임입니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("닉네임"),
+                                    fieldWithPath("username").type(STRING).description("아이디"),
+                                    fieldWithPath("password").type(STRING).description("비밀번호"),
+                                    fieldWithPath("passwordConfirm").type(STRING).description("비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("아이디가 중복되면 예외가 발생한다")
+        void memberSignupDuplicateUsername() throws Exception {
+            MemberSignupRequest memberSignupRequest = MemberSignupRequest.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password("12345678")
+                    .passwordConfirm("12345678")
+                    .build();
+
+            willThrow(new DuplicateUsernameException()).given(memberService).memberSignup(any(MemberSignupRequest.class));
+
+            mockMvc.perform(post("/api/members/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberSignupRequest))
+                    )
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E409002"))
+                    .andExpect(jsonPath("$.error.message").value("사용 중인 아이디입니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("닉네임"),
+                                    fieldWithPath("username").type(STRING).description("아이디"),
+                                    fieldWithPath("password").type(STRING).description("비밀번호"),
+                                    fieldWithPath("passwordConfirm").type(STRING).description("비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("비밀번호와 비밀번호 확인이 일치하지 않으면 예외가 발생한다")
+        void memberSignupPasswordAndPasswordConfirmMismatch() throws Exception {
+            MemberSignupRequest memberSignupRequest = MemberSignupRequest.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password("12345678")
+                    .passwordConfirm("87654321")
+                    .build();
+
+            willThrow(new PasswordMismatchException()).given(memberService).memberSignup(any(MemberSignupRequest.class));
+
+            mockMvc.perform(post("/api/members/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberSignupRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400002"))
+                    .andExpect(jsonPath("$.error.message").value("비밀번호가 일치하지 않습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("닉네임"),
+                                    fieldWithPath("username").type(STRING).description("아이디"),
+                                    fieldWithPath("password").type(STRING).description("비밀번호"),
+                                    fieldWithPath("passwordConfirm").type(STRING).description("비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
     }
 
-    @Test
-    @DisplayName("아이디 중복 시 예외가 발생한다")
-    void memberUsernameExistsDuplicateUsername() throws Exception {
-        willThrow(new DuplicateUsernameException()).given(memberService).memberUsernameExists(anyString());
+    @Nested
+    @DisplayName("로그인 요청")
+    class MemberLoginTest {
 
-        mockMvc.perform(get("/api/members/username/{username}", "yoon1234"))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(409))
-                .andExpect(jsonPath("$.result.path").value("/api/members/username/yoon1234"))
-                .andExpect(jsonPath("$.result.error.code").value("E409002"))
-                .andExpect(jsonPath("$.result.error.message").value("사용 중인 아이디입니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("username").description("아이디")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
+        @Test
+        @DisplayName("로그인을 한다")
+        void memberLogin() throws Exception {
+            Member member = Member.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password(new BCryptPasswordEncoder().encode("12345678"))
+                    .build();
+
+            LoginMember loginMember = new LoginMember(member);
+
+            given(userDetailsService.loadUserByUsername(anyString())).willReturn(loginMember);
+            given(jwtManager.createAccessToken(any(LoginMember.class))).willReturn("access-token");
+            given(jwtManager.createRefreshToken()).willReturn("refresh-token");
+            willDoNothing().given(tokenService).saveToken(anyString(), any(Member.class));
+
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                            .param("username", "yoon1234")
+                            .param("password", "12345678")
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andExpect(jsonPath("$.data.accessToken").value("access-token"))
+                    .andExpect(jsonPath("$.data.refreshToken").value("refresh-token"))
+                    .andDo(restDocs.document(
+                            formParameters(
+                                    parameterWithName("username").description("아이디"),
+                                    parameterWithName("password").description("비밀번호")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse())
+                                    .and(
+                                            fieldWithPath("data.accessToken").type(STRING).description("액세스 토큰"),
+                                            fieldWithPath("data.refreshToken").type(STRING).description("리프레시 토큰")
+                                    )
+                    ));
+
+        }
+
+        @Test
+        @DisplayName("아이디 또는 비밀번호가 일치하지 않으면 예외가 발생한다")
+        void memberLoginBadCredentials() throws Exception {
+            willThrow(UsernameNotFoundException.class).given(userDetailsService).loadUserByUsername(anyString());
+
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                            .param("username", "yoon1234")
+                            .param("password", "12345678")
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401001"))
+                    .andExpect(jsonPath("$.error.message").value("아이디 또는 비밀번호가 일치하지 않습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            formParameters(
+                                    parameterWithName("username").description("아이디"),
+                                    parameterWithName("password").description("비밀번호")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
     }
 
-    @Test
-    @DisplayName("회원가입을 한다")
-    void memberSignup() throws Exception {
-        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonkun", "yoon1234", "12345678", "12345678");
+    @Nested
+    @DisplayName("로그아웃 요청")
+    class MemberLogoutTest {
 
-        willDoNothing().given(memberService).memberSignup(any(MemberSignupRequest.class));
+        @Test
+        @DisplayName("로그아웃을 한다")
+        void memberLogout() throws Exception {
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
 
-        mockMvc.perform(post("/api/members/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(memberSignupRequest))
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result").isEmpty())
-                .andDo(restDocs.document(
-                        requestFields(
-                                fieldWithPath("nickname").type(STRING).description("닉네임"),
-                                fieldWithPath("username").type(STRING).description("아이디"),
-                                fieldWithPath("password").type(STRING).description("비밀번호"),
-                                fieldWithPath("passwordConfirm").type(STRING).description("비밀번호 확인")
-                        ),
-                        responseFields(
-                                commonSuccessResponse()
-                        )
-                ));
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willDoNothing().given(tokenService).deleteToken(anyLong());
+
+            mockMvc.perform(post("/api/auth/logout")
+                            .header("Authorization", "Bearer access-token")
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 유효하지 않으면 예외가 발생한다")
+        void memberLogoutInvalidAccessToken() throws Exception {
+            willThrow(new InvalidTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(post("/api/auth/logout")
+                            .header("Authorization", "Bearer invalid-token")
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401002"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 유효하지 않습니다."))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 만료되면 예외가 발생한다")
+        void memberLogoutExpiredAccessToken() throws Exception {
+            willThrow(new ExpiredTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(post("/api/auth/logout")
+                            .header("Authorization", "Bearer invalid-token")
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401003"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 만료되었습니다."))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
     }
 
-    @Test
-    @DisplayName("회원가입 시 입력값이 잘못되면 예외가 발생한다")
-    void memberSignupInvalidInputValue() throws Exception {
-        MemberSignupRequest invalidMemberSignupRequest = new MemberSignupRequest("yoonkun", "", "12345678", "12345678");
+    @Nested
+    @DisplayName("회원 상세정보 조회 요청")
+    class MemberProfileTest {
 
-        willDoNothing().given(memberService).memberSignup(any(MemberSignupRequest.class));
+        @Test
+        @DisplayName("회원 상세정보를 조회한다")
+        void memberProfile() throws Exception {
+            MemberProfileResponse memberProfileResponse = MemberProfileResponse.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .build();
 
-        mockMvc.perform(post("/api/members/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidMemberSignupRequest))
-                )
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.result.path").value("/api/members/signup"))
-                .andExpect(jsonPath("$.result.error.code").value("E400001"))
-                .andExpect(jsonPath("$.result.error.message").value("입력값이 잘못되었습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].field").value("username"))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].input").value(""))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].message").value("아이디를 입력해 주세요."))
-                .andDo(restDocs.document(
-                        requestFields(
-                                fieldWithPath("nickname").type(STRING).description("닉네임"),
-                                fieldWithPath("username").type(STRING).description("아이디"),
-                                fieldWithPath("password").type(STRING).description("비밀번호"),
-                                fieldWithPath("passwordConfirm").type(STRING).description("비밀번호 확인")
-                        ),
-                        responseFields(
-                                commonErrorResponse())
-                                .and(
-                                        fieldWithPath("result.error.fieldErrors[].field").description(STRING).description("필드명"),
-                                        fieldWithPath("result.error.fieldErrors[].input").description(STRING).description("입력값"),
-                                        fieldWithPath("result.error.fieldErrors[].message").description(STRING).description("메시지")
-                                )
-                ));
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            given(memberService.memberProfile(anyLong())).willReturn(memberProfileResponse);
+
+            mockMvc.perform(get("/api/members/me")
+                            .header("Authorization", "Bearer access-token")
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse())
+                                    .and(
+                                            fieldWithPath("data.nickname").type(STRING).description("닉네임"),
+                                            fieldWithPath("data.username").type(STRING).description("아이디")
+                                    )
+                    ));
+        }
+
+        @Test
+        @DisplayName("회원이 존재하지 않으면 예외가 발생한다")
+        void memberProfileNotFoundMember() throws Exception {
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willThrow(new NotFoundMemberException()).given(memberService).memberProfile(anyLong());
+
+            mockMvc.perform(get("/api/members/me")
+                            .header("Authorization", "Bearer access-token")
+                    )
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E404001"))
+                    .andExpect(jsonPath("$.error.message").value("회원을 찾을 수 없습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 유효하지 않으면 예외가 발생한다")
+        void memberProfileInvalidAccessToken() throws Exception {
+            willThrow(new InvalidTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(get("/api/members/me")
+                            .header("Authorization", "Bearer invalid-token")
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401002"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 유효하지 않습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 만료되면 예외가 발생한다")
+        void memberProfileExpiredAccessToken() throws Exception {
+            willThrow(new ExpiredTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(get("/api/members/me")
+                            .header("Authorization", "Bearer expired-token")
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401003"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 만료되었습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
     }
 
-    @Test
-    @DisplayName("회원가입 시 비밀번호가 일치하지 않으면 예외가 발생한다")
-    void memberSignupPasswordMismatch() throws Exception {
-        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonkun", "yoon1234", "12345678", "12345679");
+    @Nested
+    @DisplayName("회원이 작성한 게시글 목록 조회 요청")
+    class MemberPostListTest {
 
-        willThrow(new PasswordMismatchException()).given(memberService).memberSignup(any(MemberSignupRequest.class));
+        @Test
+        @DisplayName("회원이 작성한 게시글 목록을 조회한다")
+        void memberPostList() throws Exception {
+            PostListResponse postListResponse = PostListResponse.builder()
+                    .posts(List.of(
+                            PostListResponse.PostItem.builder()
+                                    .postId(1L)
+                                    .title("title")
+                                    .writer("writer")
+                                    .commentCount(0)
+                                    .createdAt(LocalDateTime.of(2024, 6, 17, 0, 0))
+                                    .build()
+                    ))
+                    .page(1)
+                    .totalPages(1)
+                    .totalElements(1)
+                    .first(true)
+                    .last(true)
+                    .prev(false)
+                    .next(false)
+                    .build();
 
-        mockMvc.perform(post("/api/members/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(memberSignupRequest))
-                )
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.result.path").value("/api/members/signup"))
-                .andExpect(jsonPath("$.result.error.code").value("E400002"))
-                .andExpect(jsonPath("$.result.error.message").value("비밀번호가 일치하지 않습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        requestFields(
-                                fieldWithPath("nickname").type(STRING).description("닉네임"),
-                                fieldWithPath("username").type(STRING).description("아이디"),
-                                fieldWithPath("password").type(STRING).description("비밀번호"),
-                                fieldWithPath("passwordConfirm").type(STRING).description("비밀번호 확인")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            given(memberService.memberPostList(anyInt(), anyLong())).willReturn(postListResponse);
+
+            mockMvc.perform(get("/api/members/me/posts")
+                            .header("Authorization", "Bearer access-token")
+                            .param("page", "1")
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andExpect(jsonPath("$.data.posts[0].postId").value(1))
+                    .andExpect(jsonPath("$.data.posts[0].title").value("title"))
+                    .andExpect(jsonPath("$.data.posts[0].writer").value("writer"))
+                    .andExpect(jsonPath("$.data.posts[0].commentCount").value(0))
+                    .andExpect(jsonPath("$.data.posts[0].createdAt").value("2024-06-17T00:00:00"))
+                    .andExpect(jsonPath("$.data.page").value(1))
+                    .andExpect(jsonPath("$.data.totalPages").value(1))
+                    .andExpect(jsonPath("$.data.totalElements").value(1))
+                    .andExpect(jsonPath("$.data.first").value(true))
+                    .andExpect(jsonPath("$.data.last").value(true))
+                    .andExpect(jsonPath("$.data.prev").value(false))
+                    .andExpect(jsonPath("$.data.next").value(false))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            queryParameters(
+                                    parameterWithName("page").description("페이지 번호")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 유효하지 않으면 예외가 발생한다")
+        void memberPostListInvalidAccessToken() throws Exception {
+            willThrow(new InvalidTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(get("/api/members/me/posts")
+                            .header("Authorization", "Bearer invalid-token")
+                            .param("page", "1")
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401002"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 유효하지 않습니다."))
+                    .andDo(restDocs.document(
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 만료되면 예외가 발생한다")
+        void memberPostListExpiredAccessToken() throws Exception {
+            willThrow(new ExpiredTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(get("/api/members/me/posts")
+                            .header("Authorization", "Bearer expired-token")
+                            .param("page", "1")
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401003"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 만료되었습니다."))
+                    .andDo(restDocs.document(
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
     }
 
-    @Test
-    @DisplayName("로그인을 한다")
-    void memberLogin() throws Exception {
-        Member member = Member.builder()
-                .username("yoon1234")
-                .password(new BCryptPasswordEncoder().encode("12345678"))
-                .build();
-        AuthPrincipal authPrincipal = new AuthPrincipal(member);
-        TokenResponse tokenResponse = new TokenResponse("access-token", "refresh-token");
+    @Nested
+    @DisplayName("회원 닉네임 변경 요청")
+    class MemberNicknameChangeTest {
 
-        given(userDetailsService.loadUserByUsername(anyString())).willReturn(authPrincipal);
-        given(tokenService.tokenSave(any(Member.class))).willReturn(tokenResponse);
+        @Test
+        @DisplayName("닉네임을 변경한다")
+        void memberNicknameChange() throws Exception {
+            MemberNicknameRequest memberNicknameRequest = MemberNicknameRequest.builder()
+                    .nickname("newNickname")
+                    .build();
 
-        mockMvc.perform(post("/api/members/login")
-                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                        .param("username", "yoon1234")
-                        .param("password", "12345678")
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result.accessToken").value("access-token"))
-                .andExpect(jsonPath("$.result.refreshToken").value("refresh-token"))
-                .andDo(restDocs.document(
-                        formParameters(
-                                parameterWithName("username").description("아이디"),
-                                parameterWithName("password").description("비밀번호")
-                        ),
-                        responseFields(
-                                commonSuccessResponse())
-                                .and(
-                                        fieldWithPath("result.accessToken").type(STRING).description("액세스 토큰"),
-                                        fieldWithPath("result.refreshToken").type(STRING).description("리프레시 토큰")
-                                )
-                ));
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willDoNothing().given(memberService).memberNicknameChange(any(MemberNicknameRequest.class), anyLong());
+
+            mockMvc.perform(put("/api/members/me/nickname")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberNicknameRequest))
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("변경할 닉네임")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("닉네임이 비어있으면 예외가 발생한다")
+        void memberNicknameChangeInvalidNicknameValue() throws Exception {
+            MemberNicknameRequest memberNicknameRequest = MemberNicknameRequest.builder()
+                    .nickname("")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+
+            mockMvc.perform(put("/api/members/me/nickname")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberNicknameRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("nickname"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value(""))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("닉네임을 입력해 주세요."))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("변경할 닉네임")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("회원이 존재하지 않으면 예외가 발생한다")
+        void memberNicknameChangeNotFoundMember() throws Exception {
+            MemberNicknameRequest memberNicknameRequest = MemberNicknameRequest.builder()
+                    .nickname("newNickname")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willThrow(new NotFoundMemberException()).given(memberService).memberNicknameChange(any(MemberNicknameRequest.class), anyLong());
+
+            mockMvc.perform(put("/api/members/me/nickname")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberNicknameRequest))
+                    )
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E404001"))
+                    .andExpect(jsonPath("$.error.message").value("회원을 찾을 수 없습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("변경할 닉네임")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("닉네임이 중복되면 예외가 발생한다")
+        void memberNicknameChangeDuplicateNickname() throws Exception {
+            MemberNicknameRequest memberNicknameRequest = MemberNicknameRequest.builder()
+                    .nickname("newNickname")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willThrow(new DuplicateNicknameException()).given(memberService).memberNicknameChange(any(MemberNicknameRequest.class), anyLong());
+
+            mockMvc.perform(put("/api/members/me/nickname")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberNicknameRequest))
+                    )
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E409001"))
+                    .andExpect(jsonPath("$.error.message").value("사용 중인 닉네임입니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("변경할 닉네임")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 유효하지 않으면 예외가 발생한다")
+        void memberNicknameInvalidAccessToken() throws Exception {
+            MemberNicknameRequest memberNicknameRequest = MemberNicknameRequest.builder()
+                    .nickname("newNickname")
+                    .build();
+
+            willThrow(new InvalidTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(put("/api/members/me/nickname")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberNicknameRequest))
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401002"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 유효하지 않습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("변경할 닉네임")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 만료되면 예외가 발생한다")
+        void memberNicknameExpiredAccessToken() throws Exception {
+            MemberNicknameRequest memberNicknameRequest = MemberNicknameRequest.builder()
+                    .nickname("newNickname")
+                    .build();
+
+            willThrow(new ExpiredTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(put("/api/members/me/nickname")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberNicknameRequest))
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401003"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 만료되었습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("변경할 닉네임")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
     }
 
-    @Test
-    @DisplayName("로그인 시 아이디 또는 비밀번호가 일치하지 않으면 예외가 발생한다")
-    void memberLoginBadCredentials() throws Exception {
-        Member member = Member.builder()
-                .username("yoon1234")
-                .password(new BCryptPasswordEncoder().encode("12345678"))
-                .build();
-        AuthPrincipal authPrincipal = new AuthPrincipal(member);
+    @Nested
+    @DisplayName("회원 비밀번호 변경 요청")
+    class MemberPasswordChangeTest {
 
-        given(userDetailsService.loadUserByUsername(anyString())).willReturn(authPrincipal);
+        @Test
+        @DisplayName("비밀번호를 변경한다")
+        void memberPasswordChange() throws Exception {
+            MemberPasswordRequest memberPasswordRequest = MemberPasswordRequest.builder()
+                    .curPassword("12345678")
+                    .newPassword("87654321")
+                    .newPasswordConfirm("87654321")
+                    .build();
 
-        mockMvc.perform(post("/api/members/login")
-                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                        .param("username", "yoon1234")
-                        .param("password", "87654321")
-                )
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(401))
-                .andExpect(jsonPath("$.result.path").value("/api/members/login"))
-                .andExpect(jsonPath("$.result.error.code").value("E401001"))
-                .andExpect(jsonPath("$.result.error.message").value("아이디 또는 비밀번호가 일치하지 않습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        formParameters(
-                                parameterWithName("username").description("아이디"),
-                                parameterWithName("password").description("비밀번호")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
-    }
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
 
-    @Test
-    @DisplayName("로그아웃을 한다")
-    void memberLogout() throws Exception {
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willDoNothing().given(tokenService).tokenDelete(anyString());
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willDoNothing().given(memberService).memberPasswordChange(any(MemberPasswordRequest.class), anyLong());
 
-        mockMvc.perform(post("/api/members/logout")
-                        .header("Authorization", "Bearer access-token")
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        responseFields(
-                                commonSuccessResponse()
-                        )
-                ));
-    }
+            mockMvc.perform(put("/api/members/me/password")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberPasswordRequest))
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("curPassword").type(STRING).description("현재 사용 중인 비밀번호"),
+                                    fieldWithPath("newPassword").type(STRING).description("변경할 비밀번호"),
+                                    fieldWithPath("newPasswordConfirm").type(STRING).description("변경할 비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+        }
 
-    @Test
-    @DisplayName("로그아웃 시 Refresh Token이 존재하지 않으면 예외가 발생한다")
-    void memberLogoutInvalidToken() throws Exception {
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willThrow(new InvalidTokenException()).given(tokenService).tokenDelete(anyString());
+        @Test
+        @DisplayName("현재 비밀번호가 비어있으면 예외가 발생한다")
+        void memberPasswordInvalidCurPassword() throws Exception {
+            MemberPasswordRequest memberPasswordRequest = MemberPasswordRequest.builder()
+                    .curPassword("")
+                    .newPassword("87654321")
+                    .newPasswordConfirm("87654321")
+                    .build();
 
-        mockMvc.perform(post("/api/members/logout")
-                        .header("Authorization", "Bearer access-token")
-                )
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(401))
-                .andExpect(jsonPath("$.result.path").value("/api/members/logout"))
-                .andExpect(jsonPath("$.result.error.code").value("E401002"))
-                .andExpect(jsonPath("$.result.error.message").value("토큰이 유효하지 않습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
-    }
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
 
-    @Test
-    @DisplayName("회원 정보를 조회한다")
-    void memberProfile() throws Exception {
-        MemberProfileResponse memberProfileResponse = new MemberProfileResponse("yoonkun", "yoon1234");
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        given(memberService.memberProfile(anyString())).willReturn(memberProfileResponse);
+            mockMvc.perform(put("/api/members/me/password")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberPasswordRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("curPassword"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value(""))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("현재 비밀번호를 입력해 주세요."))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("curPassword").type(STRING).description("현재 사용 중인 비밀번호"),
+                                    fieldWithPath("newPassword").type(STRING).description("변경할 비밀번호"),
+                                    fieldWithPath("newPasswordConfirm").type(STRING).description("변경할 비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
 
-        mockMvc.perform(get("/api/members/profile")
-                        .header("Authorization", "Bearer access-token")
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result.nickname").value("yoonkun"))
-                .andExpect(jsonPath("$.result.username").value("yoon1234"))
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        responseFields(
-                                commonSuccessResponse())
-                                .and(
-                                        fieldWithPath("result.nickname").type(STRING).description("회원 닉네임"),
-                                        fieldWithPath("result.username").type(STRING).description("회원 아이디")
-                                )
-                ));
-    }
+        @Test
+        @DisplayName("새 비밀번호가 비어있으면 예외가 발생한다")
+        void memberPasswordInvalidNewPassword() throws Exception {
+            MemberPasswordRequest memberPasswordRequest = MemberPasswordRequest.builder()
+                    .curPassword("12345678")
+                    .newPassword("")
+                    .newPasswordConfirm("87654321")
+                    .build();
 
-    @Test
-    @DisplayName("회원 정보 조회 시 회원을 찾을 수 없으면 예외가 발생한다")
-    void memberProfileNotFoundMember() throws Exception {
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willThrow(new NotFoundMemberException()).given(memberService).memberProfile(anyString());
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
 
-        mockMvc.perform(get("/api/members/profile")
-                        .header("Authorization", "Bearer access-token")
-                )
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(404))
-                .andExpect(jsonPath("$.result.path").value("/api/members/profile"))
-                .andExpect(jsonPath("$.result.error.code").value("E404001"))
-                .andExpect(jsonPath("$.result.error.message").value("회원을 찾을 수 없습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
-    }
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
 
-    @Test
-    @DisplayName("회원 정보에서 작성한 게시글 목록을 조회한다")
-    void memberProfilePostList() throws Exception {
-        List<PostListItem> posts = List.of(
-                new PostListItem(1L, "제목", "작성자", 5, LocalDateTime.of(2024, 6, 17, 0, 0))
-        );
-        PostListResponse postListResponse = new PostListResponse(posts, 1, 1, 1, false, false, true, true);
+            mockMvc.perform(put("/api/members/me/password")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberPasswordRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("newPassword"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value(""))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("새로운 비밀번호를 입력해 주세요."))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("curPassword").type(STRING).description("현재 사용 중인 비밀번호"),
+                                    fieldWithPath("newPassword").type(STRING).description("변경할 비밀번호"),
+                                    fieldWithPath("newPasswordConfirm").type(STRING).description("변경할 비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        given(postService.postListFromMember(anyInt(), anyString())).willReturn(postListResponse);
+        @Test
+        @DisplayName("새 비밀번호 확인이 비어있으면 예외가 발생한다")
+        void memberPasswordInvalidNewPasswordConfirm() throws Exception {
+            MemberPasswordRequest memberPasswordRequest = MemberPasswordRequest.builder()
+                    .curPassword("12345678")
+                    .newPassword("87654321")
+                    .newPasswordConfirm("")
+                    .build();
 
-        mockMvc.perform(get("/api/members/profile/posts")
-                        .param("page", "1")
-                        .header("Authorization", "Bearer access-token")
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result.posts[0].postId").value(1))
-                .andExpect(jsonPath("$.result.posts[0].title").value("제목"))
-                .andExpect(jsonPath("$.result.posts[0].writer").value("작성자"))
-                .andExpect(jsonPath("$.result.posts[0].commentCount").value(5))
-                .andExpect(jsonPath("$.result.posts[0].createdAt").value("2024-06-17T00:00:00"))
-                .andExpect(jsonPath("$.result.page").value(1))
-                .andExpect(jsonPath("$.result.totalPages").value(1))
-                .andExpect(jsonPath("$.result.totalElements").value(1))
-                .andExpect(jsonPath("$.result.prev").value(false))
-                .andExpect(jsonPath("$.result.next").value(false))
-                .andExpect(jsonPath("$.result.first").value(true))
-                .andExpect(jsonPath("$.result.last").value(true))
-                .andDo(restDocs.document(
-                        queryParameters(
-                                parameterWithName("page").description("페이지 번호")
-                        ),
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        responseFields(
-                                commonSuccessResponse())
-                                .and(
-                                        fieldWithPath("result.posts").type(ARRAY).description("게시글 목록"),
-                                        fieldWithPath("result.posts[].postId").type(NUMBER).description("게시글 번호"),
-                                        fieldWithPath("result.posts[].title").type(STRING).description("게시글 제목"),
-                                        fieldWithPath("result.posts[].writer").type(STRING).description("게시글 제목"),
-                                        fieldWithPath("result.posts[].commentCount").type(NUMBER).description("댓글 개수"),
-                                        fieldWithPath("result.posts[].createdAt").type(STRING).description("게시글 제목"),
-                                        fieldWithPath("result.page").type(NUMBER).description("페이지 번호"),
-                                        fieldWithPath("result.totalPages").type(NUMBER).description("전체 페이지 개수"),
-                                        fieldWithPath("result.totalElements").type(NUMBER).description("전체 게시글 개수"),
-                                        fieldWithPath("result.prev").type(BOOLEAN).description("이전 페이지 이동 가능 여부"),
-                                        fieldWithPath("result.next").type(BOOLEAN).description("다음 페이지 이동 가능 여부"),
-                                        fieldWithPath("result.first").type(BOOLEAN).description("첫 번째 페이지 여부"),
-                                        fieldWithPath("result.last").type(BOOLEAN).description("마지막 페이지 여부")
-                                )
-                ));
-    }
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
 
-    @Test
-    @DisplayName("회원정보에서 작성한 댓글 목록을 조회한다")
-    void memberProfileCommentList() throws Exception {
-        List<CommentListItem> comments = List.of(
-                new CommentListItem(1L, "작성자", "댓글", LocalDateTime.of(2024, 6, 17, 0, 0))
-        );
-        CommentListResponse commentListResponse = new CommentListResponse(comments, 1, 1, 1, false, false, true, true);
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        given(commentService.commentListFromMember(anyInt(), anyString())).willReturn(commentListResponse);
+            mockMvc.perform(put("/api/members/me/password")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberPasswordRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("newPasswordConfirm"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value(""))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("새로운 비밀번호를 한 번 더 입력해 주세요."))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("curPassword").type(STRING).description("현재 사용 중인 비밀번호"),
+                                    fieldWithPath("newPassword").type(STRING).description("변경할 비밀번호"),
+                                    fieldWithPath("newPasswordConfirm").type(STRING).description("변경할 비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
 
-        mockMvc.perform(get("/api/members/profile/comments")
-                        .header("Authorization", "Bearer access-token")
-                        .param("page", "1")
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result.comments[0].commentId").value(1))
-                .andExpect(jsonPath("$.result.comments[0].writer").value("작성자"))
-                .andExpect(jsonPath("$.result.comments[0].content").value("댓글"))
-                .andExpect(jsonPath("$.result.comments[0].createdAt").value("2024-06-17T00:00:00"))
-                .andExpect(jsonPath("$.result.page").value(1))
-                .andExpect(jsonPath("$.result.totalPages").value(1))
-                .andExpect(jsonPath("$.result.totalElements").value(1))
-                .andExpect(jsonPath("$.result.prev").value(false))
-                .andExpect(jsonPath("$.result.next").value(false))
-                .andExpect(jsonPath("$.result.first").value(true))
-                .andExpect(jsonPath("$.result.last").value(true))
-                .andDo(restDocs.document(
-                        queryParameters(
-                                parameterWithName("page").description("페이지 번호")
-                        ),
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        responseFields(
-                                commonSuccessResponse())
-                                .and(
-                                        fieldWithPath("result.comments").type(ARRAY).description("댓글 목록"),
-                                        fieldWithPath("result.comments[].commentId").type(NUMBER).description("댓글 번호"),
-                                        fieldWithPath("result.comments[].writer").type(STRING).description("댓글 작성자"),
-                                        fieldWithPath("result.comments[].content").type(STRING).description("댓글 내용"),
-                                        fieldWithPath("result.comments[].createdAt").type(STRING).description("댓글 작성일"),
-                                        fieldWithPath("result.page").type(NUMBER).description("페이지 번호"),
-                                        fieldWithPath("result.totalPages").type(NUMBER).description("전체 페이지 개수"),
-                                        fieldWithPath("result.totalElements").type(NUMBER).description("전체 게시글 개수"),
-                                        fieldWithPath("result.prev").type(BOOLEAN).description("이전 페이지 이동 가능 여부"),
-                                        fieldWithPath("result.next").type(BOOLEAN).description("다음 페이지 이동 가능 여부"),
-                                        fieldWithPath("result.first").type(BOOLEAN).description("첫 번째 페이지 여부"),
-                                        fieldWithPath("result.last").type(BOOLEAN).description("마지막 페이지 여부")
-                                )
-                ));
-    }
+        @Test
+        @DisplayName("회원이 존재하지 않으면 예외가 발생한다")
+        void memberPasswordChangeNotFoundMember() throws Exception {
+            MemberPasswordRequest memberPasswordRequest = MemberPasswordRequest.builder()
+                    .curPassword("12345678")
+                    .newPassword("87654321")
+                    .newPasswordConfirm("87654321")
+                    .build();
 
-    @Test
-    @DisplayName("회원 닉네임을 변경한다")
-    void memberNicknameChange() throws Exception {
-        MemberNicknameRequest memberNicknameRequest = new MemberNicknameRequest("newNickname");
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willDoNothing().given(memberService).memberNicknameChange(any(MemberNicknameRequest.class), anyString());
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willThrow(new NotFoundMemberException()).given(memberService).memberPasswordChange(any(MemberPasswordRequest.class), anyLong());
 
-        mockMvc.perform(get("/api/members/profile/nickname")
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(memberNicknameRequest))
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("nickname").type(STRING).description("변경할 닉네임")
-                        ),
-                        responseFields(
-                                commonSuccessResponse()
-                        )
-                ));
-    }
+            mockMvc.perform(put("/api/members/me/password")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberPasswordRequest))
+                    )
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E404001"))
+                    .andExpect(jsonPath("$.error.message").value("회원을 찾을 수 없습니다."))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("curPassword").type(STRING).description("현재 사용 중인 비밀번호"),
+                                    fieldWithPath("newPassword").type(STRING).description("변경할 비밀번호"),
+                                    fieldWithPath("newPasswordConfirm").type(STRING).description("변경할 비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
 
-    @Test
-    @DisplayName("회원 닉네임 변경 시 입력값이 잘못되면 예외가 발생한다")
-    void memberNicknameChangeInvalidInputValue() throws Exception {
-        MemberNicknameRequest invalidMemberNicknameRequest = new MemberNicknameRequest("");
+        @Test
+        @DisplayName("현재 사용 중인 비밀번호가 일치하지 않으면 예외가 발생한다")
+        void memberPasswordChangeCurPasswordMismatch() throws Exception {
+            MemberPasswordRequest memberPasswordRequest = MemberPasswordRequest.builder()
+                    .curPassword("12345678")
+                    .newPassword("87654321")
+                    .newPasswordConfirm("87654321")
+                    .build();
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
 
-        mockMvc.perform(get("/api/members/profile/nickname")
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidMemberNicknameRequest))
-                )
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.result.path").value("/api/members/profile/nickname"))
-                .andExpect(jsonPath("$.result.error.code").value("E400001"))
-                .andExpect(jsonPath("$.result.error.message").value("입력값이 잘못되었습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].field").value("nickname"))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].input").value(""))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].message").value("닉네임을 입력해 주세요."))
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("nickname").type(STRING).description("변경할 닉네임")
-                        ),
-                        responseFields(
-                                commonErrorResponse())
-                                .and(
-                                        fieldWithPath("result.error.fieldErrors[].field").description(STRING).description("필드명"),
-                                        fieldWithPath("result.error.fieldErrors[].input").description(STRING).description("입력값"),
-                                        fieldWithPath("result.error.fieldErrors[].message").description(STRING).description("메시지")
-                                )
-                ));
-    }
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willThrow(new PasswordMismatchException()).given(memberService).memberPasswordChange(any(MemberPasswordRequest.class), anyLong());
 
-    @Test
-    @DisplayName("회원 닉네임 변경 시 닉네임이 중복되면 예외가 발생한다")
-    void memberNicknameChangeDuplicateNickname() throws Exception {
-        MemberNicknameRequest memberNicknameRequest = new MemberNicknameRequest("newNickname");
+            mockMvc.perform(put("/api/members/me/password")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberPasswordRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400002"))
+                    .andExpect(jsonPath("$.error.message").value("비밀번호가 일치하지 않습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("curPassword").type(STRING).description("현재 사용 중인 비밀번호"),
+                                    fieldWithPath("newPassword").type(STRING).description("변경할 비밀번호"),
+                                    fieldWithPath("newPasswordConfirm").type(STRING).description("변경할 비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willThrow(new DuplicateNicknameException()).given(memberService).memberNicknameChange(any(MemberNicknameRequest.class), anyString());
+        @Test
+        @DisplayName("새 비밀번호와 새 비밀번호 확인이 일치하지 않으면 예외가 발생하다")
+        void memberPassowrdChangeNewPasswordAndNewPasswordConfirmMismatch() throws Exception {
+            MemberPasswordRequest memberPasswordRequest = MemberPasswordRequest.builder()
+                    .curPassword("12345678")
+                    .newPassword("87654321")
+                    .newPasswordConfirm("97654321")
+                    .build();
 
-        mockMvc.perform(get("/api/members/profile/nickname")
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(memberNicknameRequest))
-                )
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(409))
-                .andExpect(jsonPath("$.result.path").value("/api/members/profile/nickname"))
-                .andExpect(jsonPath("$.result.error.code").value("E409001"))
-                .andExpect(jsonPath("$.result.error.message").value("사용 중인 닉네임입니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("nickname").type(STRING).description("변경할 닉네임")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
-    }
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
 
-    @Test
-    @DisplayName("회원 비밀번호를 변경한다")
-    void memberPasswordChange() throws Exception {
-        MemberPasswordRequest memberPasswordRequest = new MemberPasswordRequest("12345678", "87654321", "87654321");
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willThrow(new PasswordMismatchException()).given(memberService).memberPasswordChange(any(MemberPasswordRequest.class), anyLong());
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willDoNothing().given(memberService).memberPasswordChange(any(MemberPasswordRequest.class), anyString());
+            mockMvc.perform(put("/api/members/me/password")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberPasswordRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400002"))
+                    .andExpect(jsonPath("$.error.message").value("비밀번호가 일치하지 않습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("curPassword").type(STRING).description("현재 사용 중인 비밀번호"),
+                                    fieldWithPath("newPassword").type(STRING).description("변경할 비밀번호"),
+                                    fieldWithPath("newPasswordConfirm").type(STRING).description("변경할 비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
 
-        mockMvc.perform(put("/api/members/profile/password")
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(memberPasswordRequest))
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("curPassword").type(STRING).description("현재 사용 중인 비밀번호"),
-                                fieldWithPath("newPassword").type(STRING).description("새로운 비밀번호"),
-                                fieldWithPath("newPasswordConfirm").type(STRING).description("새로운 비밀번호 확인")
-                        ),
-                        responseFields(
-                                commonSuccessResponse()
-                        )
-                ));
-    }
+        @Test
+        @DisplayName("액세스 토큰이 유효하지 않으면 예외가 발생한다")
+        void memberPasswordChangeInvalidAccessToken() throws Exception {
+            MemberPasswordRequest memberPasswordRequest = MemberPasswordRequest.builder()
+                    .curPassword("12345678")
+                    .newPassword("87654321")
+                    .newPasswordConfirm("87654321")
+                    .build();
 
-    @Test
-    @DisplayName("회원 비밀번호 변경 시 입력값이 잘못되면 예외가 발생한다")
-    void memberPasswordChangeInvalidInputValue() throws Exception {
-        MemberPasswordRequest invalidMemberPasswordRequest = new MemberPasswordRequest("12345678", "", "87654321");
+            willThrow(new InvalidTokenException()).given(jwtManager).getPayload(anyString());
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
+            mockMvc.perform(put("/api/members/me/password")
+                            .header("Authorization", "Bearer invalid-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberPasswordRequest))
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401002"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 유효하지 않습니다."))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("curPassword").type(STRING).description("현재 사용 중인 비밀번호"),
+                                    fieldWithPath("newPassword").type(STRING).description("변경할 비밀번호"),
+                                    fieldWithPath("newPasswordConfirm").type(STRING).description("변경할 비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
 
-        mockMvc.perform(put("/api/members/profile/password")
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidMemberPasswordRequest))
-                )
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.result.path").value("/api/members/profile/password"))
-                .andExpect(jsonPath("$.result.error.code").value("E400001"))
-                .andExpect(jsonPath("$.result.error.message").value("입력값이 잘못되었습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].field").value("newPassword"))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].input").value(""))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].message").value("새로운 비밀번호를 입력해 주세요."))
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("curPassword").type(STRING).description("현재 사용 중인 비밀번호"),
-                                fieldWithPath("newPassword").type(STRING).description("새로운 비밀번호"),
-                                fieldWithPath("newPasswordConfirm").type(STRING).description("새로운 비밀번호 확인")
-                        ),
-                        responseFields(
-                                commonErrorResponse())
-                                .and(
-                                        fieldWithPath("result.error.fieldErrors[].field").description(STRING).description("필드명"),
-                                        fieldWithPath("result.error.fieldErrors[].input").description(STRING).description("입력값"),
-                                        fieldWithPath("result.error.fieldErrors[].message").description(STRING).description("메시지")
-                                )
-                ));
-    }
+        }
 
-    @Test
-    @DisplayName("회원 비밀번호 변경 시 현재 비밀번호가 일치하지 않으면 예외가 발생한다")
-    void memberPasswordChangeMismatchCurPassword() throws Exception {
-        MemberPasswordRequest memberPasswordRequest = new MemberPasswordRequest("12345678", "87654321", "87654321");
+        @Test
+        @DisplayName("액세스 토큰이 만료되면 예외가 발생한다")
+        void memberPasswordChangeExpiredAccessToken() throws Exception {
+            MemberPasswordRequest memberPasswordRequest = MemberPasswordRequest.builder()
+                    .curPassword("12345678")
+                    .newPassword("87654321")
+                    .newPasswordConfirm("87654321")
+                    .build();
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willThrow(new PasswordMismatchException()).given(memberService).memberPasswordChange(any(MemberPasswordRequest.class), anyString());
+            willThrow(new ExpiredTokenException()).given(jwtManager).getPayload(anyString());
 
-        mockMvc.perform(put("/api/members/profile/password")
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(memberPasswordRequest))
-                )
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.result.path").value("/api/members/profile/password"))
-                .andExpect(jsonPath("$.result.error.code").value("E400002"))
-                .andExpect(jsonPath("$.result.error.message").value("비밀번호가 일치하지 않습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("curPassword").type(STRING).description("현재 사용 중인 비밀번호"),
-                                fieldWithPath("newPassword").type(STRING).description("새로운 비밀번호"),
-                                fieldWithPath("newPasswordConfirm").type(STRING).description("새로운 비밀번호 확인")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
-    }
+            mockMvc.perform(put("/api/members/me/password")
+                            .header("Authorization", "Bearer invalid-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberPasswordRequest))
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401003"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 만료되었습니다."))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("curPassword").type(STRING).description("현재 사용 중인 비밀번호"),
+                                    fieldWithPath("newPassword").type(STRING).description("변경할 비밀번호"),
+                                    fieldWithPath("newPasswordConfirm").type(STRING).description("변경할 비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
 
-    @Test
-    @DisplayName("회원 비밀번호 변경 시 새로운 비밀번호가 일치하지 않으면 예외가 발생한다")
-    void memberPasswordChangeMismatchNewPassword() throws Exception {
-        MemberPasswordRequest memberPasswordRequest = new MemberPasswordRequest("12345678", "87654321", "87654320");
-
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willThrow(new PasswordMismatchException()).given(memberService).memberPasswordChange(any(MemberPasswordRequest.class), anyString());
-
-        mockMvc.perform(put("/api/members/profile/password")
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(memberPasswordRequest))
-                )
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.result.path").value("/api/members/profile/password"))
-                .andExpect(jsonPath("$.result.error.code").value("E400002"))
-                .andExpect(jsonPath("$.result.error.message").value("비밀번호가 일치하지 않습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("curPassword").type(STRING).description("현재 사용 중인 비밀번호"),
-                                fieldWithPath("newPassword").type(STRING).description("새로운 비밀번호"),
-                                fieldWithPath("newPasswordConfirm").type(STRING).description("새로운 비밀번호 확인")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
     }
 
 }

--- a/backend/src/test/java/com/board/domain/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/member/repository/MemberRepositoryTest.java
@@ -1,71 +1,227 @@
 package com.board.domain.member.repository;
 
 import com.board.domain.member.entity.Member;
-import com.board.global.common.config.JpaAuditConfig;
-import com.board.support.config.QuerydslConfig;
+import com.board.domain.member.exception.NotFoundMemberException;
+import com.board.support.RepositoryTest;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@DataJpaTest
-@Import({JpaAuditConfig.class, QuerydslConfig.class})
-class MemberRepositoryTest {
+class MemberRepositoryTest extends RepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;
 
-    @Test
-    @DisplayName("닉네임 존재 여부를 확인한다")
-    void memberNicknameExists() {
-        Member member = Member.builder()
-                .nickname("yoonkun")
-                .username("yoon1234")
-                .password("12345678")
-                .build();
-        memberRepository.save(member);
+    @Nested
+    @DisplayName("회원 저장")
+    class MemberSaveTest {
 
-        boolean existsNickname = memberRepository.existsMemberByNickname("yoonkun");
-        boolean nonExistsNickname = memberRepository.existsMemberByNickname("yoonkong");
+        @Test
+        @DisplayName("회원을 저장한다")
+        void save() {
+            Member member = Member.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password(new BCryptPasswordEncoder().encode("12345678"))
+                    .build();
 
-        assertThat(existsNickname).isTrue();
-        assertThat(nonExistsNickname).isFalse();
+            Member saveMember = memberRepository.save(member);
+
+            assertThat(saveMember.getId()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("닉네임이 null이면 예외가 발생한다")
+        void saveNullNickname() {
+            Member member = Member.builder()
+                    .nickname(null)
+                    .username("yoon1234")
+                    .password(new BCryptPasswordEncoder().encode("12345678"))
+                    .build();
+
+            assertThatThrownBy(() -> memberRepository.save(member))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("아이디가 null이면 예외가 발생한다")
+        void saveNullUsername() {
+            Member member = Member.builder()
+                    .nickname("yoonkun")
+                    .username(null)
+                    .password(new BCryptPasswordEncoder().encode("12345678"))
+                    .build();
+
+            assertThatThrownBy(() -> memberRepository.save(member))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("비밀번호가 null이면 예외가 발생한다")
+        void saveNullPassword() {
+            Member member = Member.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password(null)
+                    .build();
+
+            assertThatThrownBy(() -> memberRepository.save(member))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 닉네임을 가진 회원을 저장하면 예외가 발생한다")
+        void saveUniqueNickname() {
+            Member memberA = Member.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password(new BCryptPasswordEncoder().encode("12345678"))
+                    .build();
+            Member memberB = Member.builder()
+                    .nickname("yoonkun")
+                    .username("yoon5678")
+                    .password(new BCryptPasswordEncoder().encode("12345678"))
+                    .build();
+            memberRepository.save(memberA);
+
+            assertThatThrownBy(() -> memberRepository.save(memberB))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 아이디를 가진 회원을 저장하면 예외가 발생한다")
+        void saveUniqueUsername() {
+            Member memberA = Member.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password(new BCryptPasswordEncoder().encode("12345678"))
+                    .build();
+            Member memberB = Member.builder()
+                    .nickname("yoongun")
+                    .username("yoon1234")
+                    .password(new BCryptPasswordEncoder().encode("12345678"))
+                    .build();
+            memberRepository.save(memberA);
+
+            assertThatThrownBy(() -> memberRepository.save(memberB))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
     }
 
-    @Test
-    @DisplayName("아이디 존재 여부를 확인한다")
-    void memberUsernameExists() {
-        Member member = Member.builder()
-                .nickname("yoonkun")
-                .username("yoon1234")
-                .password("12345678")
-                .build();
-        memberRepository.save(member);
+    @Nested
+    @DisplayName("회원 닉네임 존재 여부")
+    class MemberNicknameExistsTest {
 
-        boolean existsUsername = memberRepository.existsMemberByUsername("yoon1234");
-        boolean nonExistsUsername = memberRepository.existsMemberByUsername("yoon5678");
+        @Test
+        @DisplayName("닉네임이 존재하면 true를 반환한다")
+        void existsNicknameReturnTrue() {
+            Member member = Member.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password(new BCryptPasswordEncoder().encode("12345678"))
+                    .build();
+            memberRepository.save(member);
 
-        assertThat(existsUsername).isTrue();
-        assertThat(nonExistsUsername).isFalse();
+            boolean exists = memberRepository.existsByNickname("yoonkun");
+
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        @DisplayName("닉네임이 존재하지 않으면 false를 반환한다")
+        void nonExistsNicknameReturnFalse() {
+            boolean exists = memberRepository.existsByNickname("yoonkun");
+
+            assertThat(exists).isFalse();
+        }
+
     }
 
-    @Test
-    @DisplayName("회원을 저장한다")
-    void memberSave() {
-        Member member = Member.builder()
-                .nickname("yoonkun")
-                .username("yoon1234")
-                .password("12345678")
-                .build();
+    @Nested
+    @DisplayName("회원 아이디 존재 여부")
+    class MemberUsernameExistsTest {
 
-        Member saveMember = memberRepository.save(member);
+        @Test
+        @DisplayName("아이디가 존재하면 true를 반환한다")
+        void existsUsernameRetrunTrue() {
+            Member member = Member.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password(new BCryptPasswordEncoder().encode("12345678"))
+                    .build();
+            memberRepository.save(member);
 
-        assertThat(saveMember.getId()).isNotNull();
+            boolean exists = memberRepository.existsByUsername("yoon1234");
+
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        @DisplayName("아이디가 존재하지 않으면 false를 반환한다")
+        void existsUsernameReturnFalse() {
+            boolean exists = memberRepository.existsByUsername("yoon1234");
+
+            assertThat(exists).isFalse();
+        }
+
+    }
+
+    @Nested
+    @DisplayName("회원 조회")
+    class MemberFindTest {
+
+        @Test
+        @DisplayName("아이디(username)으로 조회한다")
+        void findByUsername() {
+            Member member = Member.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password(new BCryptPasswordEncoder().encode("12345678"))
+                    .build();
+            memberRepository.save(member);
+
+            Member findMember = memberRepository.findByUsername("yoon1234").get();
+
+            assertThat(findMember.getId()).isNotNull();
+            assertThat(findMember.getNickname()).isEqualTo("yoonkun");
+            assertThat(findMember.getUsername()).isEqualTo("yoon1234");
+            assertThat(findMember.getAuthority()).isEqualTo("ROLE_MEMBER");
+        }
+
+        @Test
+        @DisplayName("기본키(id)로 조회한다")
+        void findByMemberId() {
+            Member member = Member.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password(new BCryptPasswordEncoder().encode("12345678"))
+                    .build();
+            memberRepository.save(member);
+
+            Member findMember = memberRepository.findByMemberId(member.getId());
+
+            assertThat(findMember.getId()).isNotNull();
+            assertThat(findMember.getNickname()).isEqualTo("yoonkun");
+            assertThat(findMember.getUsername()).isEqualTo("yoon1234");
+            assertThat(findMember.getAuthority()).isEqualTo("ROLE_MEMBER");
+        }
+
+        @Test
+        @DisplayName("기본키(id)에 해당하는 회원이 없으면 예외가 발생한다")
+        void findByMemberIdNotFoundMember() {
+            assertThatThrownBy(() -> memberRepository.findByMemberId(1L))
+                    .isInstanceOf(NotFoundMemberException.class);
+        }
+
     }
 
 }

--- a/backend/src/test/java/com/board/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/board/domain/member/service/MemberServiceTest.java
@@ -2,6 +2,7 @@ package com.board.domain.member.service;
 
 import com.board.domain.member.dto.MemberNicknameRequest;
 import com.board.domain.member.dto.MemberPasswordRequest;
+import com.board.domain.member.dto.MemberProfileResponse;
 import com.board.domain.member.dto.MemberSignupRequest;
 import com.board.domain.member.entity.Member;
 import com.board.domain.member.exception.DuplicateNicknameException;
@@ -9,34 +10,42 @@ import com.board.domain.member.exception.DuplicateUsernameException;
 import com.board.domain.member.exception.NotFoundMemberException;
 import com.board.domain.member.exception.PasswordMismatchException;
 import com.board.domain.member.repository.MemberRepository;
+import com.board.domain.post.dto.PostListResponse;
+import com.board.domain.post.repository.PostRepository;
+import com.board.support.ServiceTest;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import java.util.Optional;
+import java.time.LocalDateTime;
+import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 
-@ExtendWith(MockitoExtension.class)
-class MemberServiceTest {
+class MemberServiceTest extends ServiceTest {
 
     @Mock
     private MemberRepository memberRepository;
+
+    @Mock
+    private PostRepository postRepository;
 
     @Mock
     private PasswordEncoder passwordEncoder;
@@ -44,242 +53,379 @@ class MemberServiceTest {
     @InjectMocks
     private MemberService memberService;
 
-    @Test
-    @DisplayName("닉네임 중복 확인을 한다")
-    void memberNicknameExists() {
-        String targetNickname = "yoonkun";
+    @Nested
+    @DisplayName("닉네임 중복 확인")
+    class MemberNicknameExistsTest {
 
-        given(memberRepository.existsMemberByNickname(anyString())).willReturn(false);
+        @Test
+        @DisplayName("닉네임이 중복되지 않는다")
+        void memberNicknameExists() {
+            given(memberRepository.existsByNickname(anyString())).willReturn(false);
 
-        memberService.memberNicknameExists(targetNickname);
+            memberService.memberNicknameExists("yoonkun");
 
-        then(memberRepository).should().existsMemberByNickname(anyString());
+            then(memberRepository).should().existsByNickname(anyString());
+        }
+
+        @Test
+        @DisplayName("닉네임이 중복되면 예외가 발생한다")
+        void memberNicknameExistsDuplicateNickname() {
+            given(memberRepository.existsByNickname(anyString())).willReturn(true);
+
+            assertThatThrownBy(() -> memberService.memberNicknameExists("yoonkun"))
+                    .isInstanceOf(DuplicateNicknameException.class);
+
+            then(memberRepository).should().existsByNickname(anyString());
+        }
+
     }
 
-    @Test
-    @DisplayName("닉네임 중복 시 예외가 발생한다")
-    void memberNicknameExists_duplicateNickname() {
-        String targetNickname = "yoonkun";
+    @Nested
+    @DisplayName("아이디 중복 확인")
+    class MemberUsernameExistsTest {
 
-        given(memberRepository.existsMemberByNickname(anyString())).willReturn(true);
+        @Test
+        @DisplayName("아이디가 중복되지 않는다")
+        void memberUsernameExists() {
+            given(memberRepository.existsByUsername(anyString())).willReturn(false);
 
-        assertThatThrownBy(() -> memberService.memberNicknameExists(targetNickname))
-                        .isInstanceOf(DuplicateNicknameException.class);
+            memberService.memberUsernameExists("yoonkun");
 
-        then(memberRepository).should().existsMemberByNickname(anyString());
+            then(memberRepository).should().existsByUsername(anyString());
+        }
+
+        @Test
+        @DisplayName("아이디가 중복되면 예외가 발생한다")
+        void memberUsernameExistsDuplicateUsername() {
+            given(memberRepository.existsByUsername(anyString())).willReturn(true);
+
+            assertThatThrownBy(() -> memberService.memberUsernameExists("yoonkun"))
+                    .isInstanceOf(DuplicateUsernameException.class);
+
+            then(memberRepository).should().existsByUsername(anyString());
+        }
+
     }
 
-    @Test
-    @DisplayName("아이디 중복 확인을 한다")
-    void memberUsernameExists() {
-        String targetUsername = "yoon1234";
+    @Nested
+    @DisplayName("회원가입")
+    class MemberSignupTest {
 
-        given(memberRepository.existsMemberByUsername(anyString())).willReturn(false);
+        @Test
+        @DisplayName("회원가입을 한다")
+        void memberSignup() {
+            MemberSignupRequest memberSignupRequest = MemberSignupRequest.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password("12345678")
+                    .passwordConfirm("12345678")
+                    .build();
 
-        memberService.memberUsernameExists(targetUsername);
+            String encoded = new BCryptPasswordEncoder().encode("12345678");
 
-        then(memberRepository).should().existsMemberByUsername(anyString());
+            Member member = Member.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password(encoded)
+                    .build();
+
+            given(memberRepository.existsByNickname(anyString())).willReturn(false);
+            given(memberRepository.existsByUsername(anyString())).willReturn(false);
+            given(passwordEncoder.encode(anyString())).willReturn(encoded);
+            given(memberRepository.save(any(Member.class))).willReturn(member);
+
+            memberService.memberSignup(memberSignupRequest);
+
+            then(memberRepository).should().existsByNickname(anyString());
+            then(memberRepository).should().existsByUsername(anyString());
+            then(passwordEncoder).should().encode(anyString());
+            then(memberRepository).should().save(any(Member.class));
+
+        }
+
+        @Test
+        @DisplayName("닉네임이 중복되면 예외가 발생한다")
+        void memberSignupDuplicateNickname() {
+            MemberSignupRequest memberSignupRequest = MemberSignupRequest.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password("12345678")
+                    .passwordConfirm("12345678")
+                    .build();
+
+            given(memberRepository.existsByNickname(anyString())).willReturn(true);
+
+            assertThatThrownBy(() -> memberService.memberSignup(memberSignupRequest))
+                    .isInstanceOf(DuplicateNicknameException.class);
+
+            then(memberRepository).should().existsByNickname(anyString());
+            then(memberRepository).should(never()).existsByUsername(anyString());
+            then(passwordEncoder).should(never()).encode(anyString());
+            then(memberRepository).should(never()).save(any(Member.class));
+        }
+
+        @Test
+        @DisplayName("아이디가 중복되면 예외가 발생한다")
+        void memberSignupDuplicateUsername() {
+            MemberSignupRequest memberSignupRequest = MemberSignupRequest.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password("12345678")
+                    .passwordConfirm("12345678")
+                    .build();
+
+            given(memberRepository.existsByNickname(anyString())).willReturn(false);
+            given(memberRepository.existsByUsername(anyString())).willReturn(true);
+
+            assertThatThrownBy(() -> memberService.memberSignup(memberSignupRequest))
+                    .isInstanceOf(DuplicateUsernameException.class);
+
+            then(memberRepository).should().existsByNickname(anyString());
+            then(memberRepository).should().existsByUsername(anyString());
+            then(passwordEncoder).should(never()).encode(anyString());
+            then(memberRepository).should(never()).save(any(Member.class));
+        }
+
+        @Test
+        @DisplayName("비밀번호와 비밀번호 확인이 일치하지 않으면 예외가 발생한다")
+        void memberSignupPassworndAndPasswordConfirmMismatch() {
+            MemberSignupRequest memberSignupRequest = MemberSignupRequest.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password("12345678")
+                    .passwordConfirm("87654321")
+                    .build();
+
+            given(memberRepository.existsByNickname(anyString())).willReturn(false);
+            given(memberRepository.existsByUsername(anyString())).willReturn(false);
+
+            assertThatThrownBy(() -> memberService.memberSignup(memberSignupRequest))
+                    .isInstanceOf(PasswordMismatchException.class);
+
+            then(memberRepository).should().existsByNickname(anyString());
+            then(memberRepository).should().existsByUsername(anyString());
+            then(passwordEncoder).should(never()).encode(anyString());
+            then(memberRepository).should(never()).save(any(Member.class));
+        }
+
     }
 
-    @Test
-    @DisplayName("아이이 중복 시 예외가 발생한다")
-    void memberUsernameExists_duplicateUsername() {
-        String targetUsername = "yoon1234";
+    @Nested
+    @DisplayName("회원 상세정보")
+    class MemberProfileTest {
 
-        given(memberRepository.existsMemberByUsername(anyString())).willReturn(true);
+        @Test
+        @DisplayName("상제정보를 조회한다")
+        void memberProfile() {
+            Member member = Member.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password(new BCryptPasswordEncoder().encode("12345678"))
+                    .build();
 
-        assertThatThrownBy(() -> memberService.memberUsernameExists(targetUsername))
-                .isInstanceOf(DuplicateUsernameException.class);
+            given(memberRepository.findByMemberId(anyLong())).willReturn(member);
 
-        then(memberRepository).should().existsMemberByUsername(anyString());
+            MemberProfileResponse memberProfileResponse = memberService.memberProfile(1L);
+
+            assertThat(memberProfileResponse.getNickname()).isEqualTo("yoonkun");
+            assertThat(memberProfileResponse.getUsername()).isEqualTo("yoon1234");
+            then(memberRepository).should().findByMemberId(anyLong());
+        }
+
+        @Test
+        @DisplayName("회원이 존재하지 않으면 에외가 발생한다")
+        void memberProfileNotFoundMember() {
+            willThrow(new NotFoundMemberException()).given(memberRepository).findByMemberId(anyLong());
+
+            assertThatThrownBy(() -> memberService.memberProfile(1L))
+                    .isInstanceOf(NotFoundMemberException.class);
+
+            then(memberRepository).should().findByMemberId(anyLong());
+        }
+
     }
 
-    @Test
-    @DisplayName("회원가입을 한다")
-    void memberSignup() {
-        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonkun", "yoon1234", "12345678", "12345678");
+    @Nested
+    @DisplayName("회원이 작성한 게시글 목록조회")
+    class MemberPostListTest {
 
-        String encoded = new BCryptPasswordEncoder().encode(memberSignupRequest.getPassword());
+        @Test
+        @DisplayName("회원이 작성한 게시글 목록을 조회한다")
+        void memberPostList() {
+            PostListResponse postListResponse = PostListResponse.builder()
+                    .posts(List.of(
+                            PostListResponse.PostItem.builder()
+                                    .postId(1L)
+                                    .title("title")
+                                    .writer("writer")
+                                    .commentCount(0)
+                                    .createdAt(LocalDateTime.of(2024, 6, 17, 0, 0))
+                                    .build()
+                    ))
+                    .page(1)
+                    .totalPages(1)
+                    .totalElements(1)
+                    .first(true)
+                    .last(true)
+                    .prev(false)
+                    .next(false)
+                    .build();
 
-        Member member = Member.builder()
-                .nickname(memberSignupRequest.getNickname())
-                .username(memberSignupRequest.getUsername())
-                .password(encoded)
-                .build();
+            given(postRepository.findPostMemberList(any(Pageable.class), anyLong())).willReturn(postListResponse);
 
-        given(memberRepository.existsMemberByNickname(anyString())).willReturn(false);
-        given(memberRepository.existsMemberByUsername(anyString())).willReturn(false);
-        given(passwordEncoder.encode(anyString())).willReturn(encoded);
-        given(memberRepository.save(any(Member.class))).willReturn(member);
+            PostListResponse response = memberService.memberPostList(0, 1L);
 
-        memberService.memberSignup(memberSignupRequest);
+            assertThat(response.getPosts().get(0).getPostId()).isEqualTo(1L);
+            assertThat(response.getPage()).isEqualTo(1);
+            assertThat(response.getTotalPages()).isEqualTo(1);
+            assertThat(response.getTotalElements()).isEqualTo(1);
+            assertThat(response.isFirst()).isTrue();
+            assertThat(response.isLast()).isTrue();
+            assertThat(response.isPrev()).isFalse();
+            assertThat(response.isNext()).isFalse();
+            then(postRepository).should().findPostMemberList(any(Pageable.class), anyLong());
+        }
 
-        then(memberRepository).should().existsMemberByNickname(anyString());
-        then(memberRepository).should().existsMemberByUsername(anyString());
-        then(passwordEncoder).should().encode(anyString());
-        then(memberRepository).should().save(any(Member.class));
     }
 
-    @Test
-    @DisplayName("회원가입 시 비밀번호가 일치하지 않으면 예외가 발생한다")
-    void memberSignup_passwordMismatch() {
-        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonkun", "yoon1234", "12345678", "12345679");
+    @Nested
+    @DisplayName("회원 닉네임 변경")
+    class MemberNicknameChangeTest {
 
-        given(memberRepository.existsMemberByNickname(anyString())).willReturn(false);
-        given(memberRepository.existsMemberByUsername(anyString())).willReturn(false);
+        @Test
+        @DisplayName("닉네임을 변경한다")
+        void memberNicknameChange() {
+            MemberNicknameRequest memberNicknameRequest = MemberNicknameRequest.builder()
+                    .nickname("newNickname")
+                    .build();
 
-        assertThatThrownBy(() -> memberService.memberSignup(memberSignupRequest))
-                .isInstanceOf(PasswordMismatchException.class);
+            Member member = Member.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password(new BCryptPasswordEncoder().encode("12345678"))
+                    .build();
 
-        then(memberRepository).should().existsMemberByNickname(anyString());
-        then(memberRepository).should().existsMemberByUsername(anyString());
-        then(passwordEncoder).should(never()).encode(anyString());
-        then(memberRepository).should(never()).save(any(Member.class));
+            given(memberRepository.findByMemberId(anyLong())).willReturn(member);
+
+            memberService.memberNicknameChange(memberNicknameRequest, 1L);
+
+            then(memberRepository).should().findByMemberId(anyLong());
+        }
+
+        @Test
+        @DisplayName("회원이 존재하지 않으면 예외가 발생한다")
+        void memberNicknameChangeNotFoundMember() {
+            MemberNicknameRequest memberNicknameRequest = MemberNicknameRequest.builder()
+                    .nickname("newNickname")
+                    .build();
+
+            willThrow(new NotFoundMemberException()).given(memberRepository).findByMemberId(anyLong());
+
+            assertThatThrownBy(() -> memberService.memberNicknameChange(memberNicknameRequest, 1L))
+                    .isInstanceOf(NotFoundMemberException.class);
+
+            then(memberRepository).should().findByMemberId(anyLong());
+        }
+
     }
 
-    @Test
-    @DisplayName("회원 정보를 조회한다")
-    void memberProfile() {
-        Member member = Member.builder()
-                .nickname("yoonkun")
-                .username("yoon1234")
-                .build();
+    @Nested
+    @DisplayName("회원 비밀번호 변경")
+    class MemberPasswordChangeTest {
 
-        given(memberRepository.findMemberByUsername(anyString())).willReturn(Optional.of(member));
+        @Test
+        @DisplayName("비밀번호를 변경한다")
+        void memberPasswordChange() {
+            MemberPasswordRequest memberPasswordRequest = MemberPasswordRequest.builder()
+                    .curPassword("12345678")
+                    .newPassword("87654321")
+                    .newPasswordConfirm("87654321")
+                    .build();
 
-        memberService.memberProfile("yoon1234");
+            Member member = Member.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password(new BCryptPasswordEncoder().encode("12345678"))
+                    .build();
 
-        then(memberRepository).should().findMemberByUsername(anyString());
-    }
+            given(memberRepository.findByMemberId(anyLong())).willReturn(member);
+            given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
 
-    @Test
-    @DisplayName("회원 정보 조회 시 회원을 찾을 수 없으면 예외가 발생한다")
-    void memberProfileNotFoundMember() {
-        willThrow(new NotFoundMemberException()).given(memberRepository).findMemberByUsername(anyString());
+            memberService.memberPasswordChange(memberPasswordRequest, 1L);
 
-        assertThatThrownBy(() -> memberService.memberProfile("yoon1234"))
-                .isInstanceOf(NotFoundMemberException.class);
+            then(memberRepository).should().findByMemberId(anyLong());
+            then(passwordEncoder).should().matches(anyString(), anyString());
+        }
 
-        then(memberRepository).should().findMemberByUsername(anyString());
-    }
+        @Test
+        @DisplayName("회원이 존재하지 않으면 예외가 발생한다")
+        void memberPasswordChangeNotFoundMember() {
+            MemberPasswordRequest memberPasswordRequest = MemberPasswordRequest.builder()
+                    .curPassword("12345678")
+                    .newPassword("87654321")
+                    .newPasswordConfirm("87654321")
+                    .build();
 
-    @Test
-    @DisplayName("회원 닉네임을 변경한다")
-    void memberNicknameChange() {
-        Member member = Member.builder()
-                .nickname("yoonkun")
-                .username("yoon1234")
-                .password("12345678")
-                .build();
-        MemberNicknameRequest memberNicknameRequest = new MemberNicknameRequest("newNickname");
+            willThrow(new NotFoundMemberException()).given(memberRepository).findByMemberId(anyLong());
 
-        given(memberRepository.existsMemberByNickname(anyString())).willReturn(false);
-        given(memberRepository.findMemberByUsername(anyString())).willReturn(Optional.of(member));
+            assertThatThrownBy(() -> memberService.memberPasswordChange(memberPasswordRequest, 1L))
+                    .isInstanceOf(NotFoundMemberException.class);
 
-        memberService.memberNicknameChange(memberNicknameRequest, "yoon1234");
+            then(memberRepository).should().findByMemberId(anyLong());
+            then(passwordEncoder).should(never()).matches(anyString(), anyString());
+        }
 
-        then(memberRepository).should().existsMemberByNickname(anyString());
-        then(memberRepository).should().findMemberByUsername(anyString());
-    }
+        @Test
+        @DisplayName("현재 사용 중인 비밀번호가 일치하지 않으면 예외가 발생한다")
+        void MemberPasswordCurPasswordMismatch() {
+            MemberPasswordRequest memberPasswordRequest = MemberPasswordRequest.builder()
+                    .curPassword("12345679")
+                    .newPassword("87654321")
+                    .newPasswordConfirm("98765432")
+                    .build();
 
-    @Test
-    @DisplayName("회원 닉네임 변경 시 닉네임이 중복되면 예외가 발생한다")
-    void memberNicknameChangeDuplicateNickname() {
-        MemberNicknameRequest memberNicknameRequest = new MemberNicknameRequest("newNickname");
+            Member member = Member.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password(new BCryptPasswordEncoder().encode("12345678"))
+                    .build();
 
-        given(memberRepository.existsMemberByNickname(anyString())).willReturn(true);
+            given(memberRepository.findByMemberId(anyLong())).willReturn(member);
+            given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
 
-        assertThatThrownBy(() -> memberService.memberNicknameChange(memberNicknameRequest, "yoon1234"))
-                .isInstanceOf(DuplicateNicknameException.class);
+            assertThatThrownBy(() -> memberService.memberPasswordChange(memberPasswordRequest, 1L))
+                    .isInstanceOf(PasswordMismatchException.class);
 
-        then(memberRepository).should().existsMemberByNickname(anyString());
-        then(memberRepository).should(never()).findMemberByUsername(anyString());
-    }
+            then(memberRepository).should().findByMemberId(anyLong());
+            then(passwordEncoder).should().matches(anyString(), anyString());
+        }
 
-    @Test
-    @DisplayName("회원 닉네임 변경 시 회원을 찾을 수 없으면 예외가 발생한다")
-    void memberNicknameNotFoundMember() {
-        MemberNicknameRequest memberNicknameRequest = new MemberNicknameRequest("newNickname");
+        @Test
+        @DisplayName("새 비밀번호와 새 비밀번호 확인이 일치하지 않으면 예외가 발생한다")
+        void memberPasswordNewPasswordAndNewPasswordConfirmMismatch() {
+            MemberPasswordRequest memberPasswordRequest = MemberPasswordRequest.builder()
+                    .curPassword("12345678")
+                    .newPassword("87654321")
+                    .newPasswordConfirm("98765432")
+                    .build();
 
-        given(memberRepository.existsMemberByNickname(anyString())).willReturn(false);
-        willThrow(new NotFoundMemberException()).given(memberRepository).findMemberByUsername(anyString());
+            Member member = Member.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password(new BCryptPasswordEncoder().encode("12345678"))
+                    .build();
 
-        assertThatThrownBy(() -> memberService.memberNicknameChange(memberNicknameRequest, "yoon1234"))
-                .isInstanceOf(NotFoundMemberException.class);
+            given(memberRepository.findByMemberId(anyLong())).willReturn(member);
+            given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
 
-        then(memberRepository).should().existsMemberByNickname(anyString());
-        then(memberRepository).should().findMemberByUsername(anyString());
-    }
+            assertThatThrownBy(() -> memberService.memberPasswordChange(memberPasswordRequest, 1L))
+                    .isInstanceOf(PasswordMismatchException.class);
 
-    @Test
-    @DisplayName("회원 비밀번호를 변경한다")
-    void memberPasswordChange() {
-        Member member = Member.builder()
-                .nickname("yoonkun")
-                .username("yoon1234")
-                .password(new BCryptPasswordEncoder().encode("12345678"))
-                .build();
-        MemberPasswordRequest memberPasswordRequest = new MemberPasswordRequest("12345678", "87654321", "87654321");
+            then(memberRepository).should().findByMemberId(anyLong());
+            then(passwordEncoder).should().matches(anyString(), anyString());
+        }
 
-        given(memberRepository.findMemberByUsername(anyString())).willReturn(Optional.of(member));
-        given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
 
-        memberService.memberPasswordChange(memberPasswordRequest, "yoon1234");
-
-        then(memberRepository).should().findMemberByUsername(anyString());
-        then(passwordEncoder).should().matches(anyString(), anyString());
-    }
-
-    @Test
-    @DisplayName("회원 비밀번호 변경 시 회원을 찾을 수 없으면 예외가 발생한다")
-    void memberPasswordChangeNotFoundMember() {
-        MemberPasswordRequest memberPasswordRequest = new MemberPasswordRequest("12345678", "87654321", "87654321");
-
-        willThrow(new NotFoundMemberException()).given(memberRepository).findMemberByUsername(anyString());
-
-        assertThatThrownBy(() -> memberService.memberPasswordChange(memberPasswordRequest, "yoon"))
-                .isInstanceOf(NotFoundMemberException.class);
-
-        then(memberRepository).should().findMemberByUsername(anyString());
-        then(passwordEncoder).should(never()).matches(anyString(), anyString());
-    }
-
-    @Test
-    @DisplayName("회원 비밀번호 변경 시 현재 비밀번호가 일치하지 않으면 예외가 발생한다")
-    void memberPasswordChangeMismatchCurPassword() {
-        Member member = Member.builder()
-                .nickname("yoonkun")
-                .username("yoon1234")
-                .password("12345678")
-                .build();
-        MemberPasswordRequest memberPasswordRequest = new MemberPasswordRequest("12345679", "87654321", "87654321");
-
-        given(memberRepository.findMemberByUsername(anyString())).willReturn(Optional.of(member));
-
-        assertThatThrownBy(() -> memberService.memberPasswordChange(memberPasswordRequest, "yoon"))
-                .isInstanceOf(PasswordMismatchException.class);
-
-        then(memberRepository).should().findMemberByUsername(anyString());
-        then(passwordEncoder).should().matches(anyString(), anyString());
-    }
-
-    @Test
-    @DisplayName("회원 비밀번호 변경 시 새로운 비밀번호가 일치하지 않으면 예외가 발생한다")
-    void memberPasswordChangeMismatchNewPassword() {
-        Member member = Member.builder()
-                .nickname("yoonkun")
-                .username("yoon1234")
-                .password("12345678")
-                .build();
-        MemberPasswordRequest memberPasswordRequest = new MemberPasswordRequest("12345678", "87654320", "87654321");
-
-        given(memberRepository.findMemberByUsername(anyString())).willReturn(Optional.of(member));
-
-        assertThatThrownBy(() -> memberService.memberPasswordChange(memberPasswordRequest, "yoon"))
-                .isInstanceOf(PasswordMismatchException.class);
-
-        then(memberRepository).should().findMemberByUsername(anyString());
-        then(passwordEncoder).should().matches(anyString(), anyString());
     }
 
 }

--- a/backend/src/test/java/com/board/support/ServiceTest.java
+++ b/backend/src/test/java/com/board/support/ServiceTest.java
@@ -1,0 +1,9 @@
+package com.board.support;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ServiceTest {
+}


### PR DESCRIPTION
## 설명

- 회원 자신이 작성한 게시글 목록 조회 기능을 변경했습니다.

## 주요 변경 사항

- 회원 자신이 작성한 게시글 목록 조회 기능 변경
- 회원 자신이 작성한 게시글 목록 조회 API 경로 변경
- 회원 상세정보 조회 API 경로 변경
- 회원 닉네임 변경 API 경로 변경
- 회원 비밀번호 변경 API 경로 변경
- 토큰 인증 필터를 거치치 않는 URI 검증 로직을 변경

## 구현 내용

### 1. 자신이 작성한 게시글 목록 조회 기능 변경

- MemberController에서 PostService와 CommentService 의존 객체를 제거하고 MemberService에 PostRepository 의존 객체를 추가해 PostRepository에서 회원 자신이 작성한 게시글 목록을 조회하도록 변경했습니다.
- 로그인한 회원을 조회할 때 username이 아닌 memberId를 사용하도록 변경하였고 findById를 MemberRepository에서 default 메서드로 선언해 예외 처리까지 하도록 추가했습니다.

### 2. 자신이 작성한 게시글 목록 조회 API 경로 변경

- 변경 전: `/api/members/profile/posts`
- 변경 후: `/api/members/me/posts`

### 3. 회원 상세정보 조회 API 경로 변경

- 변경 전: `/api/members/profile`
- 변경 후:  `/api/members/me`

### 4. 회원 닉네임 변경 API 경로 변경

- 변경 전: `/api/members/profile/nickname`
- 변경 후: `/api/members/me/nickname`

### 5. 회원 비밀번호 변경 API 경로 변경

- 변경 전: `/api/members/profile/password`
- 변경 후: `/api/members/me/password`

### 6. 토큰 인증 필터를 거치지 않는 URI 검증 로직 변경

- 필터 제외 경로를 관리하는 내부 enum 클래스를 제거하고 전체 요청 경로를 관리하는 별도의 enum 클래스를 추가했습니다. 
- 전체 요청 경로 enum 클래스 안에 필터 제외 경로를 판별하는 메서드를 추가해 토큰 인증 필터의 shoulNotFilter 메서드에서 사용하도록 변경했습니다.

## 관련 이슈

- close #84 
