### PR TITLE
댓글 삭제 로직 변경

### DIFF
--- a/backend/src/main/java/com/board/domain/comment/entity/Comment.java
+++ b/backend/src/main/java/com/board/domain/comment/entity/Comment.java
@@ -21,6 +21,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @NoArgsConstructor
@@ -75,12 +76,25 @@ public class Comment extends BaseEntity {
         this.content = content;
     }
 
-    public void delete() {
+    public void softDelete() {
         this.isDelete = true;
+    }
+
+    public void deleteReply(Comment reply) {
+        reply.getReplies().remove(this);
+        replies.remove(reply);
+    }
+
+    public boolean isReply() {
+        return Objects.nonNull(reference);
     }
 
     public boolean isOwner(Long memberId) {
         return member.getId().equals(memberId);
+    }
+
+    public boolean hasReplies() {
+        return !replies.isEmpty();
     }
 
 }

--- a/backend/src/main/java/com/board/domain/comment/repository/CommentCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/board/domain/comment/repository/CommentCustomRepositoryImpl.java
@@ -30,7 +30,7 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
                 .select(Projections.constructor(CommentItem.class,
                         comment.id,
                         comment.writer,
-                        comment.count(),
+                        comment.content,
                         comment.createdAt))
                 .from(comment)
                 .where(comment.member.id.eq(memberId).and(comment.isDelete.eq(false)))

--- a/backend/src/main/java/com/board/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/board/domain/comment/service/CommentService.java
@@ -89,10 +89,31 @@ public class CommentService {
         if (!comment.isOwner(memberId)) {
             throw new CommentDeleteAccessDeniedException();
         }
+        if (!comment.isReply()) {
+            commentDelete(comment);
+        } else {
+            replyDelete(comment);
+        }
+    }
+
+    private void commentDelete(Comment comment) {
         if (comment.isDelete()) {
             throw new AlreadyDeleteCommentException();
         }
-        comment.delete();
+        if (comment.hasReplies()) {
+            comment.softDelete();
+        } else {
+            commentRepository.delete(comment);
+        }
+    }
+
+    private void replyDelete(Comment reply) {
+        Comment reference = reply.getReference();
+        reference.deleteReply(reply);
+        commentRepository.delete(reply);
+        if (!reference.hasReplies() && reference.isDelete()) {
+            commentRepository.delete(reference);
+        }
     }
 
 }

--- a/backend/src/test/java/com/board/domain/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/board/domain/comment/controller/CommentControllerTest.java
@@ -2,6 +2,8 @@ package com.board.domain.comment.controller;
 
 import com.board.domain.comment.dto.CommentModifyRequest;
 import com.board.domain.comment.dto.CommentWriteRequest;
+import com.board.domain.comment.exception.AlreadyDeleteCommentException;
+import com.board.domain.comment.exception.CommentDeleteAccessDeniedException;
 import com.board.domain.comment.exception.NotFoundCommentException;
 import com.board.domain.comment.service.CommentService;
 import com.board.domain.post.exception.NotFoundPostException;
