### PR TITLE
자신이 작성한 댓글 목록 조회 기능 변경

### DIFF
--- a/backend/src/main/java/com/board/domain/comment/repository/CommentCustomRepository.java
+++ b/backend/src/main/java/com/board/domain/comment/repository/CommentCustomRepository.java
@@ -1,0 +1,11 @@
+package com.board.domain.comment.repository;
+
+import com.board.domain.member.dto.MemberCommentListResponse;
+
+import org.springframework.data.domain.Pageable;
+
+public interface CommentCustomRepository {
+
+    MemberCommentListResponse findMemberCommentList(Pageable pageable, Long memberId);
+
+}

--- a/backend/src/main/java/com/board/domain/comment/repository/CommentCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/board/domain/comment/repository/CommentCustomRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.board.domain.comment.repository;
+
+import com.board.domain.member.dto.MemberCommentListResponse;
+import com.board.domain.member.dto.MemberCommentListResponse.CommentItem;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.board.domain.comment.entity.QComment.comment;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentCustomRepositoryImpl implements CommentCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public MemberCommentListResponse findMemberCommentList(Pageable pageable, Long memberId) {
+        List<CommentItem> content = jpaQueryFactory
+                .select(Projections.constructor(CommentItem.class,
+                        comment.id,
+                        comment.writer,
+                        comment.count(),
+                        comment.createdAt))
+                .from(comment)
+                .where(comment.member.id.eq(memberId).and(comment.isDelete.eq(false)))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        JPAQuery<Long> count = jpaQueryFactory
+                .select(comment.count())
+                .from(comment)
+                .where(comment.member.id.eq(memberId).and(comment.isDelete.eq(false)));
+        Page<CommentItem> commentPage = PageableExecutionUtils.getPage(content, pageable, count::fetchOne);
+        return MemberCommentListResponse.of(commentPage);
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/board/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.board.domain.member.controller;
 
+import com.board.domain.member.dto.MemberCommentListResponse;
 import com.board.domain.member.dto.MemberNicknameRequest;
 import com.board.domain.member.dto.MemberPasswordRequest;
 import com.board.domain.member.dto.MemberProfileResponse;
@@ -63,6 +64,15 @@ public class MemberController {
         page = page <= 0 ? 0 : page - 1;
         PostListResponse postListResponse = memberService.memberPostList(page, memberId);
         return ResponseEntity.ok().body(ApiResponse.success(postListResponse));
+    }
+
+    @Secured("ROLE_MEMBER")
+    @GetMapping("/me/comments")
+    public ResponseEntity<ApiResponse<MemberCommentListResponse>> memberCommentList(@RequestParam("page") int page,
+                                                                                    @AuthenticationPrincipal Long memberId) {
+        page = page <= 0 ? 0 : page - 1;
+        MemberCommentListResponse memberCommentListResponse = memberService.memberCommentList(page, memberId);
+        return ResponseEntity.ok().body(ApiResponse.success(memberCommentListResponse));
     }
 
     @Secured("ROLE_MEMBER")

--- a/backend/src/main/java/com/board/domain/member/dto/MemberCommentListResponse.java
+++ b/backend/src/main/java/com/board/domain/member/dto/MemberCommentListResponse.java
@@ -1,0 +1,55 @@
+package com.board.domain.member.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberCommentListResponse {
+
+    private List<CommentItem> comments;
+    private int page;
+    private int totalPages;
+    private long totalElements;
+    private boolean prev;
+    private boolean next;
+    private boolean first;
+    private boolean last;
+
+    public static MemberCommentListResponse of(Page<CommentItem> commentPage) {
+        return MemberCommentListResponse.builder()
+                .comments(commentPage.getContent())
+                .page(commentPage.getNumber() + 1)
+                .totalPages(commentPage.getTotalPages())
+                .totalElements(commentPage.getTotalElements())
+                .prev(commentPage.hasPrevious())
+                .next(commentPage.hasNext())
+                .first(commentPage.isFirst())
+                .last(commentPage.isLast())
+                .build();
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PUBLIC)
+    public static class CommentItem {
+
+        private Long commentId;
+        private String writer;
+        private String content;
+        private LocalDateTime createdAt;
+
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/board/domain/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.board.domain.member.service;
 
+import com.board.domain.comment.repository.CommentRepository;
+import com.board.domain.member.dto.MemberCommentListResponse;
 import com.board.domain.member.dto.MemberNicknameRequest;
 import com.board.domain.member.dto.MemberPasswordRequest;
 import com.board.domain.member.dto.MemberProfileResponse;
@@ -24,9 +26,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private static final int POST_PER_PAGE = 10;
+    private static final int COMMENT_PER_PAGE = 10;
 
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
@@ -68,6 +72,11 @@ public class MemberService {
     @Transactional(readOnly = true)
     public PostListResponse memberPostList(int page, Long memberId) {
         return postRepository.findPostMemberList(PageRequest.of(page, POST_PER_PAGE), memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public MemberCommentListResponse memberCommentList(int page, Long memberId) {
+        return commentRepository.findMemberCommentList(PageRequest.of(page, COMMENT_PER_PAGE), memberId);
     }
 
     @Transactional

--- a/backend/src/test/java/com/board/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/board/domain/member/controller/MemberControllerTest.java
@@ -1,5 +1,7 @@
 package com.board.domain.member.controller;
 
+import com.board.domain.member.dto.MemberCommentListResponse;
+import com.board.domain.member.dto.MemberCommentListResponse.CommentItem;
 import com.board.domain.member.dto.MemberNicknameRequest;
 import com.board.domain.member.dto.MemberPasswordRequest;
 import com.board.domain.member.dto.MemberProfileResponse;
@@ -11,6 +13,7 @@ import com.board.domain.member.exception.NotFoundMemberException;
 import com.board.domain.member.exception.PasswordMismatchException;
 import com.board.domain.member.service.MemberService;
 import com.board.domain.post.dto.PostListResponse;
+import com.board.domain.post.dto.PostListResponse.PostItem;
 import com.board.global.security.exception.ExpiredTokenException;
 import com.board.global.security.exception.InvalidTokenException;
 import com.board.global.security.dto.LoginMember;
@@ -705,7 +708,7 @@ class MemberControllerTest extends ControllerTest {
         void memberPostList() throws Exception {
             PostListResponse postListResponse = PostListResponse.builder()
                     .posts(List.of(
-                            PostListResponse.PostItem.builder()
+                            PostItem.builder()
                                     .postId(1L)
                                     .title("title")
                                     .writer("writer")
@@ -796,6 +799,125 @@ class MemberControllerTest extends ControllerTest {
                     .andExpect(jsonPath("$.error.code").value("E401003"))
                     .andExpect(jsonPath("$.error.message").value("토큰이 만료되었습니다."))
                     .andDo(restDocs.document(
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("회원이 작성한 댓글 목록조회 요청")
+    class MemberCommentListTest {
+
+        @Test
+        @DisplayName("회원이 작성한 댓글 목록을 조회한다")
+        void memberCommentList() throws Exception {
+            MemberCommentListResponse memberCommentListResponse = MemberCommentListResponse.builder()
+                    .comments(List.of(
+                            CommentItem.builder()
+                                    .commentId(1L)
+                                    .writer("yoonkun")
+                                    .content("comment")
+                                    .createdAt(LocalDateTime.of(2024, 6, 17, 0, 0))
+                                    .build()
+                    ))
+                    .page(1)
+                    .totalPages(1)
+                    .totalElements(1)
+                    .first(true)
+                    .last(true)
+                    .prev(false)
+                    .next(false)
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            given(memberService.memberCommentList(anyInt(), anyLong())).willReturn(memberCommentListResponse);
+
+            mockMvc.perform(get("/api/members/me/comments")
+                            .header("Authorization", "Bearer access-token")
+                            .param("page", "1")
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andExpect(jsonPath("$.data.comments[0].commentId").value(1))
+                    .andExpect(jsonPath("$.data.comments[0].writer").value("yoonkun"))
+                    .andExpect(jsonPath("$.data.comments[0].content").value("comment"))
+                    .andExpect(jsonPath("$.data.comments[0].createdAt").value("2024-06-17T00:00:00"))
+                    .andExpect(jsonPath("$.data.page").value(1))
+                    .andExpect(jsonPath("$.data.totalPages").value(1))
+                    .andExpect(jsonPath("$.data.totalElements").value(1))
+                    .andExpect(jsonPath("$.data.first").value(true))
+                    .andExpect(jsonPath("$.data.last").value(true))
+                    .andExpect(jsonPath("$.data.prev").value(false))
+                    .andExpect(jsonPath("$.data.next").value(false))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            queryParameters(
+                                    parameterWithName("page").description("페이지 번호")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 유효하지 않으면 예외가 발생한다")
+        void memberCommentListInvalidAccessToken() throws Exception {
+            willThrow(new InvalidTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(get("/api/members/me/comments")
+                            .header("Authorization", "Bearer invalid-token")
+                            .param("page", "1")
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.error.code").value("E401002"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 유효하지 않습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            queryParameters(
+                                    parameterWithName("page").description("페이지 번호")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("리프레시 토큰이 유효하지 않으면 예외가 발생한다")
+        void memberCommentListExpiredAccessToken() throws Exception {
+            willThrow(new ExpiredTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(get("/api/members/me/comments")
+                            .header("Authorization", "Bearer invalid-token")
+                            .param("page", "1")
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.error.code").value("E401003"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 만료되었습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            queryParameters(
+                                    parameterWithName("page").description("페이지 번호")
+                            ),
                             responseFields(
                                     commonErrorResponse()
                             )

--- a/backend/src/test/java/com/board/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/board/domain/member/service/MemberServiceTest.java
@@ -1,5 +1,8 @@
 package com.board.domain.member.service;
 
+import com.board.domain.comment.repository.CommentRepository;
+import com.board.domain.member.dto.MemberCommentListResponse;
+import com.board.domain.member.dto.MemberCommentListResponse.CommentItem;
 import com.board.domain.member.dto.MemberNicknameRequest;
 import com.board.domain.member.dto.MemberPasswordRequest;
 import com.board.domain.member.dto.MemberProfileResponse;
@@ -11,6 +14,7 @@ import com.board.domain.member.exception.NotFoundMemberException;
 import com.board.domain.member.exception.PasswordMismatchException;
 import com.board.domain.member.repository.MemberRepository;
 import com.board.domain.post.dto.PostListResponse;
+import com.board.domain.post.dto.PostListResponse.PostItem;
 import com.board.domain.post.repository.PostRepository;
 import com.board.support.ServiceTest;
 
@@ -46,6 +50,9 @@ class MemberServiceTest extends ServiceTest {
 
     @Mock
     private PostRepository postRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
 
     @Mock
     private PasswordEncoder passwordEncoder;
@@ -246,7 +253,7 @@ class MemberServiceTest extends ServiceTest {
     }
 
     @Nested
-    @DisplayName("회원이 작성한 게시글 목록조회")
+    @DisplayName("회원이 작성한 게시글 목록 조회")
     class MemberPostListTest {
 
         @Test
@@ -254,7 +261,7 @@ class MemberServiceTest extends ServiceTest {
         void memberPostList() {
             PostListResponse postListResponse = PostListResponse.builder()
                     .posts(List.of(
-                            PostListResponse.PostItem.builder()
+                            PostItem.builder()
                                     .postId(1L)
                                     .title("title")
                                     .writer("writer")
@@ -284,6 +291,48 @@ class MemberServiceTest extends ServiceTest {
             assertThat(response.isPrev()).isFalse();
             assertThat(response.isNext()).isFalse();
             then(postRepository).should().findPostMemberList(any(Pageable.class), anyLong());
+        }
+
+    }
+
+    @Nested
+    @DisplayName("회원이 작성한 댓글 목록 조회")
+    class MemberCommentListTest {
+
+        @Test
+        @DisplayName("회원이 작성한 댓글 목록을 조회한다")
+        void memberCommentList() {
+            MemberCommentListResponse memberCommentListResponse = MemberCommentListResponse.builder()
+                    .comments(List.of(
+                            CommentItem.builder()
+                                    .commentId(1L)
+                                    .writer("yoonkun")
+                                    .content("comment")
+                                    .createdAt(LocalDateTime.of(2024, 6, 17, 0, 0))
+                                    .build()
+                    ))
+                    .page(1)
+                    .totalPages(1)
+                    .totalElements(1)
+                    .first(true)
+                    .last(true)
+                    .prev(false)
+                    .next(false)
+                    .build();
+
+            given(commentRepository.findMemberCommentList(any(Pageable.class), anyLong())).willReturn(memberCommentListResponse);
+
+            MemberCommentListResponse response = memberService.memberCommentList(0, 1L);
+
+            assertThat(response.getComments().get(0).getCommentId()).isEqualTo(1L);
+            assertThat(response.getPage()).isEqualTo(1);
+            assertThat(response.getTotalPages()).isEqualTo(1);
+            assertThat(response.getTotalElements()).isEqualTo(1);
+            assertThat(response.isFirst()).isTrue();
+            assertThat(response.isLast()).isTrue();
+            assertThat(response.isPrev()).isFalse();
+            assertThat(response.isNext()).isFalse();
+            then(commentRepository).should().findMemberCommentList(any(Pageable.class), anyLong());
         }
 
     }

--- a/backend/src/test/java/com/board/domain/token/service/TokenServiceTest.java
+++ b/backend/src/test/java/com/board/domain/token/service/TokenServiceTest.java
@@ -7,15 +7,14 @@ import com.board.global.security.dto.LoginMember;
 import com.board.global.security.exception.InvalidTokenException;
 import com.board.global.security.support.JwtManager;
 
+import com.board.support.ServiceTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -33,8 +32,7 @@ import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 
-@ExtendWith(MockitoExtension.class)
-class TokenServiceTest {
+class TokenServiceTest extends ServiceTest {
 
     @Mock
     private TokenRepository tokenRepository;


### PR DESCRIPTION
## 설명

- 자신이 작성한 댓글 목록 조회 기능을 변경했습니다.

## 주요 변경 사항

- 자신이 작성한 댓글 조회 기능 변경
- 자신이 작성한 댓글 조회 API 경로 변경
- 테스트 수행

## 구현 내용

### 1. 자신이 작성한 댓글 조회 기능 변경

- MemberService에 CommentRepository 의존 객체를 추가하도록 변경했습니다.
- Querydsl을 사용해 자신이 작성한 댓글 목록을 조회할 수 있도록 변경했습니다.

### 2. 자신이 작성한 댓글 조회 API 경로 변경

- 변경 전: `/api/members/profile/comments`
- 변경 후: `/api/members/me/comments`

### 3. 테스트

- 회원 자신이 작성한 댓글 목록을 조회하는 기능에 대해 단위 테스트를 수행했습니다.

## 관련 이슈

- close #85
