### PR TITLE
전역 예외 처리 핸들러 구현

### DIFF
--- a/backend/src/main/java/com/board/global/error/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/board/global/error/dto/ErrorResponse.java
@@ -1,0 +1,22 @@
+package com.board.global.error.dto;
+
+import com.board.global.error.exception.ErrorType;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+
+    private String errorCode;
+    private String message;
+
+    private ErrorResponse(ErrorType errorType) {
+        this.errorCode = errorType.getErrorCode();
+        this.message = errorType.getMessage();
+    }
+
+    public static ErrorResponse of(ErrorType errorType) {
+        return new ErrorResponse(errorType);
+    }
+
+}

--- a/backend/src/main/java/com/board/global/error/exception/APIException.java
+++ b/backend/src/main/java/com/board/global/error/exception/APIException.java
@@ -1,0 +1,14 @@
+package com.board.global.error.exception;
+
+import lombok.Getter;
+
+@Getter
+public class APIException extends RuntimeException {
+
+    private final ErrorType errorType;
+
+    public APIException(ErrorType errorType) {
+        this.errorType = errorType;
+    }
+
+}

--- a/backend/src/main/java/com/board/global/error/exception/ErrorType.java
+++ b/backend/src/main/java/com/board/global/error/exception/ErrorType.java
@@ -1,0 +1,22 @@
+package com.board.global.error.exception;
+
+import lombok.Getter;
+
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorType {
+
+    ;
+
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    ErrorType(String errorCode, String message, HttpStatus httpStatus) {
+        this.errorCode = errorCode;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+}

--- a/backend/src/main/java/com/board/global/error/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/board/global/error/handler/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.board.global.error.handler;
+
+import com.board.global.error.dto.ErrorResponse;
+import com.board.global.error.exception.APIException;
+import com.board.global.error.exception.ErrorType;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(APIException.class)
+    public ResponseEntity<ErrorResponse> handle(APIException ex) {
+        ErrorType errorType = ex.getErrorType();
+        ErrorResponse errorResponse = ErrorResponse.of(errorType);
+        return ResponseEntity.status(errorType.getHttpStatus()).body(errorResponse);
+    }
+
+}


### PR DESCRIPTION
# 작업 내용

예외 발생 시 한 곳에서 예외를 처리할 수 있는 핸들러 구현

- 기반 예외(APIException) 추가 하였고 APIException을 기준으로 처리하는 핸들러 메소드 추가
  - API 개발 시 추가되는 커스텀 예외는 기반 예외를 상속받는다.
 - 발생한 예외를 설명하는 에러 코드, 에러 메시지, HTTP 상태 코드로 이루어진 예외 유형 enum 정의
 - 예외 발생 시 클라이언트에게 일관된 응답을 위한 ErrorResponse DTO 추가

## 응답 예시

```json
{
  "errorCode": "0000000",
  "message": "예외가 발생했습니다"
}
```

### 관련 이슈

- close #4