### PR TITLE
입력값 검증 방식 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com'
-version = '1.4.1'
+version = '1.4.2'
 
 java {
     sourceCompatibility = '17'

--- a/backend/src/main/java/com/board/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/board/domain/member/controller/MemberController.java
@@ -6,16 +6,19 @@ import com.board.domain.member.dto.MemberPasswordRequest;
 import com.board.domain.member.dto.MemberProfileResponse;
 import com.board.domain.member.dto.MemberSignupRequest;
 import com.board.domain.member.service.MemberService;
+import com.board.domain.member.validator.annotation.Nickname;
+import com.board.domain.member.validator.annotation.Username;
 import com.board.domain.post.dto.PostListResponse;
 import com.board.global.common.dto.ApiResponse;
 import com.board.global.security.annotation.LoginMember;
-
 import com.board.global.security.annotation.RoleMember;
+
 import jakarta.validation.Valid;
 
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
@@ -33,13 +37,13 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/nickname/{nickname}")
-    public ResponseEntity<ApiResponse<Void>> memberNicknameExists(@PathVariable("nickname") String nickname) {
+    public ResponseEntity<ApiResponse<Void>> memberNicknameExists(@PathVariable("nickname") @Nickname String nickname) {
         memberService.memberNicknameExists(nickname);
         return ResponseEntity.ok().body(ApiResponse.success());
     }
 
     @GetMapping("/username/{username}")
-    public ResponseEntity<ApiResponse<Void>> memberUsernameExists(@PathVariable("username") String username) {
+    public ResponseEntity<ApiResponse<Void>> memberUsernameExists(@PathVariable("username") @Username String username) {
         memberService.memberUsernameExists(username);
         return ResponseEntity.ok().body(ApiResponse.success());
     }

--- a/backend/src/main/java/com/board/domain/member/dto/MemberNicknameRequest.java
+++ b/backend/src/main/java/com/board/domain/member/dto/MemberNicknameRequest.java
@@ -1,6 +1,6 @@
 package com.board.domain.member.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import com.board.domain.member.validator.annotation.Nickname;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberNicknameRequest {
 
-    @NotBlank(message = "닉네임을 입력해 주세요.")
+    @Nickname
     private String nickname;
 
 }

--- a/backend/src/main/java/com/board/domain/member/dto/MemberPasswordRequest.java
+++ b/backend/src/main/java/com/board/domain/member/dto/MemberPasswordRequest.java
@@ -1,6 +1,6 @@
 package com.board.domain.member.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import com.board.domain.member.validator.annotation.Password;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -14,13 +14,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberPasswordRequest {
 
-    @NotBlank(message = "현재 비밀번호를 입력해 주세요.")
+    @Password(requiredMessage = "현재 비밀번호를 입력해 주세요.")
     private String curPassword;
 
-    @NotBlank(message = "새로운 비밀번호를 입력해 주세요.")
+    @Password(requiredMessage = "새로운 비밀번호를 입력해 주세요.")
     private String newPassword;
 
-    @NotBlank(message = "새로운 비밀번호를 한 번 더 입력해 주세요.")
+    @Password(requiredMessage = "새로운 비밀번호 확인을 입력해 주세요.")
     private String newPasswordConfirm;
 
 }

--- a/backend/src/main/java/com/board/domain/member/dto/MemberSignupRequest.java
+++ b/backend/src/main/java/com/board/domain/member/dto/MemberSignupRequest.java
@@ -1,6 +1,8 @@
 package com.board.domain.member.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import com.board.domain.member.validator.annotation.Nickname;
+import com.board.domain.member.validator.annotation.Password;
+import com.board.domain.member.validator.annotation.Username;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -14,16 +16,16 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberSignupRequest {
 
-    @NotBlank(message = "닉네임을 입력해 주세요.")
+    @Nickname
     private String nickname;
 
-    @NotBlank(message = "아이디를 입력해 주세요.")
+    @Username
     private String username;
 
-    @NotBlank(message = "비밀번호를 입력해 주세요.")
+    @Password
     private String password;
 
-    @NotBlank(message = "비밀번호를 한 번 더 입력해 주세요.")
+    @Password(requiredMessage = "비밀번호 확인을 입력해 주세요.")
     private String passwordConfirm;
 
 }

--- a/backend/src/main/java/com/board/domain/member/validator/NicknameValidator.java
+++ b/backend/src/main/java/com/board/domain/member/validator/NicknameValidator.java
@@ -1,0 +1,36 @@
+package com.board.domain.member.validator;
+
+import com.board.domain.member.validator.annotation.Nickname;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import org.springframework.util.StringUtils;
+
+public class NicknameValidator implements ConstraintValidator<Nickname, String> {
+
+    private String requiredMessage;
+    private String regexpMessage;
+    private String regexp;
+
+    @Override
+    public void initialize(Nickname constraintAnnotation) {
+        requiredMessage = constraintAnnotation.requiredMessage();
+        regexpMessage = constraintAnnotation.regexpMessage();
+        regexp = constraintAnnotation.regexp();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        context.disableDefaultConstraintViolation();
+        if (!StringUtils.hasLength(value)) {
+            context.buildConstraintViolationWithTemplate(requiredMessage)
+                    .addConstraintViolation();
+            return false;
+        }
+        context.buildConstraintViolationWithTemplate(regexpMessage)
+                .addConstraintViolation();
+        return value.matches(regexp);
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/member/validator/PasswordValidator.java
+++ b/backend/src/main/java/com/board/domain/member/validator/PasswordValidator.java
@@ -1,0 +1,36 @@
+package com.board.domain.member.validator;
+
+import com.board.domain.member.validator.annotation.Password;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import org.springframework.util.StringUtils;
+
+public class PasswordValidator implements ConstraintValidator<Password, String> {
+
+    private String requiredMessage;
+    private String regexpMessage;
+    private String regexp;
+
+    @Override
+    public void initialize(Password constraintAnnotation) {
+        requiredMessage = constraintAnnotation.requiredMessage();
+        regexpMessage = constraintAnnotation.regexpMessage();
+        regexp = constraintAnnotation.regexp();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        context.disableDefaultConstraintViolation();
+        if (!StringUtils.hasLength(value)) {
+            context.buildConstraintViolationWithTemplate(requiredMessage)
+                    .addConstraintViolation();
+            return false;
+        }
+        context.buildConstraintViolationWithTemplate(regexpMessage)
+                .addConstraintViolation();
+        return value.matches(regexp);
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/member/validator/UsernameValidator.java
+++ b/backend/src/main/java/com/board/domain/member/validator/UsernameValidator.java
@@ -1,0 +1,36 @@
+package com.board.domain.member.validator;
+
+import com.board.domain.member.validator.annotation.Username;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import org.springframework.util.StringUtils;
+
+public class UsernameValidator implements ConstraintValidator<Username, String> {
+
+    private String requiredMessage;
+    private String regexpMessage;
+    private String regexp;
+
+    @Override
+    public void initialize(Username constraintAnnotation) {
+        requiredMessage = constraintAnnotation.requiredMessage();
+        regexpMessage = constraintAnnotation.regexpMessage();
+        regexp = constraintAnnotation.regexp();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        context.disableDefaultConstraintViolation();
+        if (!StringUtils.hasLength(value)) {
+            context.buildConstraintViolationWithTemplate(requiredMessage)
+                    .addConstraintViolation();
+            return false;
+        }
+        context.buildConstraintViolationWithTemplate(regexpMessage)
+                .addConstraintViolation();
+        return value.matches(regexp);
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/member/validator/annotation/Nickname.java
+++ b/backend/src/main/java/com/board/domain/member/validator/annotation/Nickname.java
@@ -1,0 +1,30 @@
+package com.board.domain.member.validator.annotation;
+
+import com.board.domain.member.validator.NicknameValidator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = NicknameValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Nickname {
+
+    String requiredMessage() default "닉네임을 입력해 주세요.";
+
+    String regexpMessage() default "5~10자의 영문 소문자, 숫자를 사용해 주세요.";
+
+    String regexp() default "^[가-힣a-z0-9]{5,10}$";
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/backend/src/main/java/com/board/domain/member/validator/annotation/Password.java
+++ b/backend/src/main/java/com/board/domain/member/validator/annotation/Password.java
@@ -1,0 +1,30 @@
+package com.board.domain.member.validator.annotation;
+
+import com.board.domain.member.validator.PasswordValidator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = PasswordValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Password {
+
+    String requiredMessage() default "비밀번호를 입력해 주세요.";
+
+    String regexpMessage() default "8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해 주세요.";
+
+    String regexp() default "^[A-Za-z0-9`\\-=\\\\\\[\\];',./~!@#$%^&*()_+|{}:\"<>?]{8,16}$";
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/backend/src/main/java/com/board/domain/member/validator/annotation/Username.java
+++ b/backend/src/main/java/com/board/domain/member/validator/annotation/Username.java
@@ -1,0 +1,30 @@
+package com.board.domain.member.validator.annotation;
+
+import com.board.domain.member.validator.UsernameValidator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = UsernameValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Username {
+
+    String requiredMessage() default "아이디를 입력해 주세요.";
+
+    String regexpMessage() default "5~15자의 영문 소문자, 숫자를 사용해 주세요.";
+
+    String regexp() default "^[a-z0-9]{5,15}$";
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/backend/src/main/java/com/board/global/common/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/board/global/common/dto/ErrorResponse.java
@@ -2,15 +2,17 @@ package com.board.global.common.dto;
 
 import com.board.global.error.ErrorType;
 
+import jakarta.validation.ConstraintViolation;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Getter
@@ -33,12 +35,22 @@ public class ErrorResponse {
         this.fields = Field.errors(bindingResult);
     }
 
+    private ErrorResponse(ErrorType errorType, Set<ConstraintViolation<?>> constraintViolations) {
+        this.code = errorType.getErrorCode();
+        this.message = errorType.getMessage();
+        this.fields = Field.erros(constraintViolations);
+    }
+
     public static ErrorResponse of(ErrorType errorType) {
         return new ErrorResponse(errorType);
     }
 
     public static ErrorResponse of(ErrorType errorType, BindingResult bindingResult) {
         return new ErrorResponse(errorType, bindingResult);
+    }
+
+    public static ErrorResponse of(ErrorType errorType, Set<ConstraintViolation<?>> constraintViolations) {
+        return new ErrorResponse(errorType, constraintViolations);
     }
 
     @Getter
@@ -49,17 +61,29 @@ public class ErrorResponse {
         private String input;
         private String message;
 
-        private Field(FieldError fieldError) {
-            this.field = fieldError.getField();
-            this.input= fieldError.getRejectedValue() == null ? "" : fieldError.getRejectedValue().toString();
-            this.message = fieldError.getDefaultMessage();
+        private Field(String field, String input, String message) {
+            this.field = field;
+            this.input = input;
+            this.message = message;
         }
 
         public static List<Field> errors(BindingResult bindingResult) {
             return bindingResult.getFieldErrors()
                     .stream()
-                    .map(Field::new)
-                    .collect(Collectors.toList());
+                    .map(fieldError -> new Field(
+                            fieldError.getField(),
+                            fieldError.getRejectedValue() == null ? "" : fieldError.getRejectedValue().toString(),
+                            fieldError.getDefaultMessage()
+                    )).collect(Collectors.toList());
+        }
+
+        public static List<Field> erros(Set<ConstraintViolation<?>> constraintViolations) {
+            return constraintViolations.stream()
+                    .map(constraintViolation -> new Field(
+                            constraintViolation.getPropertyPath().toString().split("\\.")[1],
+                            constraintViolation.getInvalidValue().toString(),
+                            constraintViolation.getMessage()
+                    )).collect(Collectors.toList());
         }
 
     }

--- a/backend/src/main/java/com/board/global/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/board/global/error/GlobalExceptionHandler.java
@@ -4,6 +4,8 @@ import com.board.global.common.dto.ApiResponse;
 import com.board.global.common.dto.ErrorResponse;
 import com.board.global.error.exception.BaseException;
 
+import jakarta.validation.ConstraintViolationException;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.BindingResult;
@@ -18,27 +20,26 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<ErrorResponse>> handle(BaseException e) {
         ErrorType errorType = e.getErrorType();
         ErrorResponse errorResponse = ErrorResponse.of(errorType);
-        return ResponseEntity
-                .status(errorType.getStatus())
-                .body(ApiResponse.fail(errorResponse));
+        return ResponseEntity.status(errorType.getStatus()).body(ApiResponse.fail(errorResponse));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handle(ConstraintViolationException e) {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorType.INVALID_INPUT_VALUE, e.getConstraintViolations());
+        return ResponseEntity.badRequest().body(ApiResponse.fail(errorResponse));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<ErrorResponse>> handle(BindingResult bindingResult) {
-        ErrorType errorType = ErrorType.INVALID_INPUT_VALUE;
-        ErrorResponse errorResponse = ErrorResponse.of(errorType, bindingResult);
-        return ResponseEntity
-                .badRequest()
-                .body(ApiResponse.fail(errorResponse));
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorType.INVALID_INPUT_VALUE, bindingResult);
+        return ResponseEntity.badRequest().body(ApiResponse.fail(errorResponse));
     }
 
     @ExceptionHandler(AuthenticationException.class)
     public ResponseEntity<ApiResponse<ErrorResponse>> handle(AuthenticationException e) {
         ErrorType errorType = ErrorType.of(e.getMessage());
         ErrorResponse errorResponse = ErrorResponse.of(errorType);
-        return ResponseEntity
-                .status(errorType.getStatus())
-                .body(ApiResponse.fail(errorResponse));
+        return ResponseEntity.status(errorType.getStatus()).body(ApiResponse.fail(errorResponse));
     }
 
 }

--- a/backend/src/test/java/com/board/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/board/domain/member/controller/MemberControllerTest.java
@@ -90,6 +90,27 @@ class MemberControllerTest extends ControllerTest {
         }
 
         @Test
+        @DisplayName("닉네임이 정규표현식에 일치하지 않으면 예외가 발생한다")
+        void memberNicknameRegexpException() throws Exception {
+            mockMvc.perform(get("/api/members/nickname/{nickname}", "오렌지@"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("nickname"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value("오렌지@"))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("5~10자의 영문 소문자, 숫자를 사용해 주세요."))
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("nickname").description("닉네임")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
         @DisplayName("닉네임이 중복되면 예외가 발생한다")
         void memberNicknameExistsDuplicateNickname() throws Exception {
             willThrow(new DuplicateNicknameException()).given(memberService).memberNicknameExists(anyString());
@@ -130,6 +151,27 @@ class MemberControllerTest extends ControllerTest {
                             ),
                             responseFields(
                                     commonSuccessResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("아이디가 정규표현식에 일치하지 않으면 예외가 발생한다")
+        void memberUsernameRegexpException() throws Exception {
+            mockMvc.perform(get("/api/members/username/{username}", "yoon1234@"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("username"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value("yoon1234@"))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("5~15자의 영문 소문자, 숫자를 사용해 주세요."))
+                    .andDo(restDocs.document(
+                            pathParameters(
+                                    parameterWithName("username").description("아이디")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
                             )
                     ));
         }
@@ -314,7 +356,143 @@ class MemberControllerTest extends ControllerTest {
                     .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
                     .andExpect(jsonPath("$.error.fields[0].field").value("passwordConfirm"))
                     .andExpect(jsonPath("$.error.fields[0].input").value(""))
-                    .andExpect(jsonPath("$.error.fields[0].message").value("비밀번호를 한 번 더 입력해 주세요."))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("비밀번호 확인을 입력해 주세요."))
+                    .andDo(restDocs.document(
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("닉네임"),
+                                    fieldWithPath("username").type(STRING).description("아이디"),
+                                    fieldWithPath("password").type(STRING).description("비밀번호"),
+                                    fieldWithPath("passwordConfirm").type(STRING).description("비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("닉네임이 정규표현식에 일치하지 않으면 예외가 발생한다")
+        void memberSignupInvalidNicknameRegexp() throws Exception {
+            MemberSignupRequest memberSignupRequest = MemberSignupRequest.builder()
+                    .nickname("yoonkun@")
+                    .username("yoon1234")
+                    .password("12345678")
+                    .passwordConfirm("12345678")
+                    .build();
+
+            mockMvc.perform(post("/api/members/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberSignupRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("nickname"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value("yoonkun@"))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("5~10자의 영문 소문자, 숫자를 사용해 주세요."))
+                    .andDo(restDocs.document(
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("닉네임"),
+                                    fieldWithPath("username").type(STRING).description("아이디"),
+                                    fieldWithPath("password").type(STRING).description("비밀번호"),
+                                    fieldWithPath("passwordConfirm").type(STRING).description("비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("아이디가 정규표현식에 일치하지 않으면 예외가 발생한다")
+        void memberSignupInvalidUsernameRegexp() throws Exception {
+            MemberSignupRequest memberSignupRequest = MemberSignupRequest.builder()
+                    .nickname("yoonkun")
+                    .username("yoon123 4")
+                    .password("12345678")
+                    .passwordConfirm("12345678")
+                    .build();
+
+            mockMvc.perform(post("/api/members/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberSignupRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("username"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value("yoon123 4"))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("5~15자의 영문 소문자, 숫자를 사용해 주세요."))
+                    .andDo(restDocs.document(
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("닉네임"),
+                                    fieldWithPath("username").type(STRING).description("아이디"),
+                                    fieldWithPath("password").type(STRING).description("비밀번호"),
+                                    fieldWithPath("passwordConfirm").type(STRING).description("비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("비밀번호가 정규표현식에 일치하지 않으면 예외가 발생한다")
+        void memberSignupInvalidPasswordRegexp() throws Exception {
+            MemberSignupRequest memberSignupRequest = MemberSignupRequest.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password("12")
+                    .passwordConfirm("12345678")
+                    .build();
+
+            mockMvc.perform(post("/api/members/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberSignupRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("password"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value("12"))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해 주세요."))
+                    .andDo(restDocs.document(
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("닉네임"),
+                                    fieldWithPath("username").type(STRING).description("아이디"),
+                                    fieldWithPath("password").type(STRING).description("비밀번호"),
+                                    fieldWithPath("passwordConfirm").type(STRING).description("비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("비밀번호 확인이 정규표현식에 일치하지 않으면 예외가 발생한다")
+        void memberSignupInvalidPasswordConfirmRegexp() throws Exception {
+            MemberSignupRequest memberSignupRequest = MemberSignupRequest.builder()
+                    .nickname("yoonkun")
+                    .username("yoon1234")
+                    .password("12345678")
+                    .passwordConfirm("12")
+                    .build();
+
+            mockMvc.perform(post("/api/members/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberSignupRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("passwordConfirm"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value("12"))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해 주세요."))
                     .andDo(restDocs.document(
                             requestFields(
                                     fieldWithPath("nickname").type(STRING).description("닉네임"),
@@ -934,7 +1112,7 @@ class MemberControllerTest extends ControllerTest {
         @DisplayName("닉네임을 변경한다")
         void memberNicknameChange() throws Exception {
             MemberNicknameRequest memberNicknameRequest = MemberNicknameRequest.builder()
-                    .nickname("newNickname")
+                    .nickname("yoonkun")
                     .build();
 
             Claims claims = Jwts.claims()
@@ -1007,10 +1185,50 @@ class MemberControllerTest extends ControllerTest {
         }
 
         @Test
+        @DisplayName("닉네임이 정규표현식에 일치하지 않으면 예외가 발생한다")
+        void memberNicknameChangeInvalidNicknameRegexp() throws Exception {
+            MemberNicknameRequest memberNicknameRequest = MemberNicknameRequest.builder()
+                    .nickname("new@")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+
+            mockMvc.perform(put("/api/members/me/nickname")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberNicknameRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("nickname"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value("new@"))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("5~10자의 영문 소문자, 숫자를 사용해 주세요."))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("nickname").type(STRING).description("변경할 닉네임")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
         @DisplayName("회원이 존재하지 않으면 예외가 발생한다")
         void memberNicknameChangeNotFoundMember() throws Exception {
             MemberNicknameRequest memberNicknameRequest = MemberNicknameRequest.builder()
-                    .nickname("newNickname")
+                    .nickname("yookun")
                     .build();
 
             Claims claims = Jwts.claims()
@@ -1049,7 +1267,7 @@ class MemberControllerTest extends ControllerTest {
         @DisplayName("닉네임이 중복되면 예외가 발생한다")
         void memberNicknameChangeDuplicateNickname() throws Exception {
             MemberNicknameRequest memberNicknameRequest = MemberNicknameRequest.builder()
-                    .nickname("newNickname")
+                    .nickname("yoonkun")
                     .build();
 
             Claims claims = Jwts.claims()
@@ -1310,7 +1528,7 @@ class MemberControllerTest extends ControllerTest {
                     .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
                     .andExpect(jsonPath("$.error.fields[0].field").value("newPasswordConfirm"))
                     .andExpect(jsonPath("$.error.fields[0].input").value(""))
-                    .andExpect(jsonPath("$.error.fields[0].message").value("새로운 비밀번호를 한 번 더 입력해 주세요."))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("새로운 비밀번호 확인을 입력해 주세요."))
                     .andDo(restDocs.document(
                             requestHeaders(
                                     headerWithName("Authorization").description("액세스 토큰")
@@ -1327,10 +1545,10 @@ class MemberControllerTest extends ControllerTest {
         }
 
         @Test
-        @DisplayName("회원이 존재하지 않으면 예외가 발생한다")
-        void memberPasswordChangeNotFoundMember() throws Exception {
+        @DisplayName("현재 비밀번호가 정규표현식에 일치하지 않으면 예외가 발생한다")
+        void memberPasswordInvalidCurPaswordRegexp() throws Exception {
             MemberPasswordRequest memberPasswordRequest = MemberPasswordRequest.builder()
-                    .curPassword("12345678")
+                    .curPassword("1234")
                     .newPassword("87654321")
                     .newPasswordConfirm("87654321")
                     .build();
@@ -1342,17 +1560,107 @@ class MemberControllerTest extends ControllerTest {
                     .build();
 
             given(jwtManager.getPayload(anyString())).willReturn(claims);
-            willThrow(new NotFoundMemberException()).given(memberService).memberPasswordChange(any(MemberPasswordRequest.class), anyLong());
 
             mockMvc.perform(put("/api/members/me/password")
                             .header("Authorization", "Bearer access-token")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(memberPasswordRequest))
                     )
-                    .andExpect(status().isNotFound())
+                    .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.status").value("fail"))
-                    .andExpect(jsonPath("$.error.code").value("E404001"))
-                    .andExpect(jsonPath("$.error.message").value("회원을 찾을 수 없습니다."))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("curPassword"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value("1234"))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해 주세요."))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("curPassword").type(STRING).description("현재 사용 중인 비밀번호"),
+                                    fieldWithPath("newPassword").type(STRING).description("변경할 비밀번호"),
+                                    fieldWithPath("newPasswordConfirm").type(STRING).description("변경할 비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("새로운 비밀번호가 정규표현식에 일치하지 않으면 예외가 발생한다")
+        void memberPasswordInvalidNewPasswordRegexp() throws Exception {
+            MemberPasswordRequest memberPasswordRequest = MemberPasswordRequest.builder()
+                    .curPassword("12345678@")
+                    .newPassword("8765")
+                    .newPasswordConfirm("87654321")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+
+            mockMvc.perform(put("/api/members/me/password")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberPasswordRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("newPassword"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value("8765"))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해 주세요."))
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("curPassword").type(STRING).description("현재 사용 중인 비밀번호"),
+                                    fieldWithPath("newPassword").type(STRING).description("변경할 비밀번호"),
+                                    fieldWithPath("newPasswordConfirm").type(STRING).description("변경할 비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("새로운 비밀번호 확인이 정규표현식에 일치하지 않으면 예외가 발생한다")
+        void memberPasswordInvalidNewPasswordConfirmRegexp() throws Exception {
+            MemberPasswordRequest memberPasswordRequest = MemberPasswordRequest.builder()
+                    .curPassword("12345678@")
+                    .newPassword("87654321@")
+                    .newPasswordConfirm("8765")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+
+            mockMvc.perform(put("/api/members/me/password")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberPasswordRequest))
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E400001"))
+                    .andExpect(jsonPath("$.error.message").value("입력값이 잘못되었습니다."))
+                    .andExpect(jsonPath("$.error.fields[0].field").value("newPasswordConfirm"))
+                    .andExpect(jsonPath("$.error.fields[0].input").value("8765"))
+                    .andExpect(jsonPath("$.error.fields[0].message").value("8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해 주세요."))
                     .andDo(restDocs.document(
                             requestHeaders(
                                     headerWithName("Authorization").description("액세스 토큰")
@@ -1439,6 +1747,48 @@ class MemberControllerTest extends ControllerTest {
                     .andExpect(jsonPath("$.error.code").value("E400002"))
                     .andExpect(jsonPath("$.error.message").value("비밀번호가 일치하지 않습니다."))
                     .andExpect(jsonPath("$.error.fields").isEmpty())
+                    .andDo(restDocs.document(
+                            requestHeaders(
+                                    headerWithName("Authorization").description("액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("curPassword").type(STRING).description("현재 사용 중인 비밀번호"),
+                                    fieldWithPath("newPassword").type(STRING).description("변경할 비밀번호"),
+                                    fieldWithPath("newPasswordConfirm").type(STRING).description("변경할 비밀번호 확인")
+                            ),
+                            responseFields(
+                                    commonErrorResponse()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("회원이 존재하지 않으면 예외가 발생한다")
+        void memberPasswordChangeNotFoundMember() throws Exception {
+            MemberPasswordRequest memberPasswordRequest = MemberPasswordRequest.builder()
+                    .curPassword("12345678")
+                    .newPassword("87654321")
+                    .newPasswordConfirm("87654321")
+                    .build();
+
+            Claims claims = Jwts.claims()
+                    .subject(String.valueOf(1L))
+                    .add("nickname", "yoonkun")
+                    .add("authority", "ROLE_MEMBER")
+                    .build();
+
+            given(jwtManager.getPayload(anyString())).willReturn(claims);
+            willThrow(new NotFoundMemberException()).given(memberService).memberPasswordChange(any(MemberPasswordRequest.class), anyLong());
+
+            mockMvc.perform(put("/api/members/me/password")
+                            .header("Authorization", "Bearer access-token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(memberPasswordRequest))
+                    )
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("fail"))
+                    .andExpect(jsonPath("$.error.code").value("E404001"))
+                    .andExpect(jsonPath("$.error.message").value("회원을 찾을 수 없습니다."))
                     .andDo(restDocs.document(
                             requestHeaders(
                                     headerWithName("Authorization").description("액세스 토큰")


### PR DESCRIPTION
## 설명

회원가입, 닉네임 변경, 비밀번호 변경 시 입력값에 대한 정규 표현식 검증 방식을 추가했습니다.

## 작업 내용

- 유효성 검증을 위한 커스텀 어노테이션을 추가했습니다.
  - 닉네임 검증:`@Nickname` 
  - 아이디 검증: `@Username`
  - 비밀번호 검증: `@Password` 
- 전역 예외 처리 핸들러에 ConstraintViolationException을 처리하는 핸들러를 추가했습니다.
- 공통 예외 응답에 ConstraintViolationException에 대한 정보로 응답을 생성하는 기능을 추가했습니다.
- 버전을 변경했습니다. (1.4.1 → 1.4.2)

## 관련 이슈

- close #114 
