### PR TITLE
게시글 삭제 로직 변경

### DIFF
--- a/backend/src/main/java/com/board/domain/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/board/domain/comment/repository/CommentRepository.java
@@ -3,6 +3,7 @@ package com.board.domain.comment.repository;
 import com.board.domain.comment.entity.Comment;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,5 +13,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
 
     @Query("SELECT c FROM Comment AS c WHERE c.post.id = :postId AND c.id = :commentId")
     Optional<Comment> findCommentByPostIdAndCommentId(@Param("postId") Long postId, @Param("commentId") Long commentId);
+
+    @Modifying
+    @Query("DELETE FROM Comment AS c WHERE c.post.id = :postId")
+    void deleteByPostId(@Param("postId") Long postId);
 
 }

--- a/backend/src/main/java/com/board/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/board/domain/post/entity/Post.java
@@ -4,7 +4,6 @@ import com.board.domain.comment.entity.Comment;
 import com.board.domain.member.entity.Member;
 import com.board.global.common.entity.BaseEntity;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -45,7 +44,7 @@ public class Post extends BaseEntity {
     @JoinColumn(nullable = false)
     private Member member;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "post", cascade = CascadeType.REMOVE)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "post")
     private List<Comment> comments = new ArrayList<>();
 
     @Builder

--- a/backend/src/main/java/com/board/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/board/domain/post/service/PostService.java
@@ -1,5 +1,6 @@
 package com.board.domain.post.service;
 
+import com.board.domain.comment.repository.CommentRepository;
 import com.board.domain.member.entity.Member;
 import com.board.domain.member.repository.MemberRepository;
 import com.board.domain.post.dto.PostDetailResponse;
@@ -25,6 +26,7 @@ public class PostService {
 
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
 
     @Transactional
     public void postWrite(PostWriteRequest postWriteRequest, Long memberId) {
@@ -69,6 +71,7 @@ public class PostService {
         if (!post.isOwner(memberId)) {
             throw new PostDeleteAccessDeniedException();
         }
+        commentRepository.deleteByPostId(postId);
         postRepository.delete(post);
     }
 

--- a/backend/src/test/java/com/board/domain/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/comment/repository/CommentRepositoryTest.java
@@ -320,6 +320,29 @@ class CommentRepositoryTest extends RepositoryTest {
             assertThat(commentRepository.findCommentByPostIdAndCommentId(post.getId(), comment.getId())).isEmpty();
         }
 
+        @Test
+        @DisplayName("특정 게시글에 속한 댓글들을 삭제한다")
+        void deleteByPostId() {
+            Comment commentA = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("comment")
+                    .member(member)
+                    .post(post)
+                    .build();
+            Comment commentB = Comment.builder()
+                    .writer(member.getNickname())
+                    .content("comment")
+                    .member(member)
+                    .post(post)
+                    .build();
+            commentRepository.save(commentA);
+            commentRepository.save(commentB);
+
+            commentRepository.deleteByPostId(post.getId());
+
+            assertThat(commentRepository.findCommentListByPostId(post.getId()).size()).isEqualTo(0);
+        }
+
     }
 
 }

--- a/backend/src/test/java/com/board/domain/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/board/domain/post/service/PostServiceTest.java
@@ -1,5 +1,6 @@
 package com.board.domain.post.service;
 
+import com.board.domain.comment.repository.CommentRepository;
 import com.board.domain.member.entity.Member;
 import com.board.domain.member.exception.NotFoundMemberException;
 import com.board.domain.member.repository.MemberRepository;
@@ -49,6 +50,9 @@ class PostServiceTest extends ServiceTest {
 
     @Mock
     private PostRepository postRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
 
     @InjectMocks
     private PostService postService;
@@ -312,11 +316,13 @@ class PostServiceTest extends ServiceTest {
                     .build();
 
             given(postRepository.findByPostId(anyLong())).willReturn(post);
+            willDoNothing().given(commentRepository).deleteByPostId(anyLong());
             willDoNothing().given(postRepository).delete(any(Post.class));
 
             postService.postDelete(1L, 1L);
 
             then(postRepository).should().findByPostId(anyLong());
+            then(commentRepository).should().deleteByPostId(anyLong());
             then(postRepository).should().delete(any(Post.class));
         }
 
@@ -329,6 +335,7 @@ class PostServiceTest extends ServiceTest {
                     .isInstanceOf(NotFoundPostException.class);
 
             then(postRepository).should().findByPostId(anyLong());
+            then(commentRepository).should(never()).deleteByPostId(anyLong());
             then(postRepository).should(never()).delete(any(Post.class));
         }
 
@@ -348,6 +355,7 @@ class PostServiceTest extends ServiceTest {
                     .isInstanceOf(PostDeleteAccessDeniedException.class);
 
             then(postRepository).should().findByPostId(anyLong());
+            then(commentRepository).should(never()).deleteByPostId(anyLong());
             then(postRepository).should(never()).delete(any(Post.class));
         }
 


### PR DESCRIPTION
## 설명

게시글 삭제 시 연관된 모든 댓글도 함께 삭제하도록 기능을 변경했습니다.

## 작업 내용

- cascade REMOVE 옵션을 제거했습니다.
- 게시글 삭제 시 해당 게시글과 연관된 모든 댓글을 삭제하는 로직을 추가했습니다.

## 관련 이슈

- close #108 
