### PR TITLE
엔티티 구현

### DIFF
--- a/backend/src/main/java/com/board/domain/auth/entity/Token.java
+++ b/backend/src/main/java/com/board/domain/auth/entity/Token.java
@@ -1,0 +1,42 @@
+package com.board.domain.auth.entity;
+
+import com.board.domain.member.entity.Member;
+import com.board.global.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Token extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "token_id")
+    private Long id;
+
+    @Column(name = "refreshToken", nullable = false, unique = true)
+    private String refreshToken;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Builder
+    public Token(String refreshToken, Member member) {
+        this.refreshToken = refreshToken;
+        this.member = member;
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/comment/entity/Comment.java
+++ b/backend/src/main/java/com/board/domain/comment/entity/Comment.java
@@ -1,0 +1,52 @@
+package com.board.domain.comment.entity;
+
+import com.board.domain.member.entity.Member;
+import com.board.domain.post.entity.Post;
+import com.board.global.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String writer;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Builder
+    public Comment(String writer, String content, Member member, Post post) {
+        this.writer = writer;
+        this.content = content;
+        this.member = member;
+        this.post = post;
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/board/domain/member/entity/Member.java
@@ -1,0 +1,48 @@
+package com.board.domain.member.entity;
+
+import com.board.global.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Builder
+    public Member(String nickname, String username, String password) {
+        this.nickname = nickname;
+        this.username = username;
+        this.password = password;
+        this.role = Role.MEMBER;
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/member/entity/Role.java
+++ b/backend/src/main/java/com/board/domain/member/entity/Role.java
@@ -1,0 +1,17 @@
+package com.board.domain.member.entity;
+
+public enum Role {
+
+    MEMBER("ROLE_MEMBER");
+
+    private final String authority;
+
+    Role(String authority) {
+        this.authority = authority;
+    }
+
+    public String authority() {
+        return authority;
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/board/domain/post/entity/Post.java
@@ -1,0 +1,50 @@
+package com.board.domain.post.entity;
+
+import com.board.domain.member.entity.Member;
+import com.board.global.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String writer;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Builder
+    public Post(String title, String writer, String content, Member member) {
+        this.title = title;
+        this.writer = writer;
+        this.content = content;
+        this.member = member;
+    }
+
+}

--- a/backend/src/main/java/com/board/global/common/config/JpaAuditingConfig.java
+++ b/backend/src/main/java/com/board/global/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.board.global.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/backend/src/main/java/com/board/global/common/entity/BaseEntity.java
+++ b/backend/src/main/java/com/board/global/common/entity/BaseEntity.java
@@ -1,0 +1,28 @@
+package com.board.global.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+
+import lombok.Getter;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+}


### PR DESCRIPTION
# 작업 내용

회원, 게시글, 댓글, 토큰 엔티티 및 생성, 수정 시간을 기록하는 공통 엔티티(BaseEntity) 추가했으며 각 엔티티는 BaseEntity를 상속받는다.

회원(Member) 엔티티

- 기본키, 아이디, 닉네임, 비밀번호, 권한 필드를 가지며 null을 허용하지 않는다.
- 아이디와 닉네임 필드는 중복을 허용하지 않도록 unique 설정 추가

게시글(Post) 엔티티

- 기본키, 제목, 작성자, 내용, 회원 필드를 가지며 null을 허용하지 않는다.
- 게시글과 회원의 관계는 다대일(N:1) 관계 설정

댓글(Comment) 엔티티

- 기본키, 작성자, 내용, 회원, 게시글 필드를 가지며 null을 허용하지 않는다.
- 댓글과 회원의 관계는 다대일(N:1) 관계 설정
- 댓글과 게시글의 관계는 다대일(N:1) 관계 설정

토큰(Token) 엔티티

- 기본키, 리프레시토큰, 회원 필드를 가지며 null을 허용하지 않는다.
- 리프레시토큰 필드는 중복을 허용하지 않도록 unique 설정 추가
- 토큰과 회원의 관계는 일대일(1:1) 관계 설정

### 관련 이슈

- close #1