### PR TITLE
배포된 API 문서에 접근할 수 없는 문제 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com'
-version = '1.4.0'
+version = '1.4.1'
 
 java {
     sourceCompatibility = '17'

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -71,6 +71,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET,
+                                RequestURI.REST_API_DOCS.pattern(),
                                 RequestURI.MEMBER_NICKNAME_EXISTS.pattern(),
                                 RequestURI.MEMBER_USERNAME_EXISTS.pattern(),
                                 RequestURI.POST_DETAIL.pattern(),

--- a/backend/src/main/java/com/board/global/security/support/RequestURI.java
+++ b/backend/src/main/java/com/board/global/security/support/RequestURI.java
@@ -10,6 +10,7 @@ import static org.springframework.security.web.util.matcher.AntPathRequestMatche
 
 public enum RequestURI {
 
+    REST_API_DOCS(HttpMethod.GET, "/docs/board.html", true),
     MEMBER_NICKNAME_EXISTS(HttpMethod.GET, "/api/members/nickname/*", true),
     MEMBER_USERNAME_EXISTS(HttpMethod.GET, "/api/members/username/*", true),
     MEMBER_SIGNUP(HttpMethod.POST, "/api/members/signup", true),


### PR DESCRIPTION
## 설명

배포된 API 문서에 접근할 수 없는 문제를 수정했습니다.

## 작업 내용

- API 문서 경로에 대한 접근 권한을 permitAll로 설정했습니다.
- 버전을 1.4.0에서 1.4.1로 변경했습니다.

## 관련 이슈

- close #102 
