### PR TITLE
@Secured 개선

### DIFF
--- a/backend/src/main/java/com/board/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/board/domain/comment/controller/CommentController.java
@@ -7,12 +7,12 @@ import com.board.domain.comment.service.CommentService;
 import com.board.global.common.dto.ApiResponse;
 import com.board.global.security.annotation.LoginMember;
 
+import com.board.global.security.annotation.RoleMember;
 import jakarta.validation.Valid;
 
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,7 +30,7 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    @Secured("ROLE_MEMBER")
+    @RoleMember
     @PostMapping("/{postId}/comments")
     public ResponseEntity<ApiResponse<Void>> commentWrite(@PathVariable("postId") Long postId,
                                                           @RequestBody @Valid CommentWriteRequest commentWriteRequest,
@@ -39,7 +39,7 @@ public class CommentController {
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 
-    @Secured("ROLE_MEMBER")
+    @RoleMember
     @PostMapping("/{postId}/comments/{commentId}/replies")
     public ResponseEntity<ApiResponse<Void>> replyWrite(@PathVariable("postId") Long postId,
                                                         @PathVariable("commentId") Long commentId,
@@ -57,7 +57,7 @@ public class CommentController {
         return ResponseEntity.ok().body(ApiResponse.success(commentListResponse));
     }
 
-    @Secured("ROLE_MEMBER")
+    @RoleMember
     @PutMapping("/{postId}/comments/{commentId}")
     public ResponseEntity<ApiResponse<Void>> commentModify(@PathVariable("postId") Long postId,
                                                            @PathVariable("commentId") Long commentId,
@@ -67,7 +67,7 @@ public class CommentController {
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 
-    @Secured("ROLE_MEMBER")
+    @RoleMember
     @DeleteMapping("/{postId}/comments/{commentId}")
     public ResponseEntity<ApiResponse<Void>> commentDelete(@PathVariable("postId") Long postId,
                                                            @PathVariable("commentId") Long commentId,

--- a/backend/src/main/java/com/board/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/board/domain/member/controller/MemberController.java
@@ -10,12 +10,12 @@ import com.board.domain.post.dto.PostListResponse;
 import com.board.global.common.dto.ApiResponse;
 import com.board.global.security.annotation.LoginMember;
 
+import com.board.global.security.annotation.RoleMember;
 import jakarta.validation.Valid;
 
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -50,14 +50,14 @@ public class MemberController {
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 
-    @Secured("ROLE_MEMBER")
+    @RoleMember
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<MemberProfileResponse>> memberProfile(@LoginMember Long memberId) {
         MemberProfileResponse memberProfileResponse = memberService.memberProfile(memberId);
         return ResponseEntity.ok().body(ApiResponse.success(memberProfileResponse));
     }
 
-    @Secured("ROLE_MEMBER")
+    @RoleMember
     @GetMapping("/me/posts")
     public ResponseEntity<ApiResponse<PostListResponse>> memberPostList(@RequestParam("page") int page,
                                                                         @LoginMember Long memberId) {
@@ -66,7 +66,7 @@ public class MemberController {
         return ResponseEntity.ok().body(ApiResponse.success(postListResponse));
     }
 
-    @Secured("ROLE_MEMBER")
+    @RoleMember
     @GetMapping("/me/comments")
     public ResponseEntity<ApiResponse<MemberCommentListResponse>> memberCommentList(@RequestParam("page") int page,
                                                                                     @LoginMember Long memberId) {
@@ -75,7 +75,7 @@ public class MemberController {
         return ResponseEntity.ok().body(ApiResponse.success(memberCommentListResponse));
     }
 
-    @Secured("ROLE_MEMBER")
+    @RoleMember
     @PutMapping("/me/nickname")
     public ResponseEntity<ApiResponse<Void>> memberNicknameChange(@RequestBody @Valid MemberNicknameRequest memberNicknameRequest,
                                                                   @LoginMember Long memberId) {
@@ -83,7 +83,7 @@ public class MemberController {
         return ResponseEntity.ok(ApiResponse.success());
     }
 
-    @Secured("ROLE_MEMBER")
+    @RoleMember
     @PutMapping("/me/password")
     public ResponseEntity<ApiResponse<Void>> memberPasswordChange(@RequestBody @Valid MemberPasswordRequest memberPasswordRequest,
                                                                   @LoginMember Long memberId) {

--- a/backend/src/main/java/com/board/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/board/domain/post/controller/PostController.java
@@ -8,12 +8,12 @@ import com.board.domain.post.service.PostService;
 import com.board.global.common.dto.ApiResponse;
 import com.board.global.security.annotation.LoginMember;
 
+import com.board.global.security.annotation.RoleMember;
 import jakarta.validation.Valid;
 
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,7 +31,7 @@ public class PostController {
 
     private final PostService postService;
 
-    @Secured("ROLE_MEMBER")
+    @RoleMember
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> postWrite(@RequestBody @Valid PostWriteRequest postWriteRequest,
                                                        @LoginMember Long memberId) {
@@ -61,7 +61,7 @@ public class PostController {
         return ResponseEntity.ok().body(ApiResponse.success(postListResponse));
     }
 
-    @Secured("ROLE_MEMBER")
+    @RoleMember
     @PutMapping("/{postId}")
     public ResponseEntity<ApiResponse<Void>> postModify(@PathVariable("postId") Long postId,
                                                         @RequestBody @Valid PostModifyRequest postModifyRequest,
@@ -70,7 +70,7 @@ public class PostController {
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 
-    @Secured("ROLE_MEMBER")
+    @RoleMember
     @DeleteMapping("/{postId}")
     public ResponseEntity<ApiResponse<Void>> postDelete(@PathVariable("postId") Long postId,
                                                         @LoginMember Long memberId) {

--- a/backend/src/main/java/com/board/global/security/annotation/RoleMember.java
+++ b/backend/src/main/java/com/board/global/security/annotation/RoleMember.java
@@ -1,0 +1,14 @@
+package com.board.global.security.annotation;
+
+import org.springframework.security.access.annotation.Secured;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Secured("ROLE_MEMBER")
+public @interface RoleMember {
+}


### PR DESCRIPTION
## 설명

`@Secured`에 하드 코딩된 ROLE_MEMBER 부분을 커스텀 어노테이션을 추가해 개선했습니다.

## 작업 내용

- ROLE_MEMBER 권한을 갖는 커스텀 어노테이션 `@RoleMember`를 추가했습니다.
- 컨트롤러의 각 API에 ROLE_MEMBER 권한이 필요한 API인 경우 `@RoleMember` 어노테이션을 적용했습니다.

## 관련 이슈

- close #105 
