### PR TITLE
댓글 수정 및 삭제 시 작성자 검증 로직 리팩토링

### DIFF
--- a/backend/src/main/java/com/board/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/board/domain/comment/controller/CommentController.java
@@ -34,8 +34,8 @@ public class CommentController {
     @PostMapping("/{postId}/comments")
     public ResponseEntity<ApiResponse<Void>> commentWrite(@PathVariable("postId") Long postId,
                                                           @RequestBody @Valid CommentWriteRequest commentWriteRequest,
-                                                          @AuthenticationPrincipal String username) {
-        commentService.commentWrite(postId, commentWriteRequest, username);
+                                                          @AuthenticationPrincipal Long memberId) {
+        commentService.commentWrite(postId, commentWriteRequest, memberId);
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 
@@ -44,8 +44,8 @@ public class CommentController {
     public ResponseEntity<ApiResponse<Void>> replyWrite(@PathVariable("postId") Long postId,
                                                         @PathVariable("commentId") Long commentId,
                                                         @RequestBody @Valid CommentWriteRequest commentWriteRequest,
-                                                        @AuthenticationPrincipal String username) {
-        commentService.replyWrite(postId, commentId, commentWriteRequest, username);
+                                                        @AuthenticationPrincipal Long memberId) {
+        commentService.replyWrite(postId, commentId, commentWriteRequest, memberId);
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 
@@ -62,8 +62,8 @@ public class CommentController {
     public ResponseEntity<ApiResponse<Void>> commentModify(@PathVariable("postId") Long postId,
                                                            @PathVariable("commentId") Long commentId,
                                                            @RequestBody @Valid CommentModifyRequest commentModifyRequest,
-                                                           @AuthenticationPrincipal String username) {
-        commentService.commentModify(postId, commentId, commentModifyRequest, username);
+                                                           @AuthenticationPrincipal Long memberId) {
+        commentService.commentModify(postId, commentId, commentModifyRequest, memberId);
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 
@@ -71,8 +71,8 @@ public class CommentController {
     @DeleteMapping("/{postId}/comments/{commentId}")
     public ResponseEntity<ApiResponse<Void>> commentDelete(@PathVariable("postId") Long postId,
                                                            @PathVariable("commentId") Long commentId,
-                                                           @AuthenticationPrincipal String username) {
-        commentService.commentDelete(postId, commentId, username);
+                                                           @AuthenticationPrincipal Long memberId) {
+        commentService.commentDelete(postId, commentId, memberId);
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 

--- a/backend/src/main/java/com/board/domain/comment/dto/CommentModifyRequest.java
+++ b/backend/src/main/java/com/board/domain/comment/dto/CommentModifyRequest.java
@@ -2,13 +2,16 @@ package com.board.domain.comment.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommentModifyRequest {
 
     @NotBlank(message = "내용을 입력해 주세요.")

--- a/backend/src/main/java/com/board/domain/comment/dto/CommentWriteRequest.java
+++ b/backend/src/main/java/com/board/domain/comment/dto/CommentWriteRequest.java
@@ -2,13 +2,16 @@ package com.board.domain.comment.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommentWriteRequest {
 
     @NotBlank(message = "내용을 입력해 주세요.")

--- a/backend/src/main/java/com/board/domain/comment/entity/Comment.java
+++ b/backend/src/main/java/com/board/domain/comment/entity/Comment.java
@@ -57,13 +57,13 @@ public class Comment extends BaseEntity {
     private List<Comment> replies = new ArrayList<>();
 
     @Builder
-    public Comment(String content, Member member, Post post, Comment reference) {
-        this.writer = member.getNickname();
+    public Comment(String content, String writer, Member member, Post post, Comment reference) {
+        this.writer = writer;
         this.content = content;
         this.member = member;
         this.reference = reference;
         this.isDelete = false;
-        setPost(post);
+        this.post = post;
     }
 
     public void addReply(Comment reply) {
@@ -79,16 +79,8 @@ public class Comment extends BaseEntity {
         this.isDelete = true;
     }
 
-    public boolean isOwner(String loginUsername) {
-        return member.getUsername().equals(loginUsername);
-    }
-
-    private void setPost(Post post) {
-        if (this.post != null) {
-            this.post.getComments().remove(this);
-        }
-        this.post = post;
-        post.getComments().add(this);
+    public boolean isOwner(Long memberId) {
+        return member.getId().equals(memberId);
     }
 
 }

--- a/backend/src/main/java/com/board/domain/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/board/domain/comment/repository/CommentRepository.java
@@ -10,15 +10,11 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentCustomRepository {
 
     @Query("SELECT c FROM Comment AS c WHERE c.post.id = :postId AND c.id = :commentId")
     Optional<Comment> findCommentByPostIdAndCommentId(@Param("postId") Long postId, @Param("commentId") Long commentId);
 
-    @Query("SELECT c FROM Comment AS c JOIN FETCH c.member WHERE c.post.id = :postId AND c.id = :commentId")
-    Optional<Comment> findCommentJoinFetchMember(@Param("postId") Long postId, @Param("commentId") Long commentId);
-
     Page<Comment> findCommentsByPostId(Pageable pageable, Long postId);
-    Page<Comment> findCommentsByMemberUsername(Pageable pageable, String username);
 
 }

--- a/backend/src/main/java/com/board/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/board/domain/comment/service/CommentService.java
@@ -10,10 +10,8 @@ import com.board.domain.comment.exception.CommentModifyAccessDeniedException;
 import com.board.domain.comment.exception.NotFoundCommentException;
 import com.board.domain.comment.repository.CommentRepository;
 import com.board.domain.member.entity.Member;
-import com.board.domain.member.exception.NotFoundMemberException;
 import com.board.domain.member.repository.MemberRepository;
 import com.board.domain.post.entity.Post;
-import com.board.domain.post.exception.NotFoundPostException;
 import com.board.domain.post.repository.PostRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -32,17 +30,16 @@ public class CommentService {
     private static final int PAGE_SIZE = 10;
     private static final String PROPERTIES = "id";
 
-    private final CommentRepository commentRepository;
-    private final PostRepository postRepository;
     private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
 
     @Transactional
-    public void commentWrite(Long postNumber, CommentWriteRequest commentWriteRequest, String loginUsername) {
-        Post post = postRepository.findById(postNumber)
-                .orElseThrow(NotFoundPostException::new);
-        Member member = memberRepository.findMemberByUsername(loginUsername)
-                .orElseThrow(NotFoundMemberException::new);
+    public void commentWrite(Long postId, CommentWriteRequest commentWriteRequest, Long memberId) {
+        Post post = postRepository.findByPostId(postId);
+        Member member = memberRepository.findByMemberId(memberId);
         Comment comment = Comment.builder()
+                .writer(member.getNickname())
                 .content(commentWriteRequest.getContent())
                 .member(member)
                 .post(post)
@@ -51,12 +48,12 @@ public class CommentService {
     }
 
     @Transactional
-    public void replyWrite(Long postId, Long commentId, CommentWriteRequest commentWriteRequest, String username) {
+    public void replyWrite(Long postId, Long commentId, CommentWriteRequest commentWriteRequest, Long memberId) {
         Comment comment = commentRepository.findCommentByPostIdAndCommentId(postId, commentId)
                 .orElseThrow(NotFoundCommentException::new);
-        Member member = memberRepository.findMemberByUsername(username)
-                .orElseThrow(NotFoundMemberException::new);
+        Member member = memberRepository.findByMemberId(memberId);
         Comment reply = Comment.builder()
+                .writer(member.getNickname())
                 .content(commentWriteRequest.getContent())
                 .member(member)
                 .post(comment.getPost())
@@ -66,17 +63,17 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
-    public CommentListResponse commentList(Long postNumber, int pageNumber) {
-        Pageable pageable = PageRequest.of(pageNumber, PAGE_SIZE, Sort.Direction.ASC, PROPERTIES);
-        Page<Comment> commentPage = commentRepository.findCommentsByPostId(pageable, postNumber);
+    public CommentListResponse commentList(Long postId, int page) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.Direction.ASC, PROPERTIES);
+        Page<Comment> commentPage = commentRepository.findCommentsByPostId(pageable, postId);
         return new CommentListResponse(commentPage);
     }
 
     @Transactional
-    public void commentModify(Long postNumber, Long commentNumber, CommentModifyRequest commentModifyRequest, String loginUsername) {
-        Comment comment = commentRepository.findCommentJoinFetchMember(postNumber, commentNumber)
+    public void commentModify(Long postId, Long commentId, CommentModifyRequest commentModifyRequest, Long memberId) {
+        Comment comment = commentRepository.findCommentByPostIdAndCommentId(postId, commentId)
                 .orElseThrow(NotFoundCommentException::new);
-        if (!comment.isOwner(loginUsername)) {
+        if (!comment.isOwner(memberId)) {
             throw new CommentModifyAccessDeniedException();
         }
         if (comment.isDelete()) {
@@ -86,23 +83,16 @@ public class CommentService {
     }
 
     @Transactional
-    public void commentDelete(Long postNumber, Long commentNumber, String loginUsername) {
-        Comment comment = commentRepository.findCommentJoinFetchMember(postNumber, commentNumber)
+    public void commentDelete(Long postId, Long commentId, Long memberId) {
+        Comment comment = commentRepository.findCommentByPostIdAndCommentId(postId, commentId)
                 .orElseThrow(NotFoundCommentException::new);
-        if (!comment.isOwner(loginUsername)) {
+        if (!comment.isOwner(memberId)) {
             throw new CommentDeleteAccessDeniedException();
         }
         if (comment.isDelete()) {
             throw new AlreadyDeleteCommentException();
         }
         comment.delete();
-    }
-
-    @Transactional(readOnly = true)
-    public CommentListResponse commentListFromMember(int page, String username) {
-        Pageable pageable = PageRequest.of(page, PAGE_SIZE, Sort.Direction.ASC, PROPERTIES);
-        Page<Comment> commentPage = commentRepository.findCommentsByMemberUsername(pageable, username);
-        return new CommentListResponse(commentPage);
     }
 
 }

--- a/backend/src/test/java/com/board/domain/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/board/domain/comment/controller/CommentControllerTest.java
@@ -1,626 +1,620 @@
 package com.board.domain.comment.controller;
 
-import com.board.domain.comment.dto.CommentListItem;
-import com.board.domain.comment.dto.CommentListResponse;
 import com.board.domain.comment.dto.CommentModifyRequest;
 import com.board.domain.comment.dto.CommentWriteRequest;
-import com.board.domain.comment.exception.AlreadyDeleteCommentException;
-import com.board.domain.comment.exception.CommentDeleteAccessDeniedException;
-import com.board.domain.comment.exception.CommentModifyAccessDeniedException;
 import com.board.domain.comment.exception.NotFoundCommentException;
 import com.board.domain.comment.service.CommentService;
 import com.board.domain.post.exception.NotFoundPostException;
-import com.board.support.RestDocsTestSupport;
+import com.board.global.security.exception.ExpiredTokenException;
+import com.board.global.security.exception.InvalidTokenException;
+import com.board.support.ControllerTest;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
-import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
-import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
-import static org.springframework.restdocs.payload.JsonFieldType.STRING;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = CommentController.class)
-class CommentControllerTest extends RestDocsTestSupport {
+class CommentControllerTest extends ControllerTest {
 
     @MockBean
     private CommentService commentService;
 
-    @Test
-    @DisplayName("댓글을 작성한다")
-    void commentWrite() throws Exception {
-        CommentWriteRequest commentWriteRequest = new CommentWriteRequest("댓글");
+    @Nested
+    @DisplayName("댓글 작성 요청")
+    class CommentWriteTest {
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willDoNothing().given(commentService).commentWrite(anyLong(), any(CommentWriteRequest.class), anyString());
+        @Test
+        @DisplayName("댓글을 작성한다")
+        void commentWrite() throws Exception {
+            CommentWriteRequest commentWriteRequest = CommentWriteRequest.builder()
+                    .content("comment")
+                    .build();
 
-        mockMvc.perform(post("/api/posts/{postId}/comments", 1)
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(commentWriteRequest))
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호")
-                        ),
-                        requestFields(
-                                fieldWithPath("content").type(STRING).description("댓글")
-                        ),
-                        responseFields(
-                                commonSuccessResponse()
-                        )
-                ));
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willDoNothing().given(commentService).commentWrite(anyLong(), any(CommentWriteRequest.class), anyLong());
+
+            mockMvc.perform(post("/api/posts/{postId}/comments", 1)
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(commentWriteRequest))
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("댓글 내용")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("대댓글을 작성한다")
+        void replyWrite() throws Exception {
+            CommentWriteRequest replyWriteRequest = CommentWriteRequest.builder()
+                    .content("reply")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willDoNothing().given(commentService).replyWrite(anyLong(), anyLong(), any(CommentWriteRequest.class), anyLong());
+
+            mockMvc.perform(post("/api/posts/{postId}/comments/{commentId}/replies", 1, 1)
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(replyWriteRequest))
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호"),
+                                    parameterWithName("commentId").description("댓글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("댓글 내용")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("내용이 비어있으면 예외가 발생한다")
+        void commentWriteInvalidContentValue() throws Exception {
+            CommentWriteRequest commentWriteRequest = CommentWriteRequest.builder()
+                    .content("")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+
+            mockMvc.perform(post("/api/posts/{postId}/comments", 1)
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(commentWriteRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("content"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value(""))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("내용을 입력해 주세요."))
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("댓글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("게시글이 존재하지 않으면 예외가 발생한다")
+        void commentWriteNotFoundPost() throws Exception {
+            CommentWriteRequest commentWriteRequest = CommentWriteRequest.builder()
+                    .content("comment")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willThrow(new NotFoundPostException()).given(commentService).commentWrite(anyLong(), any(CommentWriteRequest.class), anyLong());
+
+            mockMvc.perform(post("/api/posts/{postId}/comments", 1)
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(commentWriteRequest))
+                    )
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E404002"))
+                    .andExpect(jsonPath("$.error.message").value("게시글을 찾을 수 없습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("댓글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 유효하지 않으면 예외가 발생한다")
+        void commentWriteInvalidAccessToken() throws Exception {
+            CommentWriteRequest commentWriteRequest = CommentWriteRequest.builder()
+                    .content("comment")
+                    .build();
+
+            willThrow(new InvalidTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(post("/api/posts/{postId}/comments", 1)
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(commentWriteRequest))
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401002"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 유효하지 않습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("댓글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 만료되면 예외가 발생한다")
+        void commentWriteExpiredAccessToken() throws Exception {
+            CommentWriteRequest commentWriteRequest = CommentWriteRequest.builder()
+                    .content("comment")
+                    .build();
+
+            willThrow(new ExpiredTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(post("/api/posts/{postId}/comments", 1)
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(commentWriteRequest))
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401003"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 만료되었습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("댓글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
     }
 
-    @Test
-    @DisplayName("댓글 작성 시 입력값이 잘못되면 예외가 발생한다")
-    void commentWriteInvalidInputValue() throws Exception {
-        CommentWriteRequest invalidCommentWriteRequest = new CommentWriteRequest("");
+    @Nested
+    @DisplayName("댓글 수정 요청")
+    class CommentModifyTest {
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
+        @Test
+        @DisplayName("댓글을 수정한다")
+        void commentModify() throws Exception {
+            CommentModifyRequest commentModifyRequest = CommentModifyRequest.builder()
+                    .content("newComment")
+                    .build();
 
-        mockMvc.perform(post("/api/posts/{postId}/comments", 1)
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidCommentWriteRequest)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.result.path").value("/api/posts/1/comments"))
-                .andExpect(jsonPath("$.result.error.code").value("E400001"))
-                .andExpect(jsonPath("$.result.error.message").value("입력값이 잘못되었습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].field").value("content"))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].input").value(""))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].message").value("내용을 입력해 주세요."))
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호")
-                        ),
-                        requestFields(
-                                fieldWithPath("content").type(STRING).description("댓글")
-                        ),
-                        responseFields(
-                                commonErrorResponse())
-                                .and(
-                                        fieldWithPath("result.error.fieldErrors[].field").description(STRING).description("필드명"),
-                                        fieldWithPath("result.error.fieldErrors[].input").description(STRING).description("입력값"),
-                                        fieldWithPath("result.error.fieldErrors[].message").description(STRING).description("메시지")
-                                )
-                ));
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willDoNothing().given(commentService).commentModify(anyLong(), anyLong(), any(CommentModifyRequest.class), anyLong());
+
+            mockMvc.perform(put("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(commentModifyRequest))
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호"),
+                                    parameterWithName("commentId").description("댓글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("수정할 댓글 내용")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("내용이 비어있으면 예외가 발생한다")
+        void commentModifyInvalidContentValue() throws Exception {
+            CommentModifyRequest commentModifyRequest = CommentModifyRequest.builder()
+                    .content("")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+
+            mockMvc.perform(put("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(commentModifyRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("content"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value(""))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("내용을 입력해 주세요."))
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호"),
+                                    parameterWithName("commentId").description("댓글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("댓글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("댓글이 존재하지 않으면 예외가 발생한다")
+        void commentModifyNotFoundComment() throws Exception {
+            CommentModifyRequest commentModifyRequest = CommentModifyRequest.builder()
+                    .content("newComment")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willThrow(new NotFoundCommentException()).given(commentService).commentModify(anyLong(), anyLong(), any(CommentModifyRequest.class), anyLong());
+
+            mockMvc.perform(put("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(commentModifyRequest))
+                    )
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E404003"))
+                    .andExpect(jsonPath("$.error.message").value("댓글을 찾을 수 없습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호"),
+                                    parameterWithName("commentId").description("댓글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("수정할 댓글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 유효하지 않으면 예외가 발생한다")
+        void commentModifyInvalidAccessToken() throws Exception {
+            CommentModifyRequest commentModifyRequest = CommentModifyRequest.builder()
+                    .content("newComment")
+                    .build();
+
+            willThrow(new InvalidTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(put("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(commentModifyRequest))
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401002"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 유효하지 않습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호"),
+                                    parameterWithName("commentId").description("댓글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("수정할 댓글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 만료되면 예외가 발생한다")
+        void commentModifyExpiredAccessToken() throws Exception {
+            CommentModifyRequest commentModifyRequest = CommentModifyRequest.builder()
+                    .content("newComment")
+                    .build();
+
+            willThrow(new ExpiredTokenException()).given(jwtManager).getPayload(anyString());
+
+            mockMvc.perform(put("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(commentModifyRequest))
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401003"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 만료되었습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호"),
+                                    parameterWithName("commentId").description("댓글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("수정할 댓글 내용")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
     }
 
-    @Test
-    @DisplayName("댓글 작성 시 게시글을 찾을 수 없으면 예외가 발생한다")
-    void commentWriteNotFoundPost() throws Exception {
-        CommentWriteRequest commentWriteRequest = new CommentWriteRequest("댓글");
+    @Nested
+    @DisplayName("댓글 삭제 요청")
+    class CommentDeleteTest {
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willThrow(new NotFoundPostException()).given(commentService).commentWrite(anyLong(), any(CommentWriteRequest.class), anyString());
+        @Test
+        @DisplayName("댓글을 삭제한다")
+        void commentDelete() throws Exception {
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
 
-        mockMvc.perform(post("/api/posts/{postId}/comments", 1)
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(commentWriteRequest))
-                )
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.status").value(404))
-                .andExpect(jsonPath("$.result.path").value("/api/posts/1/comments"))
-                .andExpect(jsonPath("$.result.error.code").value("E404002"))
-                .andExpect(jsonPath("$.result.error.message").value("게시글을 찾을 수 없습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("Access Token")
-                        ),
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호")
-                        ),
-                        requestFields(
-                                fieldWithPath("content").type(STRING).description("댓글")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
-    }
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willDoNothing().given(commentService).commentDelete(anyLong(), anyLong(), anyLong());
 
-    @Test
-    @DisplayName("대댓글을 작성한다")
-    void replyWrite() throws Exception {
-        CommentWriteRequest replyWriteRequest = new CommentWriteRequest("대댓글");
+            mockMvc.perform(delete("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                            .header("Authorization", "Bearer access-token")
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("success"))
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호"),
+                                    parameterWithName("commentId").description("댓글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonSuccessResponse()
+                            )
+                    ));
+        }
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willDoNothing().given(commentService).replyWrite(anyLong(), anyLong(), any(CommentWriteRequest.class), anyString());
+        @Test
+        @DisplayName("댓글이 존재하지 않으면 예외가 발생한다")
+        void commentDeleteNotFoundComment() throws Exception {
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
 
-        mockMvc.perform(post("/api/posts/{postId}/comments/{commentId}/replies", 1, 1)
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(replyWriteRequest))
-                )
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호"),
-                                parameterWithName("commentId").description("댓글 번호")
-                        ),
-                        requestFields(
-                                fieldWithPath("content").type(STRING).description("대댓글")
-                        ),
-                        responseFields(
-                                commonSuccessResponse()
-                        )
-                ));
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willThrow(new NotFoundCommentException()).given(commentService).commentDelete(anyLong(), anyLong(), anyLong());
 
-    }
+            mockMvc.perform(delete("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                            .header("Authorization", "Bearer access-token")
+                    )
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E404003"))
+                    .andExpect(jsonPath("$.error.message").value("댓글을 찾을 수 없습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호"),
+                                    parameterWithName("commentId").description("댓글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
 
-    @Test
-    @DisplayName("대댓글 작성 시 입력값이 잘못되면 예외가 발생한다")
-    void replyWriteInvalidInputValue() throws Exception {
-        CommentWriteRequest invalidReplyWriteRequest = new CommentWriteRequest("");
+        @Test
+        @DisplayName("액세스 토큰이 유효하지 않으면 예외가 발생한다")
+        void commentDeleteInvalidAccessToken() throws Exception {
+            willThrow(new InvalidTokenException()).given(jwtManager).getPayload(anyString());
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
+            mockMvc.perform(delete("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                            .header("Authorization", "Bearer access-token")
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401002"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 유효하지 않습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호"),
+                                    parameterWithName("commentId").description("댓글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
 
-        mockMvc.perform(post("/api/posts/{postId}/comments/{commentId}/replies", 1, 1)
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidReplyWriteRequest))
-                )
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.result.path").value("/api/posts/1/comments/1/replies"))
-                .andExpect(jsonPath("$.result.error.code").value("E400001"))
-                .andExpect(jsonPath("$.result.error.message").value("입력값이 잘못되었습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].field").value("content"))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].input").value(""))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].message").value("내용을 입력해 주세요."))
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호"),
-                                parameterWithName("commentId").description("댓글 번호")
-                        ),
-                        requestFields(
-                                fieldWithPath("content").type(STRING).description("대댓글")
-                        ),
-                        responseFields(
-                                commonErrorResponse())
-                                .and(
-                                        fieldWithPath("result.error.fieldErrors[].field").description(STRING).description("필드명"),
-                                        fieldWithPath("result.error.fieldErrors[].input").description(STRING).description("입력값"),
-                                        fieldWithPath("result.error.fieldErrors[].message").description(STRING).description("메시지")
-                                )
-                ));
-    }
+        @Test
+        @DisplayName("액세스 토큰이 만료되면 예외가 발생한다")
+        void commentDeleteExpiredAccessToken() throws Exception {
+            willThrow(new ExpiredTokenException()).given(jwtManager).getPayload(anyString());
 
-    @Test
-    @DisplayName("대댓글 작성 시 댓글을 찾을 수 없으면 예외가 발생한다")
-    void replyWriteNotFoundComment() throws Exception {
-        CommentWriteRequest replyWriteRequest = new CommentWriteRequest("대댓글");
+            mockMvc.perform(delete("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                            .header("Authorization", "Bearer access-token")
+                    )
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E401003"))
+                    .andExpect(jsonPath("$.error.message").value("토큰이 만료되었습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호"),
+                                    parameterWithName("commentId").description("댓글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
 
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willThrow(new NotFoundCommentException()).given(commentService).replyWrite(anyLong(), anyLong(), any(CommentWriteRequest.class), anyString());
-
-        mockMvc.perform(post("/api/posts/{postId}/comments/{commentId}/replies", 1, 1)
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(replyWriteRequest))
-                )
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.status").value(404))
-                .andExpect(jsonPath("$.result.path").value("/api/posts/1/comments/1/replies"))
-                .andExpect(jsonPath("$.result.error.code").value("E404003"))
-                .andExpect(jsonPath("$.result.error.message").value("댓글을 찾을 수 없습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호"),
-                                parameterWithName("commentId").description("댓글 번호")
-                        ),
-                        requestFields(
-                                fieldWithPath("content").type(STRING).description("대댓글")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("댓글 목록을 조회한다")
-    void commentList() throws Exception {
-        List<CommentListItem> comments = List.of(
-                new CommentListItem(1L, "작성자", "댓글", LocalDateTime.of(2024, 6, 17, 0, 0))
-        );
-        CommentListResponse commentListResponse = new CommentListResponse(comments, 1, 1, 1, false, false, true, true);
-
-        given(commentService.commentList(anyLong(), anyInt())).willReturn(commentListResponse);
-
-        mockMvc.perform(get("/api/posts/{postId}/comments", 1)
-                        .param("page", "1")
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result.comments[0].commentId").value(1))
-                .andExpect(jsonPath("$.result.comments[0].writer").value("작성자"))
-                .andExpect(jsonPath("$.result.comments[0].content").value("댓글"))
-                .andExpect(jsonPath("$.result.comments[0].createdAt").value("2024-06-17T00:00:00"))
-                .andExpect(jsonPath("$.result.page").value(1))
-                .andExpect(jsonPath("$.result.totalPages").value(1))
-                .andExpect(jsonPath("$.result.totalElements").value(1))
-                .andExpect(jsonPath("$.result.prev").value(false))
-                .andExpect(jsonPath("$.result.next").value(false))
-                .andExpect(jsonPath("$.result.first").value(true))
-                .andExpect(jsonPath("$.result.last").value(true))
-                .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호")
-                        ),
-                        queryParameters(
-                                parameterWithName("page").description("페이지 번호")
-                        ),
-                        responseFields(
-                                commonSuccessResponse())
-                                .and(
-                                        fieldWithPath("result.comments").type(ARRAY).description("댓글 목록"),
-                                        fieldWithPath("result.comments[].commentId").type(NUMBER).description("댓글 번호"),
-                                        fieldWithPath("result.comments[].writer").type(STRING).description("댓글 작성자"),
-                                        fieldWithPath("result.comments[].content").type(STRING).description("댓글 내용"),
-                                        fieldWithPath("result.comments[].createdAt").type(STRING).description("댓글 작성일"),
-                                        fieldWithPath("result.page").type(NUMBER).description("페이지 번호"),
-                                        fieldWithPath("result.totalPages").type(NUMBER).description("전체 페이지 개수"),
-                                        fieldWithPath("result.totalElements").type(NUMBER).description("전체 게시글 개수"),
-                                        fieldWithPath("result.prev").type(BOOLEAN).description("이전 페이지 이동 가능 여부"),
-                                        fieldWithPath("result.next").type(BOOLEAN).description("다음 페이지 이동 가능 여부"),
-                                        fieldWithPath("result.first").type(BOOLEAN).description("첫 번째 페이지 여부"),
-                                        fieldWithPath("result.last").type(BOOLEAN).description("마지막 페이지 여부")
-                                )
-                ));
-    }
-
-    @Test
-    @DisplayName("댓글을 수정한다")
-    void commentModify() throws Exception {
-        CommentModifyRequest commentModifyRequest = new CommentModifyRequest("댓글");
-
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willDoNothing().given(commentService).commentModify(anyLong(), anyLong(), any(CommentModifyRequest.class), anyString());
-
-        mockMvc.perform(put("/api/posts/{postId}/comments/{commentId}", 1, 1)
-                        .header("Authorization", "Bearer acces-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(commentModifyRequest))
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result").isEmpty())
-                .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호"),
-                                parameterWithName("commentId").description("댓글 번호")
-                        ),
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("content").type(STRING).description("수정 댓글")
-                        ),
-                        responseFields(
-                                commonSuccessResponse()
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("댓글 수정 시 입력값이 잘못되면 예외가 발생한다")
-    void commentModifyInvalidInputValue() throws Exception {
-        CommentModifyRequest invalidCommentModifyRequest = new CommentModifyRequest("");
-
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-
-        mockMvc.perform(put("/api/posts/{postId}/comments/{commentId}", 1, 1)
-                        .header("Authorization", "Bearer acces-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidCommentModifyRequest))
-                )
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("fail"))
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.result.path").value("/api/posts/1/comments/1"))
-                .andExpect(jsonPath("$.result.error.code").value("E400001"))
-                .andExpect(jsonPath("$.result.error.message").value("입력값이 잘못되었습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].field").value("content"))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].input").value(""))
-                .andExpect(jsonPath("$.result.error.fieldErrors[0].message").value("내용을 입력해 주세요."))
-                .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호"),
-                                parameterWithName("commentId").description("댓글 번호")
-                        ),
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("content").type(STRING).description("수정 댓글")
-                        ),
-                        responseFields(
-                                commonErrorResponse())
-                                .and(
-                                        fieldWithPath("result.error.fieldErrors[].field").description(STRING).description("필드명"),
-                                        fieldWithPath("result.error.fieldErrors[].input").description(STRING).description("입력값"),
-                                        fieldWithPath("result.error.fieldErrors[].message").description(STRING).description("메시지")
-                                )
-                ));
-    }
-
-    @Test
-    @DisplayName("댓글 수정 시 댓글을 찾을 수 없으면 예외가 발생한다")
-    void commentModifyNotFoundComment() throws Exception {
-        CommentModifyRequest commentModifyRequest = new CommentModifyRequest("댓글");
-
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willThrow(new NotFoundCommentException()).given(commentService).commentModify(anyLong(), anyLong(), any(CommentModifyRequest.class), anyString());
-
-        mockMvc.perform(put("/api/posts/{postId}/comments/{commentId}", 1, 1)
-                        .header("Authorization", "Bearer acces-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(commentModifyRequest))
-                )
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.status").value(404))
-                .andExpect(jsonPath("$.result.path").value("/api/posts/1/comments/1"))
-                .andExpect(jsonPath("$.result.error.code").value("E404003"))
-                .andExpect(jsonPath("$.result.error.message").value("댓글을 찾을 수 없습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호"),
-                                parameterWithName("commentId").description("댓글 번호")
-                        ),
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("content").type(STRING).description("수정 댓글")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("댓글 수정 시 작성자가 아닌데 수정을 시도할 경우 예외가 발생한다")
-    void commentModifyNotCommentOwner() throws Exception {
-        CommentModifyRequest commentModifyRequest = new CommentModifyRequest("댓글");
-
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willThrow(new CommentModifyAccessDeniedException()).given(commentService).commentModify(anyLong(), anyLong(), any(CommentModifyRequest.class), anyString());
-
-        mockMvc.perform(put("/api/posts/{postId}/comments/{commentId}", 1, 1)
-                        .header("Authorization", "Bearer acces-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(commentModifyRequest))
-                )
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.status").value(403))
-                .andExpect(jsonPath("$.result.path").value("/api/posts/1/comments/1"))
-                .andExpect(jsonPath("$.result.error.code").value("E403003"))
-                .andExpect(jsonPath("$.result.error.message").value("댓글 수정은 작성자만 할 수 있습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호"),
-                                parameterWithName("commentId").description("댓글 번호")
-                        ),
-                        requestHeaders(
-                                headerWithName("Authorization").description("Access Token")
-                        ),
-                        requestFields(
-                                fieldWithPath("content").type(STRING).description("수정 댓글")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("이미 삭제된 댓글에 수정을 시도할 경우 예외가 발생한다")
-    void commentModifyAlreadyDeleteComment() throws Exception {
-        CommentModifyRequest commentModifyRequest = new CommentModifyRequest("댓글");
-
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willThrow(new AlreadyDeleteCommentException()).given(commentService).commentModify(anyLong(), anyLong(), any(CommentModifyRequest.class), anyString());
-
-        mockMvc.perform(put("/api/posts/{postId}/comments/{commentId}", 1, 1)
-                        .header("Authorization", "Bearer access-token")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(commentModifyRequest))
-                )
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.status").value(404))
-                .andExpect(jsonPath("$.result.path").value("/api/posts/1/comments/1"))
-                .andExpect(jsonPath("$.result.error.code").value("E404004"))
-                .andExpect(jsonPath("$.result.error.message").value("이미 삭제된 댓글입니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호"),
-                                parameterWithName("commentId").description("댓글 번호")
-                        ),
-                        requestHeaders(
-                                headerWithName("Authorization").description("Access Token")
-                        ),
-                        requestFields(
-                                fieldWithPath("content").type(STRING).description("수정 댓글")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("댓글을 삭제한다")
-    void commentDelete() throws Exception {
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willDoNothing().given(commentService).commentDelete(anyLong(), anyLong(), anyString());
-
-        mockMvc.perform(delete("/api/posts/{postId}/comments/{commentId}", 1, 1)
-                        .header("Authorization", "Bearer access-token"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.result").isEmpty())
-                .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호"),
-                                parameterWithName("commentId").description("댓글 번호")
-                        ),
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        responseFields(
-                                commonSuccessResponse()
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("댓글 삭제 시 댓글을 찾을 수 없으면 예외가 발생한다")
-    void commentDeleteNotFoundComment() throws Exception {
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willThrow(new NotFoundCommentException()).given(commentService).commentDelete(anyLong(), anyLong(), anyString());
-
-        mockMvc.perform(delete("/api/posts/{postId}/comments/{commentId}", 1, 1)
-                        .header("Authorization", "Bearer access-token"))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.status").value(404))
-                .andExpect(jsonPath("$.result.path").value("/api/posts/1/comments/1"))
-                .andExpect(jsonPath("$.result.error.code").value("E404003"))
-                .andExpect(jsonPath("$.result.error.message").value("댓글을 찾을 수 없습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호"),
-                                parameterWithName("commentId").description("댓글 번호")
-                        ),
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("댓글 삭제 시 작성자가 아닌데 삭제를 시도할 경우 예외가 발생한다")
-    void commentDeleteNotCommentOnwer() throws Exception {
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willThrow(new CommentDeleteAccessDeniedException()).given(commentService).commentDelete(anyLong(), anyLong(), anyString());
-
-        mockMvc.perform(delete("/api/posts/{postId}/comments/{commentId}", 1, 1)
-                        .header("Authorization", "Bearer access-token"))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.status").value(403))
-                .andExpect(jsonPath("$.result.path").value("/api/posts/1/comments/1"))
-                .andExpect(jsonPath("$.result.error.code").value("E403004"))
-                .andExpect(jsonPath("$.result.error.message").value("댓글 삭제는 작성자만 할 수 있습니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호"),
-                                parameterWithName("commentId").description("댓글 번호")
-                        ),
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("이미 삭제된 댓글에 삭제를 시도할 경우 예외가 발생한다")
-    void commentDeleteAlreadyDeleteComment() throws Exception {
-        given(tokenService.tokenPayload(anyString())).willReturn(mockClaims());
-        willThrow(new AlreadyDeleteCommentException()).given(commentService).commentDelete(anyLong(), anyLong(), anyString());
-
-        mockMvc.perform(delete("/api/posts/{postId}/comments/{commentId}", 1, 1)
-                        .header("Authorization", "Bearer access-token"))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.status").value(404))
-                .andExpect(jsonPath("$.result.path").value("/api/posts/1/comments/1"))
-                .andExpect(jsonPath("$.result.error.code").value("E404004"))
-                .andExpect(jsonPath("$.result.error.message").value("이미 삭제된 댓글입니다."))
-                .andExpect(jsonPath("$.result.error.fieldErrors").isEmpty())
-                .andDo(restDocs.document(
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 번호"),
-                                parameterWithName("commentId").description("댓글 번호")
-                        ),
-                        requestHeaders(
-                                headerWithName("Authorization").description("액세스 토큰")
-                        ),
-                        responseFields(
-                                commonErrorResponse()
-                        )
-                ));
     }
 
 }

--- a/backend/src/test/java/com/board/domain/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/comment/repository/CommentRepositoryTest.java
@@ -1,32 +1,32 @@
 package com.board.domain.comment.repository;
 
 import com.board.domain.comment.entity.Comment;
+import com.board.domain.comment.exception.NotFoundCommentException;
+import com.board.domain.member.dto.MemberCommentListResponse;
 import com.board.domain.member.entity.Member;
 import com.board.domain.member.repository.MemberRepository;
 import com.board.domain.post.entity.Post;
 import com.board.domain.post.repository.PostRepository;
-import com.board.global.common.config.JpaAuditConfig;
-import com.board.support.config.QuerydslConfig;
+import com.board.support.RepositoryTest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@DataJpaTest
-@Import({JpaAuditConfig.class, QuerydslConfig.class})
-class CommentRepositoryTest {
+class CommentRepositoryTest extends RepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;
@@ -42,111 +42,229 @@ class CommentRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        member = memberRepository.save(Member.builder()
+        member = Member.builder()
                 .nickname("yoonkun")
                 .username("yoon1234")
-                .password("12345678")
-                .build());
-        post = postRepository.save(Post.builder()
-                .title("제목")
-                .content("내용")
-                .member(member)
-                .build());
-    }
-
-    @Test
-    @DisplayName("댓글을 저장한다")
-    void commentSave() {
-        Comment comment = Comment.builder()
-                .content("댓글")
-                .member(member)
-                .post(post)
+                .password(new BCryptPasswordEncoder().encode("12345678"))
                 .build();
-
-        Comment saveComment = commentRepository.save(comment);
-
-        assertThat(saveComment.getId()).isNotNull();
-    }
-
-    @Test
-    @DisplayName("댓글 목록을 조회한다")
-    void findCommentsByPostId() {
-        List<Comment> commentList = List.of(
-                Comment.builder().content("댓글").member(member).post(post).build(),
-                Comment.builder().content("댓글").member(member).post(post).build(),
-                Comment.builder().content("댓글").member(member).post(post).build(),
-                Comment.builder().content("댓글").member(member).post(post).build(),
-                Comment.builder().content("댓글").member(member).post(post).build()
-        );
-        commentRepository.saveAll(commentList);
-
-        Pageable pageable = PageRequest.of(0, 5, Sort.Direction.ASC, "id");
-        Page<Comment> commentPage = commentRepository.findCommentsByPostId(pageable, post.getId());
-
-        assertThat(commentPage.getNumber()).isEqualTo(0);
-        assertThat(commentPage.getTotalElements()).isEqualTo(5);
-        assertThat(commentPage.getTotalPages()).isEqualTo(1);
-        assertThat(commentPage.hasPrevious()).isFalse();
-        assertThat(commentPage.hasNext()).isFalse();
-        assertThat(commentPage.isFirst()).isTrue();
-        assertThat(commentPage.isLast()).isTrue();
-    }
-
-    @Test
-    @DisplayName("댓글과 댓글을 작성한 회원을 한 번에 조회한다")
-    void findCommentJoinFetchMember() {
-        Comment comment = Comment.builder()
-                .content("댓글")
+        memberRepository.save(member);
+        post = Post.builder()
+                .title("title")
+                .writer(member.getNickname())
+                .content("content")
                 .member(member)
-                .post(post)
                 .build();
-        Comment saveComment = commentRepository.save(comment);
-
-        Comment findComment = commentRepository.findCommentJoinFetchMember(post.getId(), saveComment.getId()).get();
-
-        assertThat(findComment.getContent()).isEqualTo("댓글");
-        assertThat(findComment.getMember().getNickname()).isEqualTo("yoonkun");
-        assertThat(findComment.getMember().getUsername()).isEqualTo("yoon1234");
+        postRepository.save(post);
     }
 
-    @Test
-    @DisplayName("댓글을 삭제한다")
-    void commentDelete() {
-        Comment comment = Comment.builder()
-                .content("댓글")
-                .member(member)
-                .post(post)
-                .build();
-        Comment saveComment = commentRepository.save(comment);
-        Comment findComment = commentRepository.findCommentJoinFetchMember(post.getId(), saveComment.getId()).get();
+    @Nested
+    @DisplayName("댓글 저장")
+    class CommentSaveTest {
 
-        findComment.delete();
+        @Test
+        @DisplayName("댓글을 저장한다")
+        void save() {
+            Comment comment = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("comment")
+                    .member(member)
+                    .post(post)
+                    .build();
 
-        assertThat(findComment.isDelete()).isTrue();
+            Comment saveComment = commentRepository.save(comment);
+
+            assertThat(saveComment.getId()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("작성자가 null이면 에외가 발생한다")
+        void saveNullWriter() {
+            Comment comment = Comment.builder()
+                    .writer(null)
+                    .content("comment")
+                    .member(member)
+                    .post(post)
+                    .build();
+
+            assertThatThrownBy(() -> commentRepository.save(comment))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("내용이 null이면 예외가 발생한다")
+        void saveNullContent() {
+            Comment comment = Comment.builder()
+                    .writer(member.getNickname())
+                    .content(null)
+                    .member(member)
+                    .post(post)
+                    .build();
+
+            assertThatThrownBy(() -> commentRepository.save(comment))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("회원이 null이면 예외가 발생한다")
+        void saveNullMember() {
+            Comment comment = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("comment")
+                    .member(null)
+                    .post(post)
+                    .build();
+
+            assertThatThrownBy(() -> commentRepository.save(comment))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("게시글이 null이면 예외가 발생한다")
+        void saveNullPost() {
+            Comment comment = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("comment")
+                    .member(member)
+                    .post(null)
+                    .build();
+
+            assertThatThrownBy(() -> commentRepository.save(comment))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("대댓글을 저장한다")
+        void saveReply() {
+            Comment comment = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("comment")
+                    .member(member)
+                    .post(post)
+                    .build();
+            commentRepository.save(comment);
+
+            Comment reply = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("reply")
+                    .member(member)
+                    .post(post)
+                    .reference(comment)
+                    .build();
+
+            Comment saveReply = commentRepository.save(reply);
+
+            assertThat(saveReply.getId()).isNotNull();
+            assertThat(reply.getReference()).isEqualTo(comment);
+        }
+
     }
 
-    @Test
-    @DisplayName("특정 회원이 작성한 댓글 목록을 조회한다")
-    void findCommentsByMemberUsername() {
-        List<Comment> commentList = List.of(
-                Comment.builder().content("댓글").member(member).post(post).build(),
-                Comment.builder().content("댓글").member(member).post(post).build(),
-                Comment.builder().content("댓글").member(member).post(post).build(),
-                Comment.builder().content("댓글").member(member).post(post).build(),
-                Comment.builder().content("댓글").member(member).post(post).build()
-        );
-        commentRepository.saveAll(commentList);
 
-        Pageable pageable = PageRequest.of(0, 5, Sort.Direction.ASC, "id");
-        Page<Comment> commentPage = commentRepository.findCommentsByMemberUsername(pageable, member.getUsername());
+    @Nested
+    @DisplayName("댓글 조회")
+    class CommentFindTest {
 
-        assertThat(commentPage.getNumber()).isEqualTo(0);
-        assertThat(commentPage.getTotalElements()).isEqualTo(5);
-        assertThat(commentPage.getTotalPages()).isEqualTo(1);
-        assertThat(commentPage.hasPrevious()).isFalse();
-        assertThat(commentPage.hasNext()).isFalse();
-        assertThat(commentPage.isFirst()).isTrue();
-        assertThat(commentPage.isLast()).isTrue();
+        @Test
+        @DisplayName("댓글 기본키와 게시글 기본키로 조회한다")
+        void findByPostIdAndCommentId() {
+            Comment comment = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("comment")
+                    .member(member)
+                    .post(post)
+                    .build();
+            commentRepository.save(comment);
+
+            Comment findComment = commentRepository.findCommentByPostIdAndCommentId(post.getId(), comment.getId())
+                    .orElseThrow(NotFoundCommentException::new);
+
+            assertThat(findComment.getWriter()).isEqualTo("yoonkun");
+            assertThat(findComment.getContent()).isEqualTo("comment");
+            assertThat(findComment.isDelete()).isFalse();
+        }
+
+        @Test
+        @DisplayName("댓글이 존재하지 않으면 예외가 발생한다")
+        void findByPostIdAndCommentIdNotFoundComment() {
+            assertThatThrownBy(() -> commentRepository.findCommentByPostIdAndCommentId(post.getId(), 1L)
+                    .orElseThrow(NotFoundCommentException::new))
+                    .isInstanceOf(NotFoundCommentException.class);
+        }
+
+    }
+
+    @Nested
+    @DisplayName("댓글 목록 조회")
+    class CommentListFindTest {
+
+        @Test
+        @DisplayName("특정 게시글에 속한 댓글 목록을 조회한다")
+        void findCommentsByPostId() {
+            commentRepository.saveAll(commentList());
+
+            Page<Comment> commentPage = commentRepository.findCommentsByPostId(PageRequest.of(0, 10, Sort.Direction.DESC, "id"), post.getId());
+
+            assertThat(commentPage.getNumber()).isEqualTo(0);
+            assertThat(commentPage.getTotalElements()).isEqualTo(6);
+            assertThat(commentPage.getTotalPages()).isEqualTo(1);
+            assertThat(commentPage.isLast()).isTrue();
+            assertThat(commentPage.isFirst()).isTrue();
+            assertThat(commentPage.hasNext()).isFalse();
+            assertThat(commentPage.hasPrevious()).isFalse();
+        }
+
+        @Test
+        @DisplayName("회원이 작성한 댓글 목록을 조회한다")
+        void findMemberCommentList() {
+            commentRepository.saveAll(commentList());
+
+            MemberCommentListResponse memberCommentList = commentRepository.findMemberCommentList(PageRequest.of(0, 10), member.getId());
+
+            assertThat(memberCommentList.getPage()).isEqualTo(1);
+            assertThat(memberCommentList.getTotalElements()).isEqualTo(6);
+            assertThat(memberCommentList.getTotalPages()).isEqualTo(1);
+            assertThat(memberCommentList.isFirst()).isTrue();
+            assertThat(memberCommentList.isLast()).isTrue();
+            assertThat(memberCommentList.isPrev()).isFalse();
+            assertThat(memberCommentList.isNext()).isFalse();
+        }
+
+        private List<Comment> commentList() {
+            return List.of(
+                    Comment.builder().writer(member.getNickname()).content("comment").member(member).post(post).build(),
+                    Comment.builder().writer(member.getNickname()).content("comment").member(member).post(post).build(),
+                    Comment.builder().writer(member.getNickname()).content("comment").member(member).post(post).build(),
+                    Comment.builder().writer(member.getNickname()).content("comment").member(member).post(post).build(),
+                    Comment.builder().writer(member.getNickname()).content("comment").member(member).post(post).build(),
+                    Comment.builder().writer(member.getNickname()).content("comment").member(member).post(post).build()
+            );
+        }
+
+    }
+
+    @Nested
+    @DisplayName("댓글 삭제")
+    class CommentDeleteTest {
+
+        @Test
+        @DisplayName("댓글을 삭제한다")
+        void delete() {
+            Comment comment = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("comment")
+                    .member(member)
+                    .post(post)
+                    .build();
+            commentRepository.save(comment);
+
+            Comment findComment = commentRepository.findCommentByPostIdAndCommentId(post.getId(), comment.getId())
+                    .orElseThrow(NotFoundCommentException::new);
+
+            findComment.delete();
+
+            assertThat(findComment.isDelete()).isTrue();
+        }
+
     }
 
 }

--- a/backend/src/test/java/com/board/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/board/domain/comment/service/CommentServiceTest.java
@@ -1,5 +1,6 @@
 package com.board.domain.comment.service;
 
+import com.board.domain.comment.dto.CommentListResponse;
 import com.board.domain.comment.dto.CommentModifyRequest;
 import com.board.domain.comment.dto.CommentWriteRequest;
 import com.board.domain.comment.entity.Comment;
@@ -14,34 +15,34 @@ import com.board.domain.member.repository.MemberRepository;
 import com.board.domain.post.entity.Post;
 import com.board.domain.post.exception.NotFoundPostException;
 import com.board.domain.post.repository.PostRepository;
+import com.board.support.ServiceTest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 
-@ExtendWith(MockitoExtension.class)
-class CommentServiceTest {
+class CommentServiceTest extends ServiceTest {
 
     @Mock
     private CommentRepository commentRepository;
@@ -63,288 +64,296 @@ class CommentServiceTest {
         member = Member.builder()
                 .nickname("yoonkun")
                 .username("yoon1234")
+                .password(new BCryptPasswordEncoder().encode("12345678"))
                 .build();
-
         post = Post.builder()
-                .title("제목")
-                .content("내용")
+                .title("title")
+                .writer(member.getNickname())
+                .content("content")
                 .member(member)
                 .build();
+        ReflectionTestUtils.setField(member, "id", 1L);
+        ReflectionTestUtils.setField(post, "id", 1L);
     }
 
-    @Test
-    @DisplayName("댓글을 작성한다")
-    void commentWrite() {
-        CommentWriteRequest commentWriteRequest = new CommentWriteRequest("댓글");
-        Comment comment = Comment.builder()
-                .content("댓글")
-                .member(member)
-                .post(post)
-                .build();
+    @Nested
+    @DisplayName("댓글 작성")
+    class CommentWriteTest {
 
-        given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
-        given(memberRepository.findMemberByUsername(anyString())).willReturn(Optional.of(member));
-        given(commentRepository.save(any(Comment.class))).willReturn(comment);
+        @Test
+        @DisplayName("댓글을 작성한다")
+        void commentWrite() {
+            CommentWriteRequest commentWriteRequest = CommentWriteRequest.builder()
+                    .content("comment")
+                    .build();
 
-        commentService.commentWrite(1L, commentWriteRequest, "yoon1234");
+            Comment comment = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("comment")
+                    .member(member)
+                    .post(post)
+                    .build();
 
-        then(postRepository).should().findById(anyLong());
-        then(memberRepository).should().findMemberByUsername(anyString());
-        then(commentRepository).should().save(any(Comment.class));
-    }
+            given(postRepository.findByPostId(anyLong())).willReturn(post);
+            given(memberRepository.findByMemberId(anyLong())).willReturn(member);
+            given(commentRepository.save(any(Comment.class))).willReturn(comment);
 
-    @Test
-    @DisplayName("댓글 작성 시 게시글을 찾을 수 없으면 예외가 발생한다")
-    void commentWriteNotFoundPost() {
-        CommentWriteRequest commentWriteRequest = new CommentWriteRequest("댓글");
+            commentService.commentWrite(1L, commentWriteRequest, 1L);
 
-        willThrow(new NotFoundPostException()).given(postRepository).findById(anyLong());
+            then(postRepository).should().findByPostId(anyLong());
+            then(memberRepository).should().findByMemberId(anyLong());
+            then(commentRepository).should().save(any(Comment.class));
+        }
 
-        assertThatThrownBy(() -> commentService.commentWrite(1L, commentWriteRequest, "yoon1234"))
-                .isInstanceOf(NotFoundPostException.class);
+        @Test
+        @DisplayName("대댓글을 작성한다")
+        void replyWrite() {
+            CommentWriteRequest replyWriteRequest = CommentWriteRequest.builder()
+                    .content("reply")
+                    .build();
 
-        then(postRepository).should().findById(anyLong());
-        then(memberRepository).should(never()).findMemberByUsername(anyString());
-        then(commentRepository).should(never()).save(any(Comment.class));
-    }
+            Comment comment = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("comment")
+                    .member(member)
+                    .post(post)
+                    .build();
 
-    @Test
-    @DisplayName("댓글 작성 시 회원을 찾을 수 없으면 예외가 발생한다")
-    void commentWriteNotFoundMember() {
-        CommentWriteRequest commentWriteRequest = new CommentWriteRequest("댓글");
+            given(commentRepository.findCommentByPostIdAndCommentId(anyLong(), anyLong())).willReturn(Optional.of(comment));
+            given(memberRepository.findByMemberId(anyLong())).willReturn(member);
 
-        given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
-        willThrow(new NotFoundMemberException()).given(memberRepository).findMemberByUsername(anyString());
+            commentService.replyWrite(1L, 1L, replyWriteRequest, 1L);
 
-        assertThatThrownBy(() -> commentService.commentWrite(1L, commentWriteRequest, "yoon1234"))
-                .isInstanceOf(NotFoundMemberException.class);
+            then(commentRepository).should().findCommentByPostIdAndCommentId(anyLong(), anyLong());
+            then(memberRepository).should().findByMemberId(anyLong());
+        }
 
-        then(postRepository).should().findById(anyLong());
-        then(memberRepository).should().findMemberByUsername(anyString());
-        then(commentRepository).should(never()).save(any(Comment.class));
-    }
+        @Test
+        @DisplayName("게시글이 존재하지 않으면 예외가 발생한다")
+        void commentWriteNotFoundPost() {
+            CommentWriteRequest commentWriteRequest = CommentWriteRequest.builder()
+                    .content("comment")
+                    .build();
 
-    @Test
-    @DisplayName("댓글 목록을 조회한다")
-    void commentList() {
-        List<Comment> content = List.of(
-                Comment.builder().content("댓글").member(member).post(post).build(),
-                Comment.builder().content("댓글").member(member).post(post).build(),
-                Comment.builder().content("댓글").member(member).post(post).build(),
-                Comment.builder().content("댓글").member(member).post(post).build(),
-                Comment.builder().content("댓글").member(member).post(post).build()
-        );
-        PageImpl<Comment> commentPage = new PageImpl<>(content);
+            willThrow(new NotFoundPostException()).given(postRepository).findByPostId(anyLong());
 
-        given(commentRepository.findCommentsByPostId(any(Pageable.class), anyLong())).willReturn(commentPage);
+            assertThatThrownBy(() -> commentService.commentWrite(1L, commentWriteRequest, 1L))
+                    .isInstanceOf(NotFoundPostException.class);
 
-        commentService.commentList(1L, 1);
+            then(postRepository).should().findByPostId(anyLong());
+            then(memberRepository).should(never()).findByMemberId(anyLong());
+            then(commentRepository).should(never()).save(any(Comment.class));
+        }
 
-        then(commentRepository).should().findCommentsByPostId(any(Pageable.class), anyLong());
-    }
+        @Test
+        @DisplayName("회원이 존재하지 않으면 예외가 발생한다")
+        void commentWriteNotFoundComment() {
+            CommentWriteRequest commentWriteRequest = CommentWriteRequest.builder()
+                    .content("comment")
+                    .build();
 
-    @Test
-    @DisplayName("댓글을 수정한다")
-    void commentModify() {
-        CommentModifyRequest commentModifyRequest = new CommentModifyRequest("댓글");
-        Comment comment = Comment.builder()
-                .content("댓글")
-                .member(member)
-                .post(post)
-                .build();
+            given(postRepository.findByPostId(anyLong())).willReturn(post);
+            willThrow(new NotFoundMemberException()).given(memberRepository).findByMemberId(anyLong());
 
-        given(commentRepository.findCommentJoinFetchMember(anyLong(), anyLong())).willReturn(Optional.of(comment));
+            assertThatThrownBy(() -> commentService.commentWrite(1L, commentWriteRequest, 1L))
+                    .isInstanceOf(NotFoundMemberException.class);
 
-        commentService.commentModify(1L, 1L, commentModifyRequest, "yoon1234");
-
-        then(commentRepository).should().findCommentJoinFetchMember(anyLong(), anyLong());
-    }
-
-    @Test
-    @DisplayName("댓글 수정 시 댓글을 찾을 수 없으면 예외가 발생한다")
-    void commentModifyNotFoundComment() {
-        CommentModifyRequest commentModifyRequest = new CommentModifyRequest("댓글");
-
-        willThrow(new NotFoundCommentException()).given(commentRepository).findCommentJoinFetchMember(anyLong(), anyLong());
-
-        assertThatThrownBy(() -> commentService.commentModify(1L, 1L, commentModifyRequest, "yoon1234"))
-                .isInstanceOf(NotFoundCommentException.class);
-
-        then(commentRepository).should().findCommentJoinFetchMember(anyLong(), anyLong());
-    }
-
-    @Test
-    @DisplayName("댓글 수정 시 작성자가 아닌데 수정을 시도하면 예외가 발생한다")
-    void commentModifyNotCommentOwner() {
-        CommentModifyRequest commentModifyRequest = new CommentModifyRequest("댓글");
-        Comment comment = Comment.builder()
-                .content("댓글")
-                .member(member)
-                .post(post)
-                .build();
-
-        given(commentRepository.findCommentJoinFetchMember(anyLong(), anyLong())).willReturn(Optional.of(comment));
-
-        assertThatThrownBy(() -> commentService.commentModify(1L, 1L, commentModifyRequest, "unknown"))
-                .isInstanceOf(CommentModifyAccessDeniedException.class);
-
-        then(commentRepository).should().findCommentJoinFetchMember(anyLong(), anyLong());
-    }
-
-    @Test
-    @DisplayName("이미 삭제된 댓글에 수정을 시도할 경우 예외가 발생한다")
-    void commentModifyAlreadyCommentDelete() {
-        CommentModifyRequest commentModifyRequest = new CommentModifyRequest("댓글");
-        Comment comment = Comment.builder()
-                .content("댓글")
-                .member(member)
-                .post(post)
-                .build();
-        comment.delete();
-
-        given(commentRepository.findCommentJoinFetchMember(anyLong(), anyLong())).willReturn(Optional.of(comment));
-
-        assertThatThrownBy(() -> commentService.commentModify(1L, 1L, commentModifyRequest, "yoon1234"))
-                .isInstanceOf(AlreadyDeleteCommentException.class);
-
-        then(commentRepository).should().findCommentJoinFetchMember(anyLong(), anyLong());
-    }
-
-    @Test
-    @DisplayName("댓글을 삭제한다")
-    void commentDelete() {
-        Comment comment = Comment.builder()
-                .content("댓글")
-                .member(member)
-                .post(post)
-                .build();
-
-        given(commentRepository.findCommentJoinFetchMember(anyLong(), anyLong())).willReturn(Optional.of(comment));
-
-        commentService.commentDelete(1L, 1L, "yoon1234");
-
-        then(commentRepository).should().findCommentJoinFetchMember(anyLong(), anyLong());
-    }
-
-    @Test
-    @DisplayName("댓글 삭제 시 댓글을 찾을 수 없으면 예외가 발생한다")
-    void commentDeleteNotFoundComment() {
-        willThrow(new NotFoundCommentException()).given(commentRepository).findCommentJoinFetchMember(anyLong(), anyLong());
-
-        assertThatThrownBy(() -> commentService.commentDelete(1L, 1L, "yoon1234"))
-                .isInstanceOf(NotFoundCommentException.class);
-
-        then(commentRepository).should().findCommentJoinFetchMember(anyLong(), anyLong());
-    }
-
-    @Test
-    @DisplayName("댓글 삭제 시 작성자가 아닌데 삭제를 시도하면 예외가 발생한다")
-    void commentDeleteNotCommentOwner() {
-        Comment comment = Comment.builder()
-                .content("댓글")
-                .member(member)
-                .post(post)
-                .build();
-
-        given(commentRepository.findCommentJoinFetchMember(anyLong(), anyLong())).willReturn(Optional.of(comment));
-
-        assertThatThrownBy(() -> commentService.commentDelete(1L, 1L, "unknown"))
-                .isInstanceOf(CommentDeleteAccessDeniedException.class);
-
-        then(commentRepository).should().findCommentJoinFetchMember(anyLong(), anyLong());
-    }
-
-    @Test
-    @DisplayName("이미 삭제된 댓글에 삭제를 시도할 경우 예외가 발생한다")
-    void commentDeleteAlreadyDeleteComment() {
-        Comment comment = Comment.builder()
-                .content("댓글")
-                .member(member)
-                .post(post)
-                .build();
-        comment.delete();
-
-        given(commentRepository.findCommentJoinFetchMember(anyLong(), anyLong())).willReturn(Optional.of(comment));
-
-        assertThatThrownBy(() -> commentService.commentDelete(1L, 1L, "yoon1234"))
-                .isInstanceOf(AlreadyDeleteCommentException.class);
-
-        then(commentRepository).should().findCommentJoinFetchMember(anyLong(), anyLong());
-    }
-
-    @Test
-    @DisplayName("특정 회원이 작성한 댓글 목록을 조회한다")
-    void commentListFromMember() {
-        List<Comment> content = List.of(
-                Comment.builder().content("댓글").member(member).post(post).build(),
-                Comment.builder().content("댓글").member(member).post(post).build(),
-                Comment.builder().content("댓글").member(member).post(post).build(),
-                Comment.builder().content("댓글").member(member).post(post).build(),
-                Comment.builder().content("댓글").member(member).post(post).build()
-        );
-        PageImpl<Comment> commentPage = new PageImpl<>(content);
-
-        given(commentRepository.findCommentsByMemberUsername(any(Pageable.class), anyString())).willReturn(commentPage);
-
-        commentService.commentListFromMember(0, "yoon1234");
-
-        then(commentRepository).should().findCommentsByMemberUsername(any(Pageable.class), anyString());
-    }
-
-    @Test
-    @DisplayName("대댓글을 작성한다")
-    void replyWrite() {
-        Comment comment = Comment.builder()
-                .content("댓글")
-                .member(member)
-                .post(post)
-                .build();
-
-        CommentWriteRequest replyWriteRequest = new CommentWriteRequest("대댓글");
-
-        given(commentRepository.findCommentByPostIdAndCommentId(anyLong(), anyLong())).willReturn(Optional.of(comment));
-        given(memberRepository.findMemberByUsername(anyString())).willReturn(Optional.of(member));
-
-        commentService.replyWrite(1L, 1L, replyWriteRequest, "yoon1234");
-
-        then(commentRepository).should().findCommentByPostIdAndCommentId(anyLong(), anyLong());
-        then(memberRepository).should().findMemberByUsername(anyString());
+            then(postRepository).should().findByPostId(anyLong());
+            then(memberRepository).should().findByMemberId(anyLong());
+            then(commentRepository).should(never()).save(any(Comment.class));
+        }
 
     }
 
-    @Test
-    @DisplayName("대댓글 작성 시 댓글을 찾을 수 없으면 예외가 발생한다")
-    void replyWriteNotFoundComment() {
-        CommentWriteRequest replyWriteRequest = new CommentWriteRequest("대댓글");
+    @Nested
+    @DisplayName("댓글 목록 조회")
+    class CommentListFind {
 
-        willThrow(new NotFoundCommentException()).given(commentRepository).findCommentByPostIdAndCommentId(anyLong(), anyLong());
+        @Test
+        @DisplayName("특정 게시글에 속한 댓글 목록을 조회한다")
+        void commentList() {
+            List<Comment> content = List.of(
+                    Comment.builder().writer(member.getNickname()).content("comment").member(member).post(post).build(),
+                    Comment.builder().writer(member.getNickname()).content("comment").member(member).post(post).build(),
+                    Comment.builder().writer(member.getNickname()).content("comment").member(member).post(post).build(),
+                    Comment.builder().writer(member.getNickname()).content("comment").member(member).post(post).build(),
+                    Comment.builder().writer(member.getNickname()).content("comment").member(member).post(post).build(),
+                    Comment.builder().writer(member.getNickname()).content("comment").member(member).post(post).build()
+            );
+            PageImpl<Comment> commentPage = new PageImpl<>(content);
 
-        assertThatThrownBy(() -> commentService.replyWrite(1L, 1L, replyWriteRequest, "yoon1234"))
-                .isInstanceOf(NotFoundCommentException.class);
+            given(commentRepository.findCommentsByPostId(any(Pageable.class), anyLong())).willReturn(commentPage);
 
-        then(commentRepository).should().findCommentByPostIdAndCommentId(anyLong(), anyLong());
-        then(memberRepository).should(never()).findMemberByUsername(anyString());
+            CommentListResponse response = commentService.commentList(1L, 0);
+
+            assertThat(response.getPage()).isEqualTo(1);
+            assertThat(response.getTotalElements()).isEqualTo(6);
+            assertThat(response.getTotalPages()).isEqualTo(1);
+            assertThat(response.isFirst()).isTrue();
+            assertThat(response.isLast()).isTrue();
+            assertThat(response.isPrev()).isFalse();
+            assertThat(response.isNext()).isFalse();
+            then(commentRepository).should().findCommentsByPostId(any(Pageable.class), anyLong());
+        }
+
     }
 
-    @Test
-    @DisplayName("대댓글 작성 시 회원을 찾을 수 없으면 예외가 발생한다")
-    void replyWriteNotFoundMember() {
-        Comment comment = Comment.builder()
-                .content("댓글")
-                .member(member)
-                .post(post)
-                .build();
+    @Nested
+    @DisplayName("댓글 수정")
+    class CommentModifyTest {
 
-        CommentWriteRequest replyWriteRequest = new CommentWriteRequest("대댓글");
+        @Test
+        @DisplayName("댓글을 수정한다")
+        void commentModify() {
+            CommentModifyRequest commentModifyRequest = CommentModifyRequest.builder()
+                    .content("newComment")
+                    .build();
 
-        given(commentRepository.findCommentByPostIdAndCommentId(anyLong(), anyLong())).willReturn(Optional.of(comment));
-        willThrow(new NotFoundMemberException()).given(memberRepository).findMemberByUsername(anyString());
+            Comment comment = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("comment")
+                    .member(member)
+                    .post(post)
+                    .build();
 
-        assertThatThrownBy(() -> commentService.replyWrite(1L, 1L, replyWriteRequest, "yoon1234"))
-                .isInstanceOf(NotFoundMemberException.class);
+            given(commentRepository.findCommentByPostIdAndCommentId(anyLong(), anyLong())).willReturn(Optional.of(comment));
 
-        then(commentRepository).should().findCommentByPostIdAndCommentId(anyLong(), anyLong());
-        then(memberRepository).should().findMemberByUsername(anyString());
+            commentService.commentModify(1L, 1L, commentModifyRequest, 1L);
+
+            then(commentRepository).should().findCommentByPostIdAndCommentId(anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("댓글이 존재하지 않으면 예외가 발생한다")
+        void commentModifyNotFoundComment() {
+            CommentModifyRequest commentModifyRequest = CommentModifyRequest.builder()
+                    .content("newComment")
+                    .build();
+
+            willThrow(new NotFoundCommentException()).given(commentRepository).findCommentByPostIdAndCommentId(anyLong(), anyLong());
+
+            assertThatThrownBy(() -> commentService.commentModify(1L, 1L, commentModifyRequest, 1L))
+                    .isInstanceOf(NotFoundCommentException.class);
+
+            then(commentRepository).should().findCommentByPostIdAndCommentId(anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 댓글이면 예외가 발생한다")
+        void commentModifyAlreadyCommentDelete() {
+            CommentModifyRequest commentModifyRequest = CommentModifyRequest.builder()
+                    .content("newComment")
+                    .build();
+
+            Comment comment = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("comment")
+                    .member(member)
+                    .post(post)
+                    .build();
+            comment.delete();
+
+            given(commentRepository.findCommentByPostIdAndCommentId(anyLong(), anyLong())).willReturn(Optional.of(comment));
+
+            assertThatThrownBy(() -> commentService.commentModify(1L, 1L, commentModifyRequest, 1L))
+                    .isInstanceOf(AlreadyDeleteCommentException.class);
+
+            then(commentRepository).should().findCommentByPostIdAndCommentId(anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("작성자가 아니면 예외가 발생한다")
+        void commentModifyNotCommentOwner() {
+            CommentModifyRequest commentModifyRequest = CommentModifyRequest.builder()
+                    .content("newComment")
+                    .build();
+
+            Comment comment = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("comment")
+                    .member(member)
+                    .post(post)
+                    .build();
+
+            given(commentRepository.findCommentByPostIdAndCommentId(anyLong(), anyLong())).willReturn(Optional.of(comment));
+
+            assertThatThrownBy(() -> commentService.commentModify(1L, 1L, commentModifyRequest, 2L))
+                    .isInstanceOf(CommentModifyAccessDeniedException.class);
+
+            then(commentRepository).should().findCommentByPostIdAndCommentId(anyLong(), anyLong());
+        }
+
+    }
+
+    @Nested
+    @DisplayName("댓글 삭제")
+    class CommentDeleteTest {
+
+        @Test
+        @DisplayName("댓글을 삭제한다")
+        void commentDelete() {
+            Comment comment = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("comment")
+                    .member(member)
+                    .post(post)
+                    .build();
+
+            given(commentRepository.findCommentByPostIdAndCommentId(anyLong(), anyLong())).willReturn(Optional.of(comment));
+
+            commentService.commentDelete(1L, 1L, 1L);
+
+            then(commentRepository).should().findCommentByPostIdAndCommentId(anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("댓글이 존재하지 않으면 예외가 발생한다")
+        void commentDeleteNotFoundComment() {
+            willThrow(new NotFoundCommentException()).given(commentRepository).findCommentByPostIdAndCommentId(anyLong(), anyLong());
+
+            assertThatThrownBy(() -> commentService.commentDelete(1L, 1L, 1L))
+                    .isInstanceOf(NotFoundCommentException.class);
+
+            then(commentRepository).should().findCommentByPostIdAndCommentId(anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 댓글이면 예외가 발생한다")
+        void commentDeleteAlreadyCommentDelete() {
+            Comment comment = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("comment")
+                    .member(member)
+                    .post(post)
+                    .build();
+            comment.delete();
+
+            given(commentRepository.findCommentByPostIdAndCommentId(anyLong(), anyLong())).willReturn(Optional.of(comment));
+
+            assertThatThrownBy(() -> commentService.commentDelete(1L, 1L, 1L))
+                    .isInstanceOf(AlreadyDeleteCommentException.class);
+
+            then(commentRepository).should().findCommentByPostIdAndCommentId(anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("작성자가 아니면 예외가 발생한다")
+        void commentDeleteNotCommentOwner() {
+            Comment comment = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("comment")
+                    .member(member)
+                    .post(post)
+                    .build();
+
+            given(commentRepository.findCommentByPostIdAndCommentId(anyLong(), anyLong())).willReturn(Optional.of(comment));
+
+            assertThatThrownBy(() -> commentService.commentDelete(1L, 1L, 2L))
+                    .isInstanceOf(CommentDeleteAccessDeniedException.class);
+
+            then(commentRepository).should().findCommentByPostIdAndCommentId(anyLong(), anyLong());
+        }
+
     }
 
 }


### PR DESCRIPTION
## 설명

댓글 수정 및 삭제 시 요청을 보낸 클라이언트가 해당 댓글의 작성자가 맞는지 검증하는 로직 리팩토링

## 작업 내용

작성자 검증 로직을 회원 아이디(username)가 아닌 회원 기본키(id)를 비교하는 것으로 변경했습니다.

- 댓글 조회 시 회원을 페치 조인하는 메서드를 제거했습니다.

댓글 관련 테스트 코드를 수정 했습니다.

- `@Nested`를 사용해 작업 별로 테스트 코드를 분리 했습니다.
- 특정 상황에서 발생할 수 있는 예외 테스트 케이스를 추가했습니다.

## 관련 이슈

- close #98
- close #99
