### PR TITLE
게시글 단건 조회 기능 리팩토링

### DIFF
--- a/backend/src/main/java/com/board/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/board/domain/post/controller/PostController.java
@@ -34,8 +34,8 @@ public class PostController {
     @Secured("ROLE_MEMBER")
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> postWrite(@RequestBody @Valid PostWriteRequest postWriteRequest,
-                                                       @AuthenticationPrincipal String username) {
-        postService.postWrite(postWriteRequest, username);
+                                                       @AuthenticationPrincipal Long memberId) {
+        postService.postWrite(postWriteRequest, memberId);
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 
@@ -53,11 +53,11 @@ public class PostController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<ApiResponse<PostListResponse>> postListSearch(@RequestParam("page") int page,
+    public ResponseEntity<ApiResponse<PostListResponse>> postSearchList(@RequestParam("page") int page,
                                                                         @RequestParam("type") String type,
                                                                         @RequestParam("keyword") String keyword) {
         page = page <= 0 ? 0 : page - 1;
-        PostListResponse postListResponse = postService.postListSearch(page, type, keyword);
+        PostListResponse postListResponse = postService.postSearchList(page, type, keyword);
         return ResponseEntity.ok().body(ApiResponse.success(postListResponse));
     }
 
@@ -65,16 +65,16 @@ public class PostController {
     @PutMapping("/{postId}")
     public ResponseEntity<ApiResponse<Void>> postModify(@PathVariable("postId") Long postId,
                                                         @RequestBody @Valid PostModifyRequest postModifyRequest,
-                                                        @AuthenticationPrincipal String username) {
-        postService.postModify(postId, postModifyRequest, username);
+                                                        @AuthenticationPrincipal Long memberId) {
+        postService.postModify(postId, postModifyRequest, memberId);
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 
     @Secured("ROLE_MEMBER")
     @DeleteMapping("/{postId}")
     public ResponseEntity<ApiResponse<Void>> postDelete(@PathVariable("postId") Long postId,
-                                                        @AuthenticationPrincipal String username) {
-        postService.postDelete(postId, username);
+                                                        @AuthenticationPrincipal Long memberId) {
+        postService.postDelete(postId, memberId);
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 

--- a/backend/src/main/java/com/board/domain/post/dto/PostDetailResponse.java
+++ b/backend/src/main/java/com/board/domain/post/dto/PostDetailResponse.java
@@ -2,27 +2,34 @@ package com.board.domain.post.dto;
 
 import com.board.domain.post.entity.Post;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
-@AllArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostDetailResponse {
 
-    private final Long postId;
-    private final String title;
-    private final String writer;
-    private final String content;
-    private final LocalDateTime createdAt;
+    private Long postId;
+    private String title;
+    private String writer;
+    private String content;
+    private LocalDateTime createdAt;
 
-    public PostDetailResponse(Post post) {
-        this.postId = post.getId();
-        this.title = post.getTitle();
-        this.writer = post.getWriter();
-        this.content = post.getContent();
-        this.createdAt = post.getCreatedAt();
+    public static PostDetailResponse of(Post post) {
+        return PostDetailResponse.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .writer(post.getWriter())
+                .content(post.getContent())
+                .createdAt(post.getCreatedAt())
+                .build();
     }
 
 }

--- a/backend/src/main/java/com/board/domain/post/dto/PostModifyRequest.java
+++ b/backend/src/main/java/com/board/domain/post/dto/PostModifyRequest.java
@@ -2,13 +2,16 @@ package com.board.domain.post.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostModifyRequest {
 
     @NotBlank(message = "제목을 입력해 주세요.")

--- a/backend/src/main/java/com/board/domain/post/dto/PostWriteRequest.java
+++ b/backend/src/main/java/com/board/domain/post/dto/PostWriteRequest.java
@@ -2,13 +2,16 @@ package com.board.domain.post.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostWriteRequest {
 
     @NotBlank(message = "제목을 입력해 주세요.")

--- a/backend/src/main/java/com/board/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/board/domain/post/entity/Post.java
@@ -49,9 +49,9 @@ public class Post extends BaseEntity {
     private List<Comment> comments = new ArrayList<>();
 
     @Builder
-    public Post(String title, String content, Member member) {
+    public Post(String title, String writer, String content, Member member) {
         this.title = title;
-        this.writer = member.getNickname();
+        this.writer = writer;
         this.content = content;
         this.member = member;
     }
@@ -61,8 +61,8 @@ public class Post extends BaseEntity {
         this.content = content;
     }
 
-    public boolean isOwner(String loginUsername) {
-        return member.getUsername().equals(loginUsername);
+    public boolean isOwner(Long memberId) {
+        return member.getId().equals(memberId);
     }
 
 }

--- a/backend/src/main/java/com/board/domain/post/repository/PostCustomRepository.java
+++ b/backend/src/main/java/com/board/domain/post/repository/PostCustomRepository.java
@@ -6,7 +6,8 @@ import org.springframework.data.domain.Pageable;
 
 public interface PostCustomRepository {
 
-    PostListResponse findPosts(Pageable pageable);
-    PostListResponse findSearchPosts(Pageable pageable, String type, String keyword);
+    PostListResponse findPostList(Pageable pageable);
+    PostListResponse findPostSearchList(Pageable pageable, String type, String keyword);
+    PostListResponse findPostMemberList(Pageable pageable, Long memberId);
 
 }

--- a/backend/src/main/java/com/board/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/board/domain/post/repository/PostCustomRepositoryImpl.java
@@ -28,7 +28,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public PostListResponse findPosts(Pageable pageable) {
+    public PostListResponse findPostList(Pageable pageable) {
         List<PostItem> content = jpaQueryFactory
                 .select(Projections.constructor(PostItem.class,
                         post.id,
@@ -52,7 +52,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     }
 
     @Override
-    public PostListResponse findSearchPosts(Pageable pageable, String type, String keyword) {
+    public PostListResponse findPostSearchList(Pageable pageable, String type, String keyword) {
         List<PostItem> content = jpaQueryFactory
                 .select(Projections.constructor(PostItem.class,
                         post.id,
@@ -84,6 +84,32 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
             return post.writer.eq(keyword);
         }
         return null;
+    }
+
+    @Override
+    public PostListResponse findPostMemberList(Pageable pageable, Long memberId) {
+        List<PostItem> content = jpaQueryFactory
+                .select(Projections.constructor(PostItem.class,
+                        post.id,
+                        post.title,
+                        post.writer,
+                        comment.count().intValue(),
+                        post.createdAt)
+                )
+                .from(post)
+                .leftJoin(post.comments, comment).on(comment.isDelete.eq(false))
+                .groupBy(post.id)
+                .having(post.member.id.eq(memberId))
+                .orderBy(post.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        JPAQuery<Long> count = jpaQueryFactory
+                .select(post.count())
+                .where(post.member.id.eq(memberId))
+                .from(post);
+        Page<PostItem> postPage = PageableExecutionUtils.getPage(content, pageable, count::fetchOne);
+        return PostListResponse.of(postPage);
     }
 
 }

--- a/backend/src/main/java/com/board/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/board/domain/post/repository/PostRepository.java
@@ -1,16 +1,15 @@
 package com.board.domain.post.repository;
 
 import com.board.domain.post.entity.Post;
+import com.board.domain.post.exception.NotFoundPostException;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository {
 
-    @Query("SELECT p FROM Post AS p JOIN FETCH p.member WHERE p.id = :postId")
-    Optional<Post> findPostJoinFetch(@Param("postId") Long postId);
+    default Post findByPostId(Long postId) {
+        return findById(postId)
+                .orElseThrow(NotFoundPostException::new);
+    }
 
 }

--- a/backend/src/main/java/com/board/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/board/domain/post/service/PostService.java
@@ -1,14 +1,12 @@
 package com.board.domain.post.service;
 
 import com.board.domain.member.entity.Member;
-import com.board.domain.member.exception.NotFoundMemberException;
 import com.board.domain.member.repository.MemberRepository;
 import com.board.domain.post.dto.PostDetailResponse;
 import com.board.domain.post.dto.PostListResponse;
 import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.entity.Post;
-import com.board.domain.post.exception.NotFoundPostException;
 import com.board.domain.post.exception.PostDeleteAccessDeniedException;
 import com.board.domain.post.exception.PostModifyAccessDeniedException;
 import com.board.domain.post.repository.PostRepository;
@@ -25,15 +23,15 @@ public class PostService {
 
     private static final int POST_PER_PAGE = 10;
 
-    private final PostRepository postRepository;
     private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
 
     @Transactional
-    public void postWrite(PostWriteRequest postWriteRequest, String username) {
-        Member member = memberRepository.findMemberByUsername(username)
-                .orElseThrow(NotFoundMemberException::new);
+    public void postWrite(PostWriteRequest postWriteRequest, Long memberId) {
+        Member member = memberRepository.findByMemberId(memberId);
         Post post = Post.builder()
                 .title(postWriteRequest.getTitle())
+                .writer(member.getNickname())
                 .content(postWriteRequest.getContent())
                 .member(member)
                 .build();
@@ -42,44 +40,36 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public PostDetailResponse postDetail(Long postId) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(NotFoundPostException::new);
+        Post post = postRepository.findByPostId(postId);
         return PostDetailResponse.of(post);
     }
 
     @Transactional(readOnly = true)
     public PostListResponse postList(int page) {
-        return postRepository.findPosts(PageRequest.of(page, POST_PER_PAGE));
+        return postRepository.findPostList(PageRequest.of(page, POST_PER_PAGE));
     }
 
     @Transactional(readOnly = true)
-    public PostListResponse postListSearch(int page, String type, String keyword) {
-        return postRepository.findSearchPosts(PageRequest.of(page, POST_PER_PAGE), type, keyword);
+    public PostListResponse postSearchList(int page, String type, String keyword) {
+        return postRepository.findPostSearchList(PageRequest.of(page, POST_PER_PAGE), type, keyword);
     }
 
     @Transactional
-    public void postModify(Long postId, PostModifyRequest postModifyRequest, String username) {
-        Post post = postRepository.findPostJoinFetch(postId)
-                .orElseThrow(NotFoundPostException::new);
-        if (!post.isOwner(username)) {
+    public void postModify(Long postId, PostModifyRequest postModifyRequest, Long memberId) {
+        Post post = postRepository.findByPostId(postId);
+        if (!post.isOwner(memberId)) {
             throw new PostModifyAccessDeniedException();
         }
         post.modify(postModifyRequest.getTitle(), postModifyRequest.getContent());
     }
 
     @Transactional
-    public void postDelete(Long postId, String loginUsername) {
-        Post post = postRepository.findPostJoinFetch(postId)
-                .orElseThrow(NotFoundPostException::new);
-        if (!post.isOwner(loginUsername)) {
+    public void postDelete(Long postId, Long memberId) {
+        Post post = postRepository.findByPostId(postId);
+        if (!post.isOwner(memberId)) {
             throw new PostDeleteAccessDeniedException();
         }
         postRepository.delete(post);
-    }
-
-    @Transactional(readOnly = true)
-    public PostListResponse postListFromMember(int page, String username) {
-        return null;
     }
 
 }

--- a/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
@@ -1,7 +1,6 @@
 package com.board.domain.post.controller;
 
 import com.board.domain.post.dto.PostDetailResponse;
-import com.board.domain.post.dto.PostListItem;
 import com.board.domain.post.dto.PostListResponse;
 import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
@@ -9,10 +8,15 @@ import com.board.domain.post.exception.NotFoundPostException;
 import com.board.domain.post.exception.PostDeleteAccessDeniedException;
 import com.board.domain.post.exception.PostModifyAccessDeniedException;
 import com.board.domain.post.service.PostService;
+import com.board.global.security.exception.ExpiredTokenException;
+import com.board.global.security.exception.InvalidTokenException;
+import com.board.support.ControllerTest;
 
-import com.board.support.RestDocsTestSupport;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -20,6 +24,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 
 import java.time.LocalDateTime;
+
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -30,19 +35,17 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 
-import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
-import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
-import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
-import static org.springframework.restdocs.payload.JsonFieldType.STRING;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
@@ -50,478 +53,893 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = PostController.class)
-class PostControllerTest extends RestDocsTestSupport {
+class PostControllerTest extends ControllerTest {
 
     @MockBean
     private PostService postService;
 
-    @Test
-    @DisplayName("게시글을 작성한다")
-    void postWrite() throws Exception {
-        PostWriteRequest postWriteRequest = new PostWriteRequest("제목", "내용");
+    @Nested
+    @DisplayName("게시글 작성 요청")
+    class PostWriteTest {
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willDoNothing().given(postService).postWrite(any(PostWriteRequest.class), anyString());
+        @Test
+        @DisplayName("게시글을 작성한다")
+        void postWrite() throws Exception {
+            PostWriteRequest postWriteRequest = PostWriteRequest.builder()
+                    .title("title")
+                    .content("content")
+                    .build();
 
-        mockMvc.perform(post("/api/posts")
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(postWriteRequest))
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("title").type(STRING).description("제목"),
-                                fieldWithPath("content").type(STRING).description("내용")
-                        ),
-                        responseFields(
-                                commonSuccessResponse()
-                        )
-                ));
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willDoNothing().given(postService).postWrite(any(PostWriteRequest.class), anyLong());
+
+            mockMvc.perform(post("/api/posts")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(postWriteRequest))
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("게시글 제목"),
+                                    fieldWithPath("content").type(STRING).description("게시글 내용")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("제목이 비어있으면 예외가 발생한다")
+        void postWriteInvalidTitleValue() throws Exception {
+            PostWriteRequest postWriteRequest = PostWriteRequest.builder()
+                    .title("")
+                    .content("content")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+
+            mockMvc.perform(post("/api/posts")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(postWriteRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("title"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value(""))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("제목을 입력해 주세요."))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("게시글 제목"),
+                                    fieldWithPath("content").type(STRING).description("게시글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("내용이 비어있으면 예외가 발생한다")
+        void postWriteInvalidContentValue() throws Exception {
+            PostWriteRequest postWriteRequest = PostWriteRequest.builder()
+                    .title("title")
+                    .content("")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+
+            mockMvc.perform(post("/api/posts")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(postWriteRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("content"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value(""))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("내용을 입력해 주세요."))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("게시글 제목"),
+                                    fieldWithPath("content").type(STRING).description("게시글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 유효하지 않으면 예외가 발생한다")
+        void postWriteInvalidAccessToken() throws Exception {
+            PostWriteRequest postWriteRequest = PostWriteRequest.builder()
+                    .title("title")
+                    .content("content")
+                    .build();
+
+            willThrow(new InvalidTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(post("/api/posts")
+                            .header("Authorization", "Bearer invalid-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(postWriteRequest))
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401002"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 유효하지 않습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("게시글 제목"),
+                                    fieldWithPath("content").type(STRING).description("게시글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 만료되면 예외가 발생한다")
+        void postWriteExpiredAccessToken() throws Exception {
+            PostWriteRequest postWriteRequest = PostWriteRequest.builder()
+                    .title("title")
+                    .content("content")
+                    .build();
+
+            willThrow(new ExpiredTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(post("/api/posts")
+                            .header("Authorization", "Bearer expired-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(postWriteRequest))
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401003"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 만료되었습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("게시글 제목"),
+                                    fieldWithPath("content").type(STRING).description("게시글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
     }
 
-    @Test
-    @DisplayName("게시글 작성 시 입력값이 잘못되면 예외가 발생한다")
-    void postWriteInvalidInputValue() throws Exception {
-        PostWriteRequest invalidPostWriteRequest = new PostWriteRequest("", "내용");
+    @Nested
+    @DisplayName("게시글 상세조회 요청")
+    class PostDetailTest {
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willDoNothing().given(postService).postWrite(any(PostWriteRequest.class), anyString());
+        @Test
+        @DisplayName("게시글을 상세조회 한다")
+        void postDetail() throws Exception {
+            PostDetailResponse postDetailResponse = PostDetailResponse.builder()
+                    .postId(1L)
+                    .title("title")
+                    .writer("writer")
+                    .content("content")
+                    .createdAt(LocalDateTime.of(2024, 6, 17, 0, 0))
+                    .build();
 
-        mockMvc.perform(post("/api/posts")
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidPostWriteRequest))
-                )
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.result.path").value("/api/posts"))
-                .andExpect(jsonPath("$.result.error.code").value("E400001"))
-                .andExpect(jsonPath("$.result.error.message").value("입력값이 잘못되었습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].field").value("title"))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].input").value(""))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].message").value("제목을 입력해 주세요."))
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("title").type(STRING).description("제목"),
-                                fieldWithPath("content").type(STRING).description("내용")
-                        ),
-                        responseFields(
-                                commonErrorResponse())
-                                .and(
-                                        fieldWithPath("result.error.fieldErrors[].field").description(STRING).description("필드명"),
-                                        fieldWithPath("result.error.fieldErrors[].input").description(STRING).description("입력값"),
-                                        fieldWithPath("result.error.fieldErrors[].message").description(STRING).description("메시지")
-                                )
-                ));
+            given(postService.postDetail(anyLong())).willReturn(postDetailResponse);
+
+            mockMvc.perform(get("/api/posts/{postId}", 1))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andExpect(jsonPath("$.data.postId").value(1))
+                    .andExpect(jsonPath("$.data.title").value("title"))
+                    .andExpect(jsonPath("$.data.writer").value("writer"))
+                    .andExpect(jsonPath("$.data.content").value("content"))
+                    .andExpect(jsonPath("$.data.createdAt").value("2024-06-17T00:00:00"))
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse())
+                                    .and(
+                                            fieldWithPath("data.postId").type(NUMBER).description("게시글 번호"),
+                                            fieldWithPath("data.title").type(STRING).description("게시글 제목"),
+                                            fieldWithPath("data.writer").type(STRING).description("게시글 작성자"),
+                                            fieldWithPath("data.content").type(STRING).description("게시글 내용"),
+                                            fieldWithPath("data.createdAt").type(STRING).description("게시글 작성일")
+                                    )
+                    ));
+        }
+
+        @Test
+        @DisplayName("게시글이 존재하지 않으면 예외가 발생한다")
+        void postDetailNotFound() throws Exception {
+            willThrow(new NotFoundPostException()).given(postService).postDetail(anyLong());
+
+            mockMvc.perform(get("/api/posts/{postId}", 1))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E404002"))
+                    .andExpect(jsonPath("$.error.message").value("게시글을 찾을 수 없습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
     }
 
-    @Test
-    @DisplayName("게시글을 상세조회 한다")
-    void postDetail() throws Exception {
-        PostDetailResponse postDetailResponse = new PostDetailResponse(1L, "제목", "yoonkun", "내용", LocalDateTime.of(2024, 6, 17, 0, 0));
+    @Nested
+    @DisplayName("게시글 목록조회 요청")
+    class PostListTest {
 
-        given(postService.postDetail(anyLong())).willReturn(postDetailResponse);
+        @Test
+        @DisplayName("게시글 목록을 조회한다")
+        void postList() throws Exception {
+            PostListResponse postListResponse = PostListResponse.builder()
+                    .posts(List.of(
+                            PostListResponse.PostItem.builder()
+                                    .postId(1L)
+                                    .title("title")
+                                    .writer("writer")
+                                    .commentCount(0)
+                                    .createdAt(LocalDateTime.of(2024, 6, 17, 0, 0))
+                                    .build()
+                    ))
+                    .page(1)
+                    .totalPages(1)
+                    .totalElements(1)
+                    .first(true)
+                    .last(true)
+                    .prev(false)
+                    .next(false)
+                    .build();
 
-        mockMvc.perform(get("/api/posts/{postId}", 1))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result.postId").value(1))
-                .andExpect(jsonPath("$.result.title").value("제목"))
-                .andExpect(jsonPath("$.result.writer").value("yoonkun"))
-                .andExpect(jsonPath("$.result.content").value("내용"))
-                .andExpect(jsonPath("$.result.createdAt").value("2024-06-17T00:00:00"))
-                .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호")
-                        ),
-                        responseFields(
-                                commonSuccessResponse())
-                                .and(
-                                        fieldWithPath("result.postId").description("게시글 번호"),
-                                        fieldWithPath("result.title").description("게시글 제목"),
-                                        fieldWithPath("result.writer").description("게시글 작성자"),
-                                        fieldWithPath("result.content").description("게시글 내용"),
-                                        fieldWithPath("result.createdAt").description("게시글 작성일")
-                                )
-                ));
+            given(postService.postList(anyInt())).willReturn(postListResponse);
+
+            mockMvc.perform(get("/api/posts")
+                            .param("page", "1")
+                            .param("type", "title")
+                            .param("keyword", "hello")
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andExpect(jsonPath("$.data.posts[0].postId").value(1))
+                    .andExpect(jsonPath("$.data.posts[0].title").value("title"))
+                    .andExpect(jsonPath("$.data.posts[0].writer").value("writer"))
+                    .andExpect(jsonPath("$.data.posts[0].commentCount").value(0))
+                    .andExpect(jsonPath("$.data.posts[0].createdAt").value("2024-06-17T00:00:00"))
+                    .andExpect(jsonPath("$.data.page").value(1))
+                    .andExpect(jsonPath("$.data.totalPages").value(1))
+                    .andExpect(jsonPath("$.data.totalElements").value(1))
+                    .andExpect(jsonPath("$.data.first").value(true))
+                    .andExpect(jsonPath("$.data.last").value(true))
+                    .andExpect(jsonPath("$.data.prev").value(false))
+                    .andExpect(jsonPath("$.data.next").value(false))
+                    .andDo(restDocs.document(
+                            queryParameters(
+                                    parameterWithName("page").description("페이지 번호"),
+                                    parameterWithName("type").description("검색 조건"),
+                                    parameterWithName("keyword").description("검색 단어")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("제목으로 검색한 게시글 목록을 조회한다")
+        void postSearchTitleList() throws Exception {
+            PostListResponse postListResponse = PostListResponse.builder()
+                    .posts(List.of(
+                            PostListResponse.PostItem.builder()
+                                    .postId(1L)
+                                    .title("hello")
+                                    .writer("writer")
+                                    .commentCount(0)
+                                    .createdAt(LocalDateTime.of(2024, 6, 17, 0, 0))
+                                    .build()
+                    ))
+                    .page(1)
+                    .totalPages(1)
+                    .totalElements(1)
+                    .first(true)
+                    .last(true)
+                    .prev(false)
+                    .next(false)
+                    .build();
+
+            given(postService.postSearchList(anyInt(), anyString(), anyString())).willReturn(postListResponse);
+
+            mockMvc.perform(get("/api/posts/search")
+                            .param("page", "1")
+                            .param("type", "title")
+                            .param("keyword", "hello")
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andExpect(jsonPath("$.data.posts[0].postId").value(1))
+                    .andExpect(jsonPath("$.data.posts[0].title").value("hello"))
+                    .andExpect(jsonPath("$.data.posts[0].writer").value("writer"))
+                    .andExpect(jsonPath("$.data.posts[0].commentCount").value(0))
+                    .andExpect(jsonPath("$.data.posts[0].createdAt").value("2024-06-17T00:00:00"))
+                    .andExpect(jsonPath("$.data.page").value(1))
+                    .andExpect(jsonPath("$.data.totalPages").value(1))
+                    .andExpect(jsonPath("$.data.totalElements").value(1))
+                    .andExpect(jsonPath("$.data.first").value(true))
+                    .andExpect(jsonPath("$.data.last").value(true))
+                    .andExpect(jsonPath("$.data.prev").value(false))
+                    .andExpect(jsonPath("$.data.next").value(false))
+                    .andDo(restDocs.document(
+                            queryParameters(
+                                    parameterWithName("page").description("페이지 번호"),
+                                    parameterWithName("type").description("검색 조건"),
+                                    parameterWithName("keyword").description("검색 단어")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("작성자로 검색한 게시글 목록을 조회한다")
+        void postSearchWriterList() throws Exception {
+            PostListResponse postListResponse = PostListResponse.builder()
+                    .posts(List.of(
+                            PostListResponse.PostItem.builder()
+                                    .postId(1L)
+                                    .title("title")
+                                    .writer("yoonkun")
+                                    .commentCount(0)
+                                    .createdAt(LocalDateTime.of(2024, 6, 17, 0, 0))
+                                    .build()
+                    ))
+                    .page(1)
+                    .totalPages(1)
+                    .totalElements(1)
+                    .first(true)
+                    .last(true)
+                    .prev(false)
+                    .next(false)
+                    .build();
+
+            given(postService.postSearchList(anyInt(), anyString(), anyString())).willReturn(postListResponse);
+
+            mockMvc.perform(get("/api/posts/search")
+                            .param("page", "1")
+                            .param("type", "writer")
+                            .param("keyword", "yoonkun")
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andExpect(jsonPath("$.data.posts[0].postId").value(1))
+                    .andExpect(jsonPath("$.data.posts[0].title").value("title"))
+                    .andExpect(jsonPath("$.data.posts[0].writer").value("yoonkun"))
+                    .andExpect(jsonPath("$.data.posts[0].commentCount").value(0))
+                    .andExpect(jsonPath("$.data.posts[0].createdAt").value("2024-06-17T00:00:00"))
+                    .andExpect(jsonPath("$.data.page").value(1))
+                    .andExpect(jsonPath("$.data.totalPages").value(1))
+                    .andExpect(jsonPath("$.data.totalElements").value(1))
+                    .andExpect(jsonPath("$.data.first").value(true))
+                    .andExpect(jsonPath("$.data.last").value(true))
+                    .andExpect(jsonPath("$.data.prev").value(false))
+                    .andExpect(jsonPath("$.data.next").value(false))
+                    .andDo(restDocs.document(
+                            queryParameters(
+                                    parameterWithName("page").description("페이지 번호"),
+                                    parameterWithName("type").description("검색 조건"),
+                                    parameterWithName("keyword").description("검색 단어")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+        }
+
     }
 
-    @Test
-    @DisplayName("게시글 상세조회 시 게시글을 찾을 수 없으면 예외가 발생한다")
-    void postDetailNotFoundPost() throws Exception {
-        willThrow(new NotFoundPostException()).given(postService).postDetail(anyLong());
+    @Nested
+    @DisplayName("게시글 수정 요청")
+    class PostModifyTest {
 
-        mockMvc.perform(get("/api/posts/{postId}", 1))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(404))
-                .andExpect(jsonPath("$.result.path").value("/api/posts/1"))
-                .andExpect(jsonPath("$.result.error.code").value("E404002"))
-                .andExpect(jsonPath("$.result.error.message").value("게시글을 찾을 수 없습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
+        @Test
+        @DisplayName("게시글을 수정한다")
+        void postModify() throws Exception {
+            PostModifyRequest postModifyRequest = PostModifyRequest.builder()
+                    .title("title")
+                    .content("content")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willDoNothing().given(postService).postModify(anyLong(), any(PostModifyRequest.class), anyLong());
+
+            mockMvc.perform(put("/api/posts/{postId}", 1)
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(postModifyRequest))
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("게시글 제목"),
+                                    fieldWithPath("content").type(STRING).description("게시글 내용")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("제목이 비어있으면 예외가 발생한다")
+        void postModifyInvalidTitleValue() throws Exception {
+            PostModifyRequest postModifyRequest = PostModifyRequest.builder()
+                    .title("")
+                    .content("content")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+
+            mockMvc.perform(put("/api/posts/{postId}", 1)
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(postModifyRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("title"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value(""))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("제목을 입력해 주세요."))
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("게시글 제목"),
+                                    fieldWithPath("content").type(STRING).description("게시글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("내용이 비어있으면 예외가 발생한다")
+        void postModifyInvalidContentValue() throws Exception {
+            PostModifyRequest postModifyRequest = PostModifyRequest.builder()
+                    .title("title")
+                    .content("")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+
+            mockMvc.perform(put("/api/posts/{postId}", 1)
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(postModifyRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("content"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value(""))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("내용을 입력해 주세요."))
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("게시글 제목"),
+                                    fieldWithPath("content").type(STRING).description("게시글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("게시글이 존재하지 않으면 예외가 발생한다")
+        void postModifyNotFoundPost() throws Exception {
+            PostModifyRequest postModifyRequest = PostModifyRequest.builder()
+                    .title("title")
+                    .content("content")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willThrow(new NotFoundPostException()).given(postService).postModify(anyLong(), any(PostModifyRequest.class), anyLong());
+
+            mockMvc.perform(put("/api/posts/{postId}", 1)
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(postModifyRequest))
+                    )
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E404002"))
+                    .andExpect(jsonPath("$.error.message").value("게시글을 찾을 수 없습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("게시글 제목"),
+                                    fieldWithPath("content").type(STRING).description("게시글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("작성자가 아닌데 수정을 시도하면 예외가 발생한다")
+        void postModifyNotPostOwner() throws Exception {
+            PostModifyRequest postModifyRequest = PostModifyRequest.builder()
+                    .title("title")
+                    .content("content")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willThrow(new PostModifyAccessDeniedException()).given(postService).postModify(anyLong(), any(PostModifyRequest.class), any());
+
+            mockMvc.perform(put("/api/posts/{postId}", 1)
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(postModifyRequest))
+                    )
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E403001"))
+                    .andExpect(jsonPath("$.error.message").value("게시글 수정은 작성자만 할 수 있습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("게시글 제목"),
+                                    fieldWithPath("content").type(STRING).description("게시글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 유효하지 않으면 예외가 발생한다")
+        void postModifyInvalidAccessToken() throws Exception {
+            PostModifyRequest postModifyRequest = PostModifyRequest.builder()
+                    .title("title")
+                    .content("content")
+                    .build();
+
+            willThrow(new InvalidTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(put("/api/posts/{postId}", 1)
+                            .header("Authorization", "Bearer invalid-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(postModifyRequest))
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401002"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 유효하지 않습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("게시글 제목"),
+                                    fieldWithPath("content").type(STRING).description("게시글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 만료되면 예외가 발생한다")
+        void postModifyExpiredAccessToken() throws Exception {
+            PostModifyRequest postModifyRequest = PostModifyRequest.builder()
+                    .title("title")
+                    .content("content")
+                    .build();
+
+            willThrow(new ExpiredTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(put("/api/posts/{postId}", 1)
+                            .header("Authorization", "Bearer expired-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(postModifyRequest))
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401003"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 만료되었습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("게시글 제목"),
+                                    fieldWithPath("content").type(STRING).description("게시글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
     }
 
-    @Test
-    @DisplayName("게시글 목록을 조회한다")
-    void postList() throws Exception {
-        List<PostListItem> posts = List.of(
-                new PostListItem(1L, "제목", "작성자", 5, LocalDateTime.of(2024, 6, 17, 0, 0))
-        );
-        PostListResponse postListResponse = new PostListResponse(posts, 1, 1, 1, false, false, true, true);
+    @Nested
+    @DisplayName("게시글 삭제 요청")
+    class PostDeleteTest {
 
-        given(postService.postList(anyInt())).willReturn(postListResponse);
+        @Test
+        @DisplayName("게시글을 삭제한다")
+        void postDelete() throws Exception {
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
 
-        mockMvc.perform(get("/api/posts")
-                        .param("page", "1")
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result.posts[0].postId").value(1))
-                .andExpect(jsonPath("$.result.posts[0].title").value("제목"))
-                .andExpect(jsonPath("$.result.posts[0].writer").value("작성자"))
-                .andExpect(jsonPath("$.result.posts[0].commentCount").value(5))
-                .andExpect(jsonPath("$.result.posts[0].createdAt").value("2024-06-17T00:00:00"))
-                .andExpect(jsonPath("$.result.page").value(1))
-                .andExpect(jsonPath("$.result.totalPages").value(1))
-                .andExpect(jsonPath("$.result.totalElements").value(1))
-                .andExpect(jsonPath("$.result.prev").value(false))
-                .andExpect(jsonPath("$.result.next").value(false))
-                .andExpect(jsonPath("$.result.first").value(true))
-                .andExpect(jsonPath("$.result.last").value(true))
-                .andDo(restDocs.document(
-                        queryParameters(
-                                parameterWithName("page").description("페이지 번호")
-                        ),
-                        responseFields(
-                                commonSuccessResponse())
-                                .and(
-                                        fieldWithPath("result.posts").type(ARRAY).description("게시글 목록"),
-                                        fieldWithPath("result.posts[].postId").type(NUMBER).description("게시글 번호"),
-                                        fieldWithPath("result.posts[].title").type(STRING).description("게시글 제목"),
-                                        fieldWithPath("result.posts[].writer").type(STRING).description("게시글 제목"),
-                                        fieldWithPath("result.posts[].commentCount").type(NUMBER).description("댓글 개수"),
-                                        fieldWithPath("result.posts[].createdAt").type(STRING).description("게시글 제목"),
-                                        fieldWithPath("result.page").type(NUMBER).description("페이지 번호"),
-                                        fieldWithPath("result.totalPages").type(NUMBER).description("전체 페이지 개수"),
-                                        fieldWithPath("result.totalElements").type(NUMBER).description("전체 게시글 개수"),
-                                        fieldWithPath("result.prev").type(BOOLEAN).description("이전 페이지 이동 가능 여부"),
-                                        fieldWithPath("result.next").type(BOOLEAN).description("다음 페이지 이동 가능 여부"),
-                                        fieldWithPath("result.first").type(BOOLEAN).description("첫 번째 페이지 여부"),
-                                        fieldWithPath("result.last").type(BOOLEAN).description("마지막 페이지 여부")
-                                )
-                ));
-    }
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willDoNothing().given(postService).postDelete(anyLong(), anyLong());
 
-    @Test
-    @DisplayName("게시글을 검색한다")
-    void postListSearch() throws Exception {
-        List<PostListItem> posts = List.of(
-                new PostListItem(1L, "제목", "작성자", 5, LocalDateTime.of(2024, 6, 17, 0, 0))
-        );
-        PostListResponse postListResponse = new PostListResponse(posts, 1, 1, 1, false, false, true, true);
+            mockMvc.perform(delete("/api/posts/{postId}", 1)
+                            .header("Authorization", "Bearer access-token")
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+        }
 
-        given(postService.postListSearch(anyInt(), anyString(), anyString())).willReturn(postListResponse);
+        @Test
+        @DisplayName("게시글이 존재하지 않으면 예외가 발생한다")
+        void postDeleteNotFoundPost() throws Exception {
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
 
-        mockMvc.perform(get("/api/posts/search")
-                        .param("page", "1")
-                        .param("type", "title")
-                        .param("keyword", "제목")
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result.posts[0].postId").value(1))
-                .andExpect(jsonPath("$.result.posts[0].title").value("제목"))
-                .andExpect(jsonPath("$.result.posts[0].writer").value("작성자"))
-                .andExpect(jsonPath("$.result.posts[0].commentCount").value(5))
-                .andExpect(jsonPath("$.result.posts[0].createdAt").value("2024-06-17T00:00:00"))
-                .andExpect(jsonPath("$.result.page").value(1))
-                .andExpect(jsonPath("$.result.totalPages").value(1))
-                .andExpect(jsonPath("$.result.totalElements").value(1))
-                .andExpect(jsonPath("$.result.prev").value(false))
-                .andExpect(jsonPath("$.result.next").value(false))
-                .andExpect(jsonPath("$.result.first").value(true))
-                .andExpect(jsonPath("$.result.last").value(true))
-                .andDo(restDocs.document(
-                        queryParameters(
-                                parameterWithName("page").description("페이지 번호"),
-                                parameterWithName("type").description("검색 기준"),
-                                parameterWithName("keyword").description("검색 단어")
-                        ),
-                        responseFields(
-                                commonSuccessResponse())
-                                .and(
-                                        fieldWithPath("result.posts").type(ARRAY).description("게시글 목록"),
-                                        fieldWithPath("result.posts[].postId").type(NUMBER).description("게시글 번호"),
-                                        fieldWithPath("result.posts[].title").type(STRING).description("게시글 제목"),
-                                        fieldWithPath("result.posts[].writer").type(STRING).description("게시글 제목"),
-                                        fieldWithPath("result.posts[].commentCount").type(NUMBER).description("댓글 개수"),
-                                        fieldWithPath("result.posts[].createdAt").type(STRING).description("게시글 제목"),
-                                        fieldWithPath("result.page").type(NUMBER).description("페이지 번호"),
-                                        fieldWithPath("result.totalPages").type(NUMBER).description("전체 페이지 개수"),
-                                        fieldWithPath("result.totalElements").type(NUMBER).description("전체 게시글 개수"),
-                                        fieldWithPath("result.prev").type(BOOLEAN).description("이전 페이지 이동 가능 여부"),
-                                        fieldWithPath("result.next").type(BOOLEAN).description("다음 페이지 이동 가능 여부"),
-                                        fieldWithPath("result.first").type(BOOLEAN).description("첫 번째 페이지 여부"),
-                                        fieldWithPath("result.last").type(BOOLEAN).description("마지막 페이지 여부")
-                                )
-                ));
-    }
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willThrow(new NotFoundPostException()).given(postService).postDelete(anyLong(), anyLong());
 
-    @Test
-    @DisplayName("게시글을 수정한다")
-    void postModify() throws Exception {
-        PostModifyRequest postModifyRequest = new PostModifyRequest("제목", "내용");
+            mockMvc.perform(delete("/api/posts/{postId}", 1)
+                            .header("Authorization", "Bearer access-token")
+                    )
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E404002"))
+                    .andExpect(jsonPath("$.error.message").value("게시글을 찾을 수 없습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willDoNothing().given(postService).postModify(anyLong(), any(PostModifyRequest.class), anyString());
+        @Test
+        @DisplayName("작성자가 아닌데 삭제를 시도하면 예외가 발생한다")
+        void postDeletNotPostOwner() throws Exception {
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
 
-        mockMvc.perform(put("/api/posts/{postId}", 1)
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(postModifyRequest))
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호")
-                        ),
-                        requestFields(
-                                fieldWithPath("title").type(STRING).description("제목"),
-                                fieldWithPath("content").type(STRING).description("내용")
-                        ),
-                        responseFields(
-                                commonSuccessResponse()
-                        )
-                ));
-    }
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willThrow(new PostDeleteAccessDeniedException()).given(postService).postDelete(anyLong(), anyLong());
 
-    @Test
-    @DisplayName("게시글 수정 시 입력값이 잘못되면 예외가 발생한다")
-    void postModifyInvalidInputValue() throws Exception {
-        PostModifyRequest invalidPostModifyRequest = new PostModifyRequest("", "내용");
+            mockMvc.perform(delete("/api/posts/{postId}", 1)
+                            .header("Authorization", "Bearer access-token")
+                    )
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E403002"))
+                    .andExpect(jsonPath("$.error.message").value("게시글 삭제는 작성자만 할 수 있습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willDoNothing().given(postService).postModify(anyLong(), any(PostModifyRequest.class), anyString());
+        @Test
+        @DisplayName("액세스 토큰이 유효하지 않으면 예외가 발생한다")
+        void postDeleteInvalidAccessToken() throws Exception {
+            willThrow(new InvalidTokenException()).given(jwtManager).getPayload(anyString());
 
-        mockMvc.perform(put("/api/posts/{postId}", 1)
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidPostModifyRequest))
-                )
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.result.path").value("/api/posts/1"))
-                .andExpect(jsonPath("$.result.error.code").value("E400001"))
-                .andExpect(jsonPath("$.result.error.message").value("입력값이 잘못되었습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].field").value("title"))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].input").value(""))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].message").value("제목을 입력해 주세요."))
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호")
-                        ),
-                        requestFields(
-                                fieldWithPath("title").type(STRING).description("제목"),
-                                fieldWithPath("content").type(STRING).description("내용")
-                        ),
-                        responseFields(
-                                commonErrorResponse())
-                                .and(
-                                        fieldWithPath("result.error.fieldErrors[].field").description(STRING).description("필드명"),
-                                        fieldWithPath("result.error.fieldErrors[].input").description(STRING).description("입력값"),
-                                        fieldWithPath("result.error.fieldErrors[].message").description(STRING).description("메시지")
-                                )
-                ));
-    }
+            mockMvc.perform(delete("/api/posts/{postId}", 1)
+                            .header("Authorization", "Bearer invalid-token")
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401002"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 유효하지 않습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
 
-    @Test
-    @DisplayName("게시글 수정 시 게시글을 찾을 수 없으면 예외가 발생한다")
-    void postModifyNotFoundPost() throws Exception {
-        PostModifyRequest postModifyRequest = new PostModifyRequest("제목", "내용");
+        @Test
+        @DisplayName("액세스 토큰이 만료되면 예외가 발생한다")
+        void postDeleteExpiredAccessToken() throws Exception {
+            willThrow(new ExpiredTokenException()).given(jwtManager).getPayload(anyString());
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willThrow(new NotFoundPostException()).given(postService).postModify(anyLong(), any(PostModifyRequest.class), anyString());
+            mockMvc.perform(delete("/api/posts/{postId}", 1)
+                            .header("Authorization", "Bearer expired-token")
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401003"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 만료되었습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
 
-        mockMvc.perform(put("/api/posts/{postId}", 1)
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(postModifyRequest))
-                )
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(404))
-                .andExpect(jsonPath("$.result.path").value("/api/posts/1"))
-                .andExpect(jsonPath("$.result.error.code").value("E404002"))
-                .andExpect(jsonPath("$.result.error.message").value("게시글을 찾을 수 없습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("Access Token")
-                        ),
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호")
-                        ),
-                        requestFields(
-                                fieldWithPath("title").type(STRING).description("제목"),
-                                fieldWithPath("content").type(STRING).description("내용")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("게시글 수정 시 작성자가 아닌데 수정을 시도할 경우 예외가 발생한다")
-    void postModifyNotPostOwner() throws Exception {
-        PostModifyRequest postModifyRequest = new PostModifyRequest("제목", "내용");
-
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willThrow(new PostModifyAccessDeniedException()).given(postService).postModify(anyLong(), any(PostModifyRequest.class), anyString());
-
-        mockMvc.perform(put("/api/posts/{postId}", 1)
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(postModifyRequest))
-                )
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(403))
-                .andExpect(jsonPath("$.result.path").value("/api/posts/1"))
-                .andExpect(jsonPath("$.result.error.code").value("E403001"))
-                .andExpect(jsonPath("$.result.error.message").value("게시글 수정은 작성자만 할 수 있습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("Access Token")
-                        ),
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호")
-                        ),
-                        requestFields(
-                                fieldWithPath("title").type(STRING).description("제목"),
-                                fieldWithPath("content").type(STRING).description("내용")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("게시글을 삭제한다")
-    void postDelete() throws Exception {
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willDoNothing().given(postService).postDelete(anyLong(), anyString());
-
-        mockMvc.perform(delete("/api/posts/{postId}", 1)
-                        .header("Authorization", "Bearer access-token")
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호")
-                        ),
-                        responseFields(
-                                commonSuccessResponse()
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("게시글 삭제 시 게시글을 찾을 수 없으면 예외가 발생한다")
-    void postDeleteNotFoundPost() throws Exception {
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willThrow(new NotFoundPostException()).given(postService).postDelete(anyLong(), anyString());
-
-        mockMvc.perform(delete("/api/posts/{postId}", 1)
-                        .header("Authorization", "Bearer access-token")
-                )
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(404))
-                .andExpect(jsonPath("$.result.path").value("/api/posts/1"))
-                .andExpect(jsonPath("$.result.error.code").value("E404002"))
-                .andExpect(jsonPath("$.result.error.message").value("게시글을 찾을 수 없습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("게시글 삭제 시 작성자가 아닌데 삭제를 시도할 경우 예외가 발생한다")
-    void postDeleteNotPostOwner() throws Exception {
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willThrow(new PostDeleteAccessDeniedException()).given(postService).postDelete(anyLong(), anyString());
-
-        mockMvc.perform(delete("/api/posts/{postId}", 1)
-                        .header("Authorization", "Bearer access-token")
-                )
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(403))
-                .andExpect(jsonPath("$.result.path").value("/api/posts/1"))
-                .andExpect(jsonPath("$.result.error.code").value("E403002"))
-                .andExpect(jsonPath("$.result.error.message").value("게시글 삭제는 작성자만 할 수 있습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
     }
 
 }

--- a/backend/src/test/java/com/board/domain/post/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/post/repository/PostRepositoryTest.java
@@ -2,182 +2,258 @@ package com.board.domain.post.repository;
 
 import com.board.domain.member.entity.Member;
 import com.board.domain.member.repository.MemberRepository;
-import com.board.domain.post.dto.PostListItem;
+import com.board.domain.post.dto.PostListResponse;
 import com.board.domain.post.entity.Post;
-import com.board.global.common.config.JpaAuditConfig;
-import com.board.support.config.QuerydslConfig;
+import com.board.domain.post.exception.NotFoundPostException;
+import com.board.support.RepositoryTest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.Page;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@DataJpaTest
-@Import({JpaAuditConfig.class, QuerydslConfig.class})
-class PostRepositoryTest {
-
-    @Autowired
-    private PostRepository postRepository;
+class PostRepositoryTest extends RepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private PostRepository postRepository;
+
     private Member member;
+    private Member memberB;
 
     @BeforeEach
     void setUp() {
-        member = memberRepository.save(Member.builder()
+        member = Member.builder()
                 .nickname("yoonkun")
                 .username("yoon1234")
-                .password("12345678")
-                .build());
-    }
-
-    @Test
-    @DisplayName("게시글을 저장한다")
-    void postSave() {
-        Post post = Post.builder()
-                .title("제목")
-                .content("내용")
-                .member(member)
+                .password(new BCryptPasswordEncoder().encode("12345678"))
                 .build();
-
-        Post savePost = postRepository.save(post);
-
-        assertThat(savePost.getId()).isNotNull();
-    }
-
-    @Test
-    @DisplayName("게시글 기본키로 상세조회 한다")
-    void postDetail() {
-        Post post = Post.builder()
-                .title("제목")
-                .content("내용")
-                .member(member)
+        memberB = Member.builder()
+                .nickname("yoongun")
+                .username("yoon5678")
+                .password(new BCryptPasswordEncoder().encode("12345678"))
                 .build();
-        Post savePost = postRepository.save(post);
-
-        Post findPost = postRepository.findById(savePost.getId()).get();
-
-        assertThat(findPost.getTitle()).isEqualTo("제목");
-        assertThat(findPost.getContent()).isEqualTo("내용");
+        memberRepository.save(member);
+        memberRepository.save(memberB);
     }
 
-    @Test
-    @DisplayName("게시글과 해당 게시글을 작성한 회원을 한 번에 조회한다")
-    void findPostJoinFetch() {
-        Post post = Post.builder()
-                .title("제목")
-                .content("내용")
-                .member(member)
-                .build();
-        Post savePost = postRepository.save(post);
+    @Nested
+    @DisplayName("게시글 저장")
+    class PostSaveTest {
 
-        Post findPost = postRepository.findPostJoinFetch(savePost.getId()).get();
+        @Test
+        @DisplayName("게시글을 저장한다")
+        void save() {
+            Post post = Post.builder()
+                    .title("title")
+                    .writer(member.getNickname())
+                    .content("content")
+                    .member(member)
+                    .build();
 
-        assertThat(findPost.getTitle()).isEqualTo("제목");
-        assertThat(findPost.getContent()).isEqualTo("내용");
-        assertThat(findPost.getMember().getNickname()).isEqualTo("yoonkun");
-        assertThat(findPost.getMember().getUsername()).isEqualTo("yoon1234");
+            Post savePost = postRepository.save(post);
+
+            assertThat(savePost.getId()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("제목이 Null이면 예외가 발생한다")
+        void saveNullTitle() {
+            Post post = Post.builder()
+                    .writer(member.getNickname())
+                    .content("content")
+                    .member(member)
+                    .build();
+
+            assertThatThrownBy(() -> postRepository.save(post))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("작성자가 Null이면 예외가 발생한다")
+        void saveNullWriter() {
+            Post post = Post.builder()
+                    .title("title")
+                    .content("content")
+                    .member(member)
+                    .build();
+
+            assertThatThrownBy(() -> postRepository.save(post))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("내용이 Null이면 예외가 발생한다")
+        void saveNullContent() {
+            Post post = Post.builder()
+                    .title("title")
+                    .writer(member.getNickname())
+                    .member(member)
+                    .build();
+
+            assertThatThrownBy(() -> postRepository.save(post))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("회원이 Null이면 예외가 발생한다")
+        void saveNullMember() {
+            Post post = Post.builder()
+                    .title("title")
+                    .writer(member.getNickname())
+                    .content("content")
+                    .build();
+
+            assertThatThrownBy(() -> postRepository.save(post))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
     }
 
-    @Test
-    @DisplayName("게시글 목록을 조회한다")
-    void postFindAll() {
-        List<Post> content = List.of(
-                Post.builder().title("제목").content("내용").member(member).build(),
-                Post.builder().title("제목").content("내용").member(member).build(),
-                Post.builder().title("제목").content("내용").member(member).build(),
-                Post.builder().title("제목").content("내용").member(member).build(),
-                Post.builder().title("제목").content("내용").member(member).build()
-        );
-        postRepository.saveAll(content);
+    @Nested
+    @DisplayName("게시글 단건 조회")
+    class PostFindTest {
 
-        Pageable pageable = PageRequest.of(0, 10, Sort.Direction.DESC, "id");
-        Page<PostListItem> postPage = postRepository.findPosts(pageable);
+        @Test
+        @DisplayName("게시글 기본키(id)로 조회한다")
+        void findByPostId() {
+            Post post = Post.builder()
+                    .title("title")
+                    .writer(member.getNickname())
+                    .content("content")
+                    .member(member)
+                    .build();
+            postRepository.save(post);
 
-        assertThat(postPage.getNumber()).isEqualTo(0);
-        assertThat(postPage.getTotalPages()).isEqualTo(1);
-        assertThat(postPage.getTotalElements()).isEqualTo(5);
-        assertThat(postPage.hasPrevious()).isFalse();
-        assertThat(postPage.hasNext()).isFalse();
-        assertThat(postPage.isFirst()).isTrue();
-        assertThat(postPage.isLast()).isTrue();
+            Post findPost = postRepository.findByPostId(post.getId());
+
+            assertThat(findPost.getTitle()).isEqualTo("title");
+            assertThat(findPost.getWriter()).isEqualTo("yoonkun");
+            assertThat(findPost.getContent()).isEqualTo("content");
+        }
+
+        @Test
+        @DisplayName("기본키(id)에 해당하는 게시글이 없으면 예외가 발생한다")
+        void findByPostIdNotFoundPost() {
+            assertThatThrownBy(() -> postRepository.findByPostId(1L))
+                    .isInstanceOf(NotFoundPostException.class);
+        }
+
     }
 
-    @Test
-    @DisplayName("특정 단어가 포함된 게시글 목록을 조회한다")
-    void findPostsSearch() {
-        List<Post> content = List.of(
-                Post.builder().title("독수리").content("내용").member(member).build(),
-                Post.builder().title("기러기").content("내용").member(member).build(),
-                Post.builder().title("호랑이").content("내용").member(member).build(),
-                Post.builder().title("거북이").content("내용").member(member).build(),
-                Post.builder().title("코끼리").content("내용").member(member).build()
-        );
-        postRepository.saveAll(content);
+    @Nested
+    @DisplayName("게시글 목록 조회")
+    @Transactional
+    class PostListFindTest {
 
-        Pageable pageable = PageRequest.of(0, 10, Sort.Direction.DESC, "id");
-        Page<PostListItem> postPage = postRepository.findPostsSearch(pageable, "title", "이");
+        @Test
+        @DisplayName("게시글 목록을 조회한다")
+        void findPostList() {
+            postRepository.saveAll(postList());
 
-        assertThat(postPage.getNumber()).isEqualTo(0);
-        assertThat(postPage.getTotalPages()).isEqualTo(1);
-        assertThat(postPage.getTotalElements()).isEqualTo(2);
-        assertThat(postPage.hasPrevious()).isFalse();
-        assertThat(postPage.hasNext()).isFalse();
-        assertThat(postPage.isFirst()).isTrue();
-        assertThat(postPage.isLast()).isTrue();
+            PostListResponse postListResponse = postRepository.findPostList(PageRequest.of(0, 10));
+
+            assertThat(postListResponse.getPage()).isEqualTo(1);
+            assertThat(postListResponse.getTotalPages()).isEqualTo(1);
+            assertThat(postListResponse.getTotalElements()).isEqualTo(4);
+            assertThat(postListResponse.isNext()).isFalse();
+            assertThat(postListResponse.isPrev()).isFalse();
+            assertThat(postListResponse.isFirst()).isTrue();
+            assertThat(postListResponse.isLast()).isTrue();
+        }
+
+        @Test
+        @DisplayName("제목이 apple인 게시글 목록을 조회한다")
+        void findSearchTitlePostList() {
+            postRepository.saveAll(postList());
+
+            PostListResponse postListResponse = postRepository.findPostSearchList(PageRequest.of(0, 10), "title", "apple");
+
+            assertThat(postListResponse.getPage()).isEqualTo(1);
+            assertThat(postListResponse.getTotalPages()).isEqualTo(1);
+            assertThat(postListResponse.getTotalElements()).isEqualTo(2);
+            assertThat(postListResponse.isNext()).isFalse();
+            assertThat(postListResponse.isPrev()).isFalse();
+            assertThat(postListResponse.isFirst()).isTrue();
+            assertThat(postListResponse.isLast()).isTrue();
+        }
+
+        @Test
+        @DisplayName("작성자가 yoonkun인 게시글 목록을 조회한다")
+        void findSearchWriterPostList() {
+            postRepository.saveAll(postList());
+
+            PostListResponse postListResponse = postRepository.findPostSearchList(PageRequest.of(0, 10), "writer", "yoonkun");
+
+            assertThat(postListResponse.getPage()).isEqualTo(1);
+            assertThat(postListResponse.getTotalPages()).isEqualTo(1);
+            assertThat(postListResponse.getTotalElements()).isEqualTo(2);
+            assertThat(postListResponse.isNext()).isFalse();
+            assertThat(postListResponse.isPrev()).isFalse();
+            assertThat(postListResponse.isFirst()).isTrue();
+            assertThat(postListResponse.isLast()).isTrue();
+        }
+
+        @Test
+        @DisplayName("자신이 작성한 게시글 목록을 조회한다")
+        void findmemberPostList() {
+            postRepository.saveAll(postList());
+
+            PostListResponse postListResponse = postRepository.findPostMemberList(PageRequest.of(0, 10), member.getId());
+
+            assertThat(postListResponse.getPage()).isEqualTo(1);
+            assertThat(postListResponse.getTotalPages()).isEqualTo(1);
+            assertThat(postListResponse.getTotalElements()).isEqualTo(2);
+            assertThat(postListResponse.isNext()).isFalse();
+            assertThat(postListResponse.isPrev()).isFalse();
+            assertThat(postListResponse.isFirst()).isTrue();
+            assertThat(postListResponse.isLast()).isTrue();
+        }
+
+        private List<Post> postList() {
+            return List.of(
+                    Post.builder().title("apple").writer("yoonkun").content("content").member(member).build(),
+                    Post.builder().title("banana").writer("yoongun").content("content").member(memberB).build(),
+                    Post.builder().title("apple").writer("yoonkun").content("content").member(member).build(),
+                    Post.builder().title("title").writer("yoongun").content("content").member(memberB).build()
+            );
+        }
+
     }
 
-    @Test
-    @DisplayName("게시글을 삭제한다")
-    void postDelete() {
-        Post post = Post.builder()
-                .title("제목")
-                .content("내용")
-                .member(member)
-                .build();
-        Post savePost = postRepository.save(post);
-        Post findPost = postRepository.findPostJoinFetch(savePost.getId()).get();
+    @Nested
+    @DisplayName("게시글 삭제")
+    class PostDelete {
 
-        postRepository.delete(findPost);
+        @Test
+        @DisplayName("게시글을 삭제한다")
+        void delete() {
+            Post post = Post.builder()
+                    .title("title")
+                    .writer(member.getNickname())
+                    .content("content")
+                    .member(member)
+                    .build();
+            postRepository.save(post);
 
-        assertThat(postRepository.findPostJoinFetch(savePost.getId())).isEmpty();
-    }
+            postRepository.delete(post);
 
-    @Test
-    @DisplayName("특정 회원이 작성한 게시글 목록을 조회한다")
-    void findPostsFromMember() {
-        List<Post> content = List.of(
-                Post.builder().title("독수리").content("내용").member(member).build(),
-                Post.builder().title("기러기").content("내용").member(member).build(),
-                Post.builder().title("호랑이").content("내용").member(member).build(),
-                Post.builder().title("거북이").content("내용").member(member).build(),
-                Post.builder().title("코끼리").content("내용").member(member).build()
-        );
-        postRepository.saveAll(content);
+            assertThat(postRepository.findById(post.getId())).isEmpty();
+        }
 
-        Pageable pageable = PageRequest.of(0, 10, Sort.Direction.DESC, "id");
-        Page<PostListItem> postPage = postRepository.findPostsFromMember(pageable, "yoon1234");
-
-        assertThat(postPage.getNumber()).isEqualTo(0);
-        assertThat(postPage.getTotalPages()).isEqualTo(1);
-        assertThat(postPage.getTotalElements()).isEqualTo(5);
-        assertThat(postPage.hasPrevious()).isFalse();
-        assertThat(postPage.hasNext()).isFalse();
-        assertThat(postPage.isFirst()).isTrue();
-        assertThat(postPage.isLast()).isTrue();
     }
 
 }

--- a/backend/src/test/java/com/board/domain/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/board/domain/post/service/PostServiceTest.java
@@ -3,7 +3,9 @@ package com.board.domain.post.service;
 import com.board.domain.member.entity.Member;
 import com.board.domain.member.exception.NotFoundMemberException;
 import com.board.domain.member.repository.MemberRepository;
-import com.board.domain.post.dto.PostListItem;
+import com.board.domain.post.dto.PostDetailResponse;
+import com.board.domain.post.dto.PostListResponse;
+import com.board.domain.post.dto.PostListResponse.PostItem;
 import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.entity.Post;
@@ -11,22 +13,24 @@ import com.board.domain.post.exception.NotFoundPostException;
 import com.board.domain.post.exception.PostDeleteAccessDeniedException;
 import com.board.domain.post.exception.PostModifyAccessDeniedException;
 import com.board.domain.post.repository.PostRepository;
+import com.board.support.ServiceTest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageImpl;
+
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -38,8 +42,7 @@ import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 
-@ExtendWith(MockitoExtension.class)
-class PostServiceTest {
+class PostServiceTest extends ServiceTest {
 
     @Mock
     private MemberRepository memberRepository;
@@ -57,220 +60,297 @@ class PostServiceTest {
         member = Member.builder()
                 .nickname("yoonkun")
                 .username("yoon1234")
+                .password(new BCryptPasswordEncoder().encode("12345678"))
                 .build();
+        ReflectionTestUtils.setField(member, "id", 1L);
     }
 
-    @Test
-    @DisplayName("게시글을 작성한다")
-    void postWrite() {
-        PostWriteRequest postWriteRequest = new PostWriteRequest("제목", "내용");
-        Post post = Post.builder()
-                .title(postWriteRequest.getTitle())
-                .content(postWriteRequest.getContent())
-                .member(member)
-                .build();
+    @Nested
+    @DisplayName("게시글 작성")
+    class PostWriteTest {
 
-        given(memberRepository.findMemberByUsername(anyString())).willReturn(Optional.of(member));
-        given(postRepository.save(any(Post.class))).willReturn(post);
+        @Test
+        @DisplayName("게시글을 작성한다")
+        void postWrite() {
+            PostWriteRequest postWriteRequest = PostWriteRequest.builder()
+                    .title("title")
+                    .content("content")
+                    .build();
 
-        postService.postWrite(postWriteRequest, "yoon1234");
+            Post post = Post.builder()
+                    .title("title")
+                    .writer(member.getNickname())
+                    .content("content")
+                    .member(member)
+                    .build();
 
-        then(memberRepository).should().findMemberByUsername(anyString());
-        then(postRepository).should().save(any(Post.class));
+            given(memberRepository.findByMemberId(anyLong())).willReturn(member);
+            given(postRepository.save(any(Post.class))).willReturn(post);
+
+            postService.postWrite(postWriteRequest, 1L);
+
+            then(memberRepository).should().findByMemberId(anyLong());
+            then(postRepository).should().save(any(Post.class));
+        }
+
+        @Test
+        @DisplayName("회원이 존재하지 않으면 예외가 발생한다")
+        void postWriteNotFoundMember() {
+            PostWriteRequest postWriteRequest = PostWriteRequest.builder()
+                    .title("title")
+                    .content("content")
+                    .build();
+
+            willThrow(new NotFoundMemberException()).given(memberRepository).findByMemberId(anyLong());
+
+            assertThatThrownBy(() -> postService.postWrite(postWriteRequest, 1L))
+                    .isInstanceOf(NotFoundMemberException.class);
+
+            then(memberRepository).should().findByMemberId(anyLong());
+            then(postRepository).should(never()).save(any(Post.class));
+        }
+
     }
 
-    @Test
-    @DisplayName("게시글 작성 시 회원을 찾을 수 없으면 예외가 발생한다")
-    void postWrite_notFoundPost() {
-        PostWriteRequest postWriteRequest = new PostWriteRequest("제목", "내용");
+    @Nested
+    @DisplayName("게시글 상세조회")
+    class PostDetailTest {
 
-        willThrow(new NotFoundMemberException()).given(memberRepository).findMemberByUsername(anyString());
+        @Test
+        @DisplayName("게시글을 상세조회 한다")
+        void postDetail() {
+            Post post = Post.builder()
+                    .title("title")
+                    .writer(member.getNickname())
+                    .content("content")
+                    .member(member)
+                    .build();
 
-        assertThatThrownBy(() -> postService.postWrite(postWriteRequest, "yoon1234"))
-                .isInstanceOf(NotFoundMemberException.class);
+            given(postRepository.findByPostId(anyLong())).willReturn(post);
 
-        then(memberRepository).should().findMemberByUsername(anyString());
-        then(postRepository).should(never()).save(any(Post.class));
+            PostDetailResponse response = postService.postDetail(1L);
+
+            assertThat(response.getTitle()).isEqualTo("title");
+            assertThat(response.getWriter()).isEqualTo("yoonkun");
+            assertThat(response.getContent()).isEqualTo("content");
+            then(postRepository).should().findByPostId(anyLong());
+        }
+
+        @Test
+        @DisplayName("게시글이 존재하지 않으면 예외가 발생한다")
+        void postDetailNotFoundMember() {
+            willThrow(new NotFoundPostException()).given(postRepository).findByPostId(anyLong());
+
+            assertThatThrownBy(() -> postService.postDetail(1L))
+                    .isInstanceOf(NotFoundPostException.class);
+
+            then(postRepository).should().findByPostId(anyLong());
+        }
+
     }
 
-    @Test
-    @DisplayName("게시글을 상세조회 한다")
-    void postDetail() {
-        Post post = Post.builder()
-                .title("제목")
-                .content("내용")
-                .member(member)
-                .build();
+    @Nested
+    @DisplayName("게시글 목록조회")
+    class PostListTest {
 
-        given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
+        @Test
+        @DisplayName("게시글 목록을 조회한다")
+        void findPostList() {
+            PostListResponse postListResponse = PostListResponse.builder()
+                    .posts(List.of(
+                            PostItem.builder()
+                                    .postId(1L)
+                                    .title("title")
+                                    .writer("writer")
+                                    .commentCount(0)
+                                    .createdAt(LocalDateTime.of(2024, 6, 17, 0, 0))
+                                    .build()
+                    ))
+                    .page(1)
+                    .totalPages(1)
+                    .totalElements(1)
+                    .first(true)
+                    .last(true)
+                    .prev(false)
+                    .next(false)
+                    .build();
 
-        postService.postDetail(1L);
+            given(postRepository.findPostList(any(Pageable.class))).willReturn(postListResponse);
 
-        then(postRepository).should().findById(anyLong());
+            PostListResponse response = postService.postList(0);
+
+            assertThat(response.getPosts().get(0).getPostId()).isEqualTo(1L);
+            assertThat(response.getPage()).isEqualTo(1);
+            assertThat(response.getTotalPages()).isEqualTo(1);
+            assertThat(response.getTotalElements()).isEqualTo(1);
+            assertThat(response.isFirst()).isTrue();
+            assertThat(response.isLast()).isTrue();
+            assertThat(response.isPrev()).isFalse();
+            assertThat(response.isNext()).isFalse();
+            then(postRepository).should().findPostList(any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("검색 조건에 맞는 게시글 목록을 조회한다")
+        void findSearchPostList() {
+            PostListResponse postListResponse = PostListResponse.builder()
+                    .posts(List.of(
+                            PostItem.builder()
+                                    .postId(1L)
+                                    .title("hello")
+                                    .writer("writer")
+                                    .commentCount(0)
+                                    .createdAt(LocalDateTime.of(2024, 6, 17, 0, 0))
+                                    .build()
+                    ))
+                    .page(1)
+                    .totalPages(1)
+                    .totalElements(1)
+                    .first(true)
+                    .last(true)
+                    .prev(false)
+                    .next(false)
+                    .build();
+
+            given(postRepository.findPostSearchList(any(Pageable.class), anyString(), anyString())).willReturn(postListResponse);
+
+            PostListResponse response = postService.postSearchList(0, "title", "hello");
+
+            assertThat(response.getPosts().get(0).getTitle()).isEqualTo("hello");
+            assertThat(response.getPage()).isEqualTo(1);
+            assertThat(response.getTotalPages()).isEqualTo(1);
+            assertThat(response.getTotalElements()).isEqualTo(1);
+            assertThat(response.isFirst()).isTrue();
+            assertThat(response.isLast()).isTrue();
+            assertThat(response.isPrev()).isFalse();
+            assertThat(response.isNext()).isFalse();
+            then(postRepository).should().findPostSearchList(any(Pageable.class), anyString(), anyString());
+        }
+
     }
 
-    @Test
-    @DisplayName("게시글 상세조회 시 게시글을 찾을 수 없으면 예외가 발생한다")
-    void postDetail_notFoundPost() {
-        willThrow(new NotFoundPostException()).given(postRepository).findById(anyLong());
+    @Nested
+    @DisplayName("게시글 수정")
+    class PostModifyTest {
 
-        assertThatThrownBy(() -> postService.postDetail(1L))
-                .isInstanceOf(NotFoundPostException.class);
+        @Test
+        @DisplayName("게시글을 수정한다")
+        void postModify() {
+            PostModifyRequest postModifyRequest = PostModifyRequest.builder()
+                    .title("newTitle")
+                    .content("newContent")
+                    .build();
 
-        then(postRepository).should().findById(anyLong());
+            Post post = Post.builder()
+                    .title("title")
+                    .writer(member.getNickname())
+                    .content("content")
+                    .member(member)
+                    .build();
+
+            given(postRepository.findByPostId(anyLong())).willReturn(post);
+
+            postService.postModify(1L, postModifyRequest, 1L);
+
+            then(postRepository).should().findByPostId(anyLong());
+        }
+
+        @Test
+        @DisplayName("게시글이 존재하지 않으면 예외가 발생한다")
+        void postModifyNotFoundPost() {
+            PostModifyRequest postModifyRequest = PostModifyRequest.builder()
+                    .title("newTitle")
+                    .content("newContent")
+                    .build();
+
+            willThrow(new NotFoundPostException()).given(postRepository).findByPostId(anyLong());
+
+            assertThatThrownBy(() -> postService.postModify(1L, postModifyRequest, 1L))
+                    .isInstanceOf(NotFoundPostException.class);
+
+            then(postRepository).should().findByPostId(anyLong());
+        }
+
+        @Test
+        @DisplayName("작성자가 아닌데 수정을 시도하면 예외가 발생한다")
+        void postModifyNotPostOwner() {
+            PostModifyRequest postModifyRequest = PostModifyRequest.builder()
+                    .title("newTitle")
+                    .content("newContent")
+                    .build();
+
+            Post post = Post.builder()
+                    .title("title")
+                    .writer(member.getNickname())
+                    .content("content")
+                    .member(member)
+                    .build();
+
+            given(postRepository.findByPostId(anyLong())).willReturn(post);
+
+            assertThatThrownBy(() -> postService.postModify(1L, postModifyRequest, 2L))
+                    .isInstanceOf(PostModifyAccessDeniedException.class);
+
+            then(postRepository).should().findByPostId(anyLong());
+        }
+
+
     }
 
-    @Test
-    @DisplayName("게시글 목록을 조회한다")
-    void postList() {
-        List<PostListItem> content = List.of(
-                new PostListItem(5L, "제목5", "작성자5", 0, LocalDateTime.now()),
-                new PostListItem(4L, "제목4", "작성자4", 0, LocalDateTime.now()),
-                new PostListItem(3L, "제목3", "작성자3", 0, LocalDateTime.now()),
-                new PostListItem(2L, "제목2", "작성자2", 0, LocalDateTime.now()),
-                new PostListItem(1L, "제목1", "작성자1", 0, LocalDateTime.now())
-        );
-        PageImpl<PostListItem> postPage = new PageImpl<>(content);
+    @Nested
+    @DisplayName("게시글 삭제")
+    class PostDeleteTest {
 
-        given(postRepository.findPosts(any(Pageable.class))).willReturn(postPage);
+        @Test
+        @DisplayName("게시글을 삭제한다")
+        void postDelete() {
+            Post post = Post.builder()
+                    .title("title")
+                    .writer(member.getNickname())
+                    .content("content")
+                    .member(member)
+                    .build();
 
-        postService.postList(1);
+            given(postRepository.findByPostId(anyLong())).willReturn(post);
+            willDoNothing().given(postRepository).delete(any(Post.class));
 
-        then(postRepository).should().findPosts(any(Pageable.class));
-    }
+            postService.postDelete(1L, 1L);
 
-    @Test
-    @DisplayName("게시글을 검색한다")
-    void postListSearch() {
-        List<PostListItem> content = List.of(
-                new PostListItem(5L, "제목5", "작성자5", 0, LocalDateTime.now()),
-                new PostListItem(4L, "제목4", "작성자4", 0, LocalDateTime.now()),
-                new PostListItem(3L, "제목3", "작성자3", 0, LocalDateTime.now()),
-                new PostListItem(2L, "제목2", "작성자2", 0, LocalDateTime.now()),
-                new PostListItem(1L, "제목1", "작성자1", 0, LocalDateTime.now())
-        );
-        PageImpl<PostListItem> postPage = new PageImpl<>(content);
+            then(postRepository).should().findByPostId(anyLong());
+            then(postRepository).should().delete(any(Post.class));
+        }
 
-        given(postRepository.findPostsSearch(any(Pageable.class), anyString(), anyString())).willReturn(postPage);
+        @Test
+        @DisplayName("게시글이 존재하지 않으면 예외가 발생한다")
+        void postDeleteNotFoundPost() {
+            willThrow(new NotFoundPostException()).given(postRepository).findByPostId(anyLong());
 
-        postService.postListSearch(1, "title", "제목");
+            assertThatThrownBy(() -> postService.postDelete(1L, 1L))
+                    .isInstanceOf(NotFoundPostException.class);
 
-        then(postRepository).should().findPostsSearch(any(Pageable.class), anyString(), anyString());
-    }
+            then(postRepository).should().findByPostId(anyLong());
+            then(postRepository).should(never()).delete(any(Post.class));
+        }
 
-    @Test
-    @DisplayName("게시글을 수정한다")
-    void postModify() {
-        PostModifyRequest postModifyRequest = new PostModifyRequest("제목", "내용");
-        Post post = Post.builder()
-                .title("제목")
-                .content("내용")
-                .member(member)
-                .build();
+        @Test
+        @DisplayName("작성자가 아닌데 삭제를 시도하면 예외가 발생한다")
+        void postDeleteNotPostOwner() {
+            Post post = Post.builder()
+                    .title("title")
+                    .writer(member.getNickname())
+                    .content("content")
+                    .member(member)
+                    .build();
 
-        given(postRepository.findPostJoinFetch(anyLong())).willReturn(Optional.of(post));
+            given(postRepository.findByPostId(anyLong())).willReturn(post);
 
-        postService.postModify(1L, postModifyRequest, "yoon1234");
+            assertThatThrownBy(() -> postService.postDelete(1L, 2L))
+                    .isInstanceOf(PostDeleteAccessDeniedException.class);
 
-        then(postRepository).should().findPostJoinFetch(anyLong());
-    }
+            then(postRepository).should().findByPostId(anyLong());
+            then(postRepository).should(never()).delete(any(Post.class));
+        }
 
-    @Test
-    @DisplayName("게시글 수정 시 게시글을 찾을 수 없으면 예외가 발생한다")
-    void postModify_notFoundPost() {
-        PostModifyRequest postModifyRequest = new PostModifyRequest("제목", "내용");
-
-        willThrow(new NotFoundPostException()).given(postRepository).findPostJoinFetch(anyLong());
-
-        assertThatThrownBy(() -> postService.postModify(1L, postModifyRequest, "yoon1234"))
-                .isInstanceOf(NotFoundPostException.class);
-
-        then(postRepository).should().findPostJoinFetch(anyLong());
-    }
-
-    @Test
-    @DisplayName("게시글 수정 시 작성자가 아닌데 수정을 시도할 경우 예외가 발생한다")
-    void postModify_notPostOwner() {
-        PostModifyRequest postModifyRequest = new PostModifyRequest("제목", "내용");
-        Post post = Post.builder()
-                .title("제목")
-                .content("내용")
-                .member(member)
-                .build();
-
-        given(postRepository.findPostJoinFetch(anyLong())).willReturn(Optional.of(post));
-
-        assertThatThrownBy(() -> postService.postModify(1L, postModifyRequest, "unknown"))
-                .isInstanceOf(PostModifyAccessDeniedException.class);
-
-        then(postRepository).should().findPostJoinFetch(anyLong());
-    }
-
-    @Test
-    @DisplayName("게시글을 삭제한다")
-    void postDelete() {
-        Post post = Post.builder()
-                .title("제목")
-                .content("내용")
-                .member(member)
-                .build();
-
-        given(postRepository.findPostJoinFetch(anyLong())).willReturn(Optional.of(post));
-        willDoNothing().given(postRepository).delete(any(Post.class));
-
-        postService.postDelete(1L, "yoon1234");
-
-        then(postRepository).should().findPostJoinFetch(anyLong());
-        then(postRepository).should().delete(any(Post.class));
-    }
-
-    @Test
-    @DisplayName("게시글 삭제 시 게시글을 찾을 수 없으면 예외가 발생한다")
-    void postDelete_notFoundPost() {
-        willThrow(new NotFoundPostException()).given(postRepository).findPostJoinFetch(anyLong());
-
-        assertThatThrownBy(() -> postService.postDelete(1L, "yoon1234"))
-                .isInstanceOf(NotFoundPostException.class);
-
-        then(postRepository).should().findPostJoinFetch(anyLong());
-        then(postRepository).should(never()).delete(any(Post.class));
-    }
-
-    @Test
-    @DisplayName("게시글 삭제 시 작성자가 아닌데 삭제를 시도할 경우 예외가 발생한다")
-    void postDelete_notPostOwner() {
-        Post post = Post.builder()
-                .title("제목")
-                .content("내용")
-                .member(member)
-                .build();
-
-        given(postRepository.findPostJoinFetch(anyLong())).willReturn(Optional.of(post));
-
-        assertThatThrownBy(() -> postService.postDelete(1L, "unknown"))
-                .isInstanceOf(PostDeleteAccessDeniedException.class);
-
-        then(postRepository).should().findPostJoinFetch(anyLong());
-        then(postRepository).should(never()).delete(any(Post.class));
-    }
-
-    @Test
-    @DisplayName("특정 회원이 작성한 게시글 목록을 조회한다")
-    void postListFromMember() {
-        List<PostListItem> content = List.of(
-                new PostListItem(5L, "제목5", "작성자5", 0, LocalDateTime.now()),
-                new PostListItem(4L, "제목4", "작성자4", 0, LocalDateTime.now()),
-                new PostListItem(3L, "제목3", "작성자3", 0, LocalDateTime.now()),
-                new PostListItem(2L, "제목2", "작성자2", 0, LocalDateTime.now()),
-                new PostListItem(1L, "제목1", "작성자1", 0, LocalDateTime.now())
-        );
-        PageImpl<PostListItem> postPage = new PageImpl<>(content);
-
-        given(postRepository.findPostsFromMember(any(Pageable.class), anyString())).willReturn(postPage);
-
-        postService.postListFromMember(0, "yoon1234");
-
-        then(postRepository).should().findPostsFromMember(any(Pageable.class), anyString());
     }
 
 }

--- a/backend/src/test/java/com/board/support/ControllerTest.java
+++ b/backend/src/test/java/com/board/support/ControllerTest.java
@@ -1,13 +1,12 @@
 package com.board.support;
 
 import com.board.domain.token.service.TokenService;
+import com.board.global.common.config.ObjectMapperConfig;
 import com.board.global.security.config.SecurityConfig;
+import com.board.global.security.support.JwtManager;
 import com.board.support.config.RestDocsConfig;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,15 +28,18 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
-import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.OBJECT;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 
-@Import({SecurityConfig.class, RestDocsConfig.class})
+@Import({
+        SecurityConfig.class,
+        RestDocsConfig.class,
+        ObjectMapperConfig.class
+})
 @ExtendWith(RestDocumentationExtension.class)
-public abstract class RestDocsTestSupport {
+public abstract class ControllerTest {
 
     @Autowired
     protected ObjectMapper objectMapper;
@@ -54,6 +56,9 @@ public abstract class RestDocsTestSupport {
     @MockBean
     protected TokenService tokenService;
 
+    @MockBean
+    protected JwtManager jwtManager;
+
     @BeforeEach
     void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
@@ -65,31 +70,20 @@ public abstract class RestDocsTestSupport {
                 .build();
     }
 
-    protected Claims mockClaims() {
-        return Jwts.claims().subject("yoon1234")
-                .add("nickname", "yoonkun")
-                .add("authority", "ROLE_MEMBER")
-                .build();
-    }
-
     protected FieldDescriptor[] commonSuccessResponse() {
         return new FieldDescriptor[] {
-                fieldWithPath("message").type(STRING).description("요청 성공/실패 여부"),
-                fieldWithPath("status").type(NUMBER).description("Http 상태 코드"),
-                subsectionWithPath("result").description("요청 결과 데이터"),
+                fieldWithPath("status").type(STRING).description("API 요청 성공/실패 상태"),
+                subsectionWithPath("data").type(OBJECT).description("응답 데이터").optional()
         };
     }
 
     protected FieldDescriptor[] commonErrorResponse() {
         return new FieldDescriptor[] {
-                fieldWithPath("message").type(STRING).description("요청 성공/실패 여부"),
-                fieldWithPath("status").type(NUMBER).description("Http 상태 코드"),
-                fieldWithPath("result").type(OBJECT).description("에러 결과 데이터"),
-                fieldWithPath("result.timeStamp").type(STRING).description("에러 발생 시간"),
-                fieldWithPath("result.path").type(STRING).description("요청 api 경로"),
-                fieldWithPath("result.error.code").type(STRING).description("에러 코드"),
-                fieldWithPath("result.error.message").type(STRING).description("에러 메시지"),
-                subsectionWithPath("result.error.fieldErrors").type(ARRAY).description("유효성 검증 에러 필드 목록"),
+                fieldWithPath("status").type(STRING).description("API 요청 성공/실패 상태"),
+                subsectionWithPath("error").type(OBJECT).description("에러 데이터"),
+                fieldWithPath("error.code").type(STRING).description("에러 코드"),
+                fieldWithPath("error.message").type(STRING).description("에러 메시지"),
+                subsectionWithPath("error.fields").type(ARRAY).description("유효성 에러 필드"),
         };
     }
 


### PR DESCRIPTION
## 설명

게시글 단건 조회 기능 리팩토링

## 주요 변경 사항

- findPostJoinFetch() 메서드 제거
- 게시글 단건 조회 메서드를 PostRepository 인터페이스에 디폴트 메서드로 정의

## 구현 내용

### 1. findPostJoinFetch() 메서드 제거

- 그 동안 페치조인이 필요했던 이유는 게시글 수정 및 삭제 시 작성자가 맞는지 검사하는 로직에 로그인 사용자의 아이디와 비교하는 대상이 조회한 게시글과 연관된 회원의 아이디가 였기 때문입니다. 이제 `@AuthenticationPrincipal`에서 로그인 사용자의 아이디가 아닌 기본키를 가져오기 때문에 작성자가 맞는지 검사하는 로직도 아이디가 아닌 기본키를 비교하는 것으로 변경했습니다. 따라서 더 이상 게시글 단건 조회 시 회원도 함께 페치조인할 필요가 없기 때문에 findPostJoinFetch() 메서드를 제거했습니다.

### 2. 게시글 단건 조회 메서드를 PostRepository 인터페이스에 디폴트 메서드로 정의

- 게시글 단건 조회 메서드를 PostRepository 인터페이스에 디폴트 메서드로 정의해 게시글 단건 조회 시 Optional의 orElseThrow로 예외를 처리하는 부분이 중복되는 부분을 개선했습니다.

## 관련 이슈

- close #94