@@ -546,6 +548,74 @@ class CommentControllerTest extends ControllerTest {
                     .andExpect(jsonPath("$.status").value("fail"))
                     .andExpect(jsonPath("$.error.code").value("E404003"))
                     .andExpect(jsonPath("$.error.message").value("댓글을 찾을 수 없습니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호"),
+                                    parameterWithName("commentId").description("댓글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 댓글을 삭제를 시도하면 예외가 발생한다")
+        void commentDeleteAlreadyDeleteComment() throws Exception {
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willThrow(new AlreadyDeleteCommentException()).given(commentService).commentDelete(anyLong(), anyLong(), anyLong());
+
+            mockMvc.perform(delete("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                            .header("Authorization", "Bearer access-token")
+                    )
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E404004"))
+                    .andExpect(jsonPath("$.error.message").value("이미 삭제된 댓글입니다."))
+                    .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("postId").description("게시글 번호"),
+                                    parameterWithName("commentId").description("댓글 번호")
+                            ),
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("댓글 작성자가 아닌데 삭제를 시도하면 예외가 발생한다")
+        void commentDeleteNotCommentOwner() throws Exception {
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willThrow(new CommentDeleteAccessDeniedException()).given(commentService).commentDelete(anyLong(), anyLong(), anyLong());
+
+            mockMvc.perform(delete("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                            .header("Authorization", "Bearer access-token")
+                    )
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E403004"))
+                    .andExpect(jsonPath("$.error.message").value("댓글 삭제는 작성자만 할 수 있습니다."))
                     .andExpect(jsonPath("$.error.fields").isEmpty())
                     .andDo(restDocs.document(
                             pathParameters(

--- a/backend/src/test/java/com/board/domain/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/comment/repository/CommentRepositoryTest.java
@@ -247,8 +247,8 @@ class CommentRepositoryTest extends RepositoryTest {
     class CommentDeleteTest {
 
         @Test
-        @DisplayName("댓글을 삭제한다")
-        void delete() {
+        @DisplayName("댓글을 논리 삭제한다")
+        void softDelete() {
             Comment comment = Comment.builder()
                     .writer(member.getNickname())
                     .content("comment")
@@ -260,9 +260,28 @@ class CommentRepositoryTest extends RepositoryTest {
             Comment findComment = commentRepository.findCommentByPostIdAndCommentId(post.getId(), comment.getId())
                     .orElseThrow(NotFoundCommentException::new);
 
-            findComment.delete();
+            findComment.softDelete();
 
             assertThat(findComment.isDelete()).isTrue();
+        }
+
+        @Test
+        @DisplayName("댓글을 물리 삭제한다")
+        void hardDelete() {
+            Comment comment = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("comment")
+                    .member(member)
+                    .post(post)
+                    .build();
+            commentRepository.save(comment);
+
+            Comment findComment = commentRepository.findCommentByPostIdAndCommentId(post.getId(), comment.getId())
+                    .orElseThrow(NotFoundCommentException::new);
+
+            commentRepository.delete(findComment);
+
+            assertThat(commentRepository.findCommentByPostIdAndCommentId(post.getId(), comment.getId())).isEmpty();
         }
 
     }

--- a/backend/src/test/java/com/board/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/board/domain/comment/service/CommentServiceTest.java
@@ -39,8 +39,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 class CommentServiceTest extends ServiceTest {
 
@@ -251,7 +253,7 @@ class CommentServiceTest extends ServiceTest {
                     .member(member)
                     .post(post)
                     .build();
-            comment.delete();
+            comment.softDelete();
 
             given(commentRepository.findCommentByPostIdAndCommentId(anyLong(), anyLong())).willReturn(Optional.of(comment));
 
@@ -289,21 +291,91 @@ class CommentServiceTest extends ServiceTest {
     @DisplayName("댓글 삭제")
     class CommentDeleteTest {
 
-        @Test
-        @DisplayName("댓글을 삭제한다")
-        void commentDelete() {
-            Comment comment = Comment.builder()
-                    .writer(member.getNickname())
+        private Comment comment;
+
+        @BeforeEach
+        void setUp() {
+            comment = Comment.builder()
+                    .writer("yoonkun")
                     .content("comment")
-                    .member(member)
                     .post(post)
+                    .member(member)
                     .build();
+        }
+
+        @Test
+        @DisplayName("대댓글이 존재하면 댓글을 논리 삭제한다")
+        void commentSoftDeleteHasReplies() {
+            Comment reply = Comment.builder()
+                    .writer("yoonkun")
+                    .content("reply")
+                    .post(post)
+                    .member(member)
+                    .reference(comment)
+                    .build();
+            comment.addReply(reply);
 
             given(commentRepository.findCommentByPostIdAndCommentId(anyLong(), anyLong())).willReturn(Optional.of(comment));
 
             commentService.commentDelete(1L, 1L, 1L);
 
             then(commentRepository).should().findCommentByPostIdAndCommentId(anyLong(), anyLong());
+            then(commentRepository).should(never()).delete(any(Comment.class));
+        }
+
+        @Test
+        @DisplayName("대댓글이 존재하지 않으면 댓글을 물리 삭제한다")
+        void commentHardDeleteHasNoReplies() {
+            given(commentRepository.findCommentByPostIdAndCommentId(anyLong(), anyLong())).willReturn(Optional.of(comment));
+            willDoNothing().given(commentRepository).delete(any(Comment.class));
+
+            commentService.commentDelete(1L, 1L, 1L);
+
+            then(commentRepository).should().findCommentByPostIdAndCommentId(anyLong(), anyLong());
+            then(commentRepository).should().delete(any(Comment.class));
+        }
+
+        @Test
+        @DisplayName("대댓글을 삭제한다")
+        void commentReplyDelete() {
+            Comment reply = Comment.builder()
+                    .writer("yoonkun")
+                    .content("reply")
+                    .post(post)
+                    .member(member)
+                    .reference(comment)
+                    .build();
+            comment.addReply(reply);
+
+            given(commentRepository.findCommentByPostIdAndCommentId(anyLong(), anyLong())).willReturn(Optional.of(reply));
+            willDoNothing().given(commentRepository).delete(any(Comment.class));
+
+            commentService.commentDelete(1L, 1L, 1L);
+
+            then(commentRepository).should().findCommentByPostIdAndCommentId(anyLong(), anyLong());
+            then(commentRepository).should().delete(any(Comment.class));
+        }
+
+        @Test
+        @DisplayName("논리 삭제된 댓글에 작성된 대댓글을 삭제 후 대댓글이 없는 경우 댓글도 물리 삭제한다")
+        void commentDeleteReplyDeleteHasNoReplies() {
+            Comment reply = Comment.builder()
+                    .writer("yoonkun")
+                    .content("reply")
+                    .post(post)
+                    .member(member)
+                    .reference(comment)
+                    .build();
+            comment.addReply(reply);
+            comment.softDelete();
+
+            given(commentRepository.findCommentByPostIdAndCommentId(anyLong(), anyLong())).willReturn(Optional.of(reply));
+            willDoNothing().given(commentRepository).delete(any(Comment.class));
+
+            commentService.commentDelete(1L, 1L, 1L);
+
+            then(commentRepository).should().findCommentByPostIdAndCommentId(anyLong(), anyLong());
+            then(commentRepository).should(times(2)).delete(any(Comment.class));
         }
 
         @Test
@@ -326,7 +398,7 @@ class CommentServiceTest extends ServiceTest {
                     .member(member)
                     .post(post)
                     .build();
-            comment.delete();
+            comment.softDelete();
 
             given(commentRepository.findCommentByPostIdAndCommentId(anyLong(), anyLong())).willReturn(Optional.of(comment));
 


### PR DESCRIPTION
## 설명

댓글 삭제 로직을 변경했습니다.

## 작업 내용

댓글 삭제를 delete 플래그를 조작해 논리 삭제(soft delete)로만 동작하던 방식을 다음과 같이 변경했습니다.

#### 1. 댓글 삭제

- 삭제하려는 댓글에 대댓글이 존재하면 논리 삭제(soft delete)한다.
- 삭제하려는 댓글에 대댓글이 존재하지 않으면 물리 삭제(hard delete)한다.

#### 2. 대댓글 삭제

- 대댓글 삭제는 물리 삭제만 한다.
- 대댓글 삭제 시 댓글이 논리 삭제된 상태이고 더 이상 대댓글이 존재하지 않으면 해당 댓글을 물리 삭제한다.

변경된 댓글 삭제 기능에 대한 테스트 케이스를 추가했습니다.

## 관련 이슈

- close #102 