### PR TITLE
AuthenticationPrincipal 커스텀 애노테이션 추가

### DIFF
--- a/backend/src/main/java/com/board/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/board/domain/comment/controller/CommentController.java
@@ -5,6 +5,7 @@ import com.board.domain.comment.dto.CommentModifyRequest;
 import com.board.domain.comment.dto.CommentWriteRequest;
 import com.board.domain.comment.service.CommentService;
 import com.board.global.common.dto.ApiResponse;
+import com.board.global.security.annotation.LoginMember;
 
 import jakarta.validation.Valid;
 
@@ -12,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,7 +34,7 @@ public class CommentController {
     @PostMapping("/{postId}/comments")
     public ResponseEntity<ApiResponse<Void>> commentWrite(@PathVariable("postId") Long postId,
                                                           @RequestBody @Valid CommentWriteRequest commentWriteRequest,
-                                                          @AuthenticationPrincipal Long memberId) {
+                                                          @LoginMember Long memberId) {
         commentService.commentWrite(postId, commentWriteRequest, memberId);
         return ResponseEntity.ok().body(ApiResponse.success());
     }
@@ -44,7 +44,7 @@ public class CommentController {
     public ResponseEntity<ApiResponse<Void>> replyWrite(@PathVariable("postId") Long postId,
                                                         @PathVariable("commentId") Long commentId,
                                                         @RequestBody @Valid CommentWriteRequest commentWriteRequest,
-                                                        @AuthenticationPrincipal Long memberId) {
+                                                        @LoginMember Long memberId) {
         commentService.replyWrite(postId, commentId, commentWriteRequest, memberId);
         return ResponseEntity.ok().body(ApiResponse.success());
     }
@@ -62,7 +62,7 @@ public class CommentController {
     public ResponseEntity<ApiResponse<Void>> commentModify(@PathVariable("postId") Long postId,
                                                            @PathVariable("commentId") Long commentId,
                                                            @RequestBody @Valid CommentModifyRequest commentModifyRequest,
-                                                           @AuthenticationPrincipal Long memberId) {
+                                                           @LoginMember Long memberId) {
         commentService.commentModify(postId, commentId, commentModifyRequest, memberId);
         return ResponseEntity.ok().body(ApiResponse.success());
     }
@@ -71,7 +71,7 @@ public class CommentController {
     @DeleteMapping("/{postId}/comments/{commentId}")
     public ResponseEntity<ApiResponse<Void>> commentDelete(@PathVariable("postId") Long postId,
                                                            @PathVariable("commentId") Long commentId,
-                                                           @AuthenticationPrincipal Long memberId) {
+                                                           @LoginMember Long memberId) {
         commentService.commentDelete(postId, commentId, memberId);
         return ResponseEntity.ok().body(ApiResponse.success());
     }

--- a/backend/src/main/java/com/board/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/board/domain/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.board.domain.member.dto.MemberSignupRequest;
 import com.board.domain.member.service.MemberService;
 import com.board.domain.post.dto.PostListResponse;
 import com.board.global.common.dto.ApiResponse;
+import com.board.global.security.annotation.LoginMember;
 
 import jakarta.validation.Valid;
 
@@ -15,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -52,7 +52,7 @@ public class MemberController {
 
     @Secured("ROLE_MEMBER")
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<MemberProfileResponse>> memberProfile(@AuthenticationPrincipal Long memberId) {
+    public ResponseEntity<ApiResponse<MemberProfileResponse>> memberProfile(@LoginMember Long memberId) {
         MemberProfileResponse memberProfileResponse = memberService.memberProfile(memberId);
         return ResponseEntity.ok().body(ApiResponse.success(memberProfileResponse));
     }
@@ -60,7 +60,7 @@ public class MemberController {
     @Secured("ROLE_MEMBER")
     @GetMapping("/me/posts")
     public ResponseEntity<ApiResponse<PostListResponse>> memberPostList(@RequestParam("page") int page,
-                                                                        @AuthenticationPrincipal Long memberId) {
+                                                                        @LoginMember Long memberId) {
         page = page <= 0 ? 0 : page - 1;
         PostListResponse postListResponse = memberService.memberPostList(page, memberId);
         return ResponseEntity.ok().body(ApiResponse.success(postListResponse));
@@ -69,7 +69,7 @@ public class MemberController {
     @Secured("ROLE_MEMBER")
     @GetMapping("/me/comments")
     public ResponseEntity<ApiResponse<MemberCommentListResponse>> memberCommentList(@RequestParam("page") int page,
-                                                                                    @AuthenticationPrincipal Long memberId) {
+                                                                                    @LoginMember Long memberId) {
         page = page <= 0 ? 0 : page - 1;
         MemberCommentListResponse memberCommentListResponse = memberService.memberCommentList(page, memberId);
         return ResponseEntity.ok().body(ApiResponse.success(memberCommentListResponse));
@@ -78,7 +78,7 @@ public class MemberController {
     @Secured("ROLE_MEMBER")
     @PutMapping("/me/nickname")
     public ResponseEntity<ApiResponse<Void>> memberNicknameChange(@RequestBody @Valid MemberNicknameRequest memberNicknameRequest,
-                                                                  @AuthenticationPrincipal Long memberId) {
+                                                                  @LoginMember Long memberId) {
         memberService.memberNicknameChange(memberNicknameRequest, memberId);
         return ResponseEntity.ok(ApiResponse.success());
     }
@@ -86,7 +86,7 @@ public class MemberController {
     @Secured("ROLE_MEMBER")
     @PutMapping("/me/password")
     public ResponseEntity<ApiResponse<Void>> memberPasswordChange(@RequestBody @Valid MemberPasswordRequest memberPasswordRequest,
-                                                                  @AuthenticationPrincipal Long memberId) {
+                                                                  @LoginMember Long memberId) {
         memberService.memberPasswordChange(memberPasswordRequest, memberId);
         return ResponseEntity.ok().body(ApiResponse.success());
     }

--- a/backend/src/main/java/com/board/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/board/domain/post/controller/PostController.java
@@ -6,6 +6,7 @@ import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.service.PostService;
 import com.board.global.common.dto.ApiResponse;
+import com.board.global.security.annotation.LoginMember;
 
 import jakarta.validation.Valid;
 
@@ -13,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,7 +34,7 @@ public class PostController {
     @Secured("ROLE_MEMBER")
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> postWrite(@RequestBody @Valid PostWriteRequest postWriteRequest,
-                                                       @AuthenticationPrincipal Long memberId) {
+                                                       @LoginMember Long memberId) {
         postService.postWrite(postWriteRequest, memberId);
         return ResponseEntity.ok().body(ApiResponse.success());
     }
@@ -65,7 +65,7 @@ public class PostController {
     @PutMapping("/{postId}")
     public ResponseEntity<ApiResponse<Void>> postModify(@PathVariable("postId") Long postId,
                                                         @RequestBody @Valid PostModifyRequest postModifyRequest,
-                                                        @AuthenticationPrincipal Long memberId) {
+                                                        @LoginMember Long memberId) {
         postService.postModify(postId, postModifyRequest, memberId);
         return ResponseEntity.ok().body(ApiResponse.success());
     }
@@ -73,7 +73,7 @@ public class PostController {
     @Secured("ROLE_MEMBER")
     @DeleteMapping("/{postId}")
     public ResponseEntity<ApiResponse<Void>> postDelete(@PathVariable("postId") Long postId,
-                                                        @AuthenticationPrincipal Long memberId) {
+                                                        @LoginMember Long memberId) {
         postService.postDelete(postId, memberId);
         return ResponseEntity.ok().body(ApiResponse.success());
     }

--- a/backend/src/main/java/com/board/global/security/annotation/LoginMember.java
+++ b/backend/src/main/java/com/board/global/security/annotation/LoginMember.java
@@ -1,0 +1,14 @@
+package com.board.global.security.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal
+public @interface LoginMember {
+}


### PR DESCRIPTION
## 설명

AuthenticationPrincipal 커스텀 애노테이션 추가

## 작업 내용

`@AuthenticationPrincipal`래핑한 `@LoginMember`를 추가 했습니다.

- 각 컨트롤러에서 로그인 사용자 정보를 가져오는 `@AuthenticationPrincipal`를 `@LoginMember`로 교체했습니다.

## 관련 이슈

- close #96 