### PR TITLE
회원가입 API 구현

### DIFF
--- a/backend/src/main/java/com/board/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/board/domain/member/controller/MemberController.java
@@ -1,0 +1,35 @@
+package com.board.domain.member.controller;
+
+import com.board.domain.member.dto.MemberSignupRequest;
+import com.board.domain.member.service.MemberService;
+
+import jakarta.validation.Valid;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    /**
+     * 사용자가 입력한 닉네임, 아이디, 비밀번호를 전달받아 유효성 검사를 거친 후 회원가입을 진행한다.
+     *
+     * @param memberSignupRequest 회원가입 요청 데이터(닉네임, 아이디, 비밀번호)
+     * @return 200 OK – 회원가입 성공 시 "ok" 문자열 반환
+     */
+    @PostMapping("/signup")
+    public ResponseEntity<Void> memberSignup(@RequestBody @Valid MemberSignupRequest memberSignupRequest) {
+        memberService.memberSignup(memberSignupRequest);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/member/dto/MemberSignupRequest.java
+++ b/backend/src/main/java/com/board/domain/member/dto/MemberSignupRequest.java
@@ -1,0 +1,27 @@
+package com.board.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberSignupRequest {
+
+    @NotBlank(message = "닉네임을 입력해 주세요.")
+    @Pattern(regexp = "(^$)|^[a-zA-Z가-힣0-9]{6,10}$", message = "닉네임은 6~10자의 영문 대소문자, 한글, 숫자만 사용할 수 있습니다.")
+    private String nickname;
+
+    @NotBlank(message = "아이디를 입력해 주세요.")
+    @Pattern(regexp = "(^$)|^[a-z0-9]{8,16}$", message = "아이디는 8~16자의 영문 소문자, 숫자만 사용할 수 있습니다.")
+    private String username;
+
+    @NotBlank(message = "비밀번호를 입력해 주세요.")
+    @Pattern(regexp = "(^$)|^[a-zA-Z0-9!@#$%^&*()_+\\-=\\[\\]{};:|./?]{8,16}$", message = "비밀번호는 8~16자의 영문 대소문자, 숫자, 특수문자만 사용할 수 있습니다.")
+    private String password;
+
+}

--- a/backend/src/main/java/com/board/domain/member/exception/DuplicateNicknameException.java
+++ b/backend/src/main/java/com/board/domain/member/exception/DuplicateNicknameException.java
@@ -1,0 +1,12 @@
+package com.board.domain.member.exception;
+
+import com.board.global.error.exception.APIException;
+import com.board.global.error.exception.ErrorType;
+
+public class DuplicateNicknameException extends APIException {
+
+    public DuplicateNicknameException() {
+        super(ErrorType.DUPLICATE_NICKNAME);
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/member/exception/DuplicateUsernameException.java
+++ b/backend/src/main/java/com/board/domain/member/exception/DuplicateUsernameException.java
@@ -1,0 +1,12 @@
+package com.board.domain.member.exception;
+
+import com.board.global.error.exception.APIException;
+import com.board.global.error.exception.ErrorType;
+
+public class DuplicateUsernameException extends APIException {
+
+    public DuplicateUsernameException() {
+        super(ErrorType.DUPLICATE_USERNAME);
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/board/domain/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.board.domain.member.repository;
+
+import com.board.domain.member.entity.Member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    boolean existsByNickname(String nickname);
+    boolean existsByUsername(String username);
+
+}

--- a/backend/src/main/java/com/board/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/board/domain/member/service/MemberService.java
@@ -1,0 +1,51 @@
+package com.board.domain.member.service;
+
+import com.board.domain.member.dto.MemberSignupRequest;
+import com.board.domain.member.entity.Member;
+import com.board.domain.member.exception.DuplicateNicknameException;
+import com.board.domain.member.exception.DuplicateUsernameException;
+import com.board.domain.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * 회원가입 로직을 수행한다.
+     * <p>
+     * 1. 닉네임 중복 검증 <br>
+     * 2. 아이디 중복 검증 <br>
+     * 3. 비밀번호 암호화 <br>
+     * 4. 회원 저장
+     *
+     * @param memberSignupRequest 회원가입 요청 데이터(닉네임, 아이디, 비밀번호)
+     * @throws DuplicateNicknameException 닉네임이 이미 존재하는 경우 발생
+     * @throws DuplicateUsernameException 아이디가 이미 존재하는 경우 발생
+     */
+    @Transactional
+    public void memberSignup(MemberSignupRequest memberSignupRequest) {
+        if (memberRepository.existsByNickname(memberSignupRequest.getNickname())) {
+            throw new DuplicateNicknameException();
+        }
+        if (memberRepository.existsByUsername(memberSignupRequest.getUsername())) {
+            throw new DuplicateUsernameException();
+        }
+        String encodedPassword = passwordEncoder.encode(memberSignupRequest.getPassword());
+        Member member = Member.builder()
+                .nickname(memberSignupRequest.getNickname())
+                .username(memberSignupRequest.getUsername())
+                .password(encodedPassword)
+                .build();
+        memberRepository.save(member);
+    }
+
+}

--- a/backend/src/main/java/com/board/global/error/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/board/global/error/dto/ErrorResponse.java
@@ -2,7 +2,14 @@ package com.board.global.error.dto;
 
 import com.board.global.error.exception.ErrorType;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import lombok.Getter;
+
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class ErrorResponse {
@@ -10,13 +17,46 @@ public class ErrorResponse {
     private String errorCode;
     private String message;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<Field> fields;
+
     private ErrorResponse(ErrorType errorType) {
         this.errorCode = errorType.getErrorCode();
         this.message = errorType.getMessage();
     }
 
+    private ErrorResponse(ErrorType errorType, List<FieldError> fieldErrors) {
+        this(errorType);
+        this.fields = Field.of(fieldErrors);
+    }
+
     public static ErrorResponse of(ErrorType errorType) {
         return new ErrorResponse(errorType);
+    }
+
+    public static ErrorResponse of(ErrorType errorType, List<FieldError> fieldErrors) {
+        return new ErrorResponse(errorType, fieldErrors);
+    }
+
+    @Getter
+    private static class Field {
+
+        private String field;
+        private String input;
+        private String message;
+
+        private Field(FieldError fieldError) {
+            this.field = fieldError.getField();
+            this.input = fieldError.getRejectedValue().toString();
+            this.message = fieldError.getDefaultMessage();
+        }
+
+        private static List<Field> of(List<FieldError> fieldErrors) {
+            return fieldErrors.stream()
+                    .map(Field::new)
+                    .collect(Collectors.toList());
+        }
+
     }
 
 }

--- a/backend/src/main/java/com/board/global/error/exception/ErrorType.java
+++ b/backend/src/main/java/com/board/global/error/exception/ErrorType.java
@@ -7,7 +7,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorType {
 
-    ;
+    // HTTP 400 Bad Request
+    INVALID_INPUT_VALUE("1001", "입력값이 잘못되었습니다.", HttpStatus.BAD_REQUEST),
+
+    // HTTP 409 Conflict
+    DUPLICATE_NICKNAME("2001", "사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
+    DUPLICATE_USERNAME("2002", "사용 중인 아이디입니다.", HttpStatus.CONFLICT);
 
     private final String errorCode;
     private final String message;

--- a/backend/src/main/java/com/board/global/error/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/board/global/error/handler/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.board.global.error.exception.APIException;
 import com.board.global.error.exception.ErrorType;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -16,6 +17,12 @@ public class GlobalExceptionHandler {
         ErrorType errorType = ex.getErrorType();
         ErrorResponse errorResponse = ErrorResponse.of(errorType);
         return ResponseEntity.status(errorType.getHttpStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handle(MethodArgumentNotValidException ex) {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorType.INVALID_INPUT_VALUE, ex.getFieldErrors());
+        return ResponseEntity.badRequest().body(errorResponse);
     }
 
 }

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package com.board.global.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST,
+                                "/api/members/signup").permitAll()
+                        .anyRequest().denyAll()
+                );
+        return httpSecurity.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/backend/src/test/java/com/board/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/board/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,167 @@
+package com.board.domain.member.controller;
+
+import com.board.domain.member.dto.MemberSignupRequest;
+import com.board.domain.member.exception.DuplicateNicknameException;
+import com.board.domain.member.exception.DuplicateUsernameException;
+import com.board.domain.member.service.MemberService;
+import com.board.restdocs.RestDocs;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willDoNothing;
+
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = MemberController.class)
+class MemberControllerTest extends RestDocs {
+
+    @MockitoBean
+    private MemberService memberService;
+
+    @DisplayName("회원가입에 성공하면 200 상태 코드를 반환한다.")
+    @Test
+    void memberSignup() throws Exception {
+        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonkun", "yoon1234", "12345678");
+
+        willDoNothing().given(memberService).memberSignup(any(MemberSignupRequest.class));
+
+        mockMvc.perform(post("/api/members/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberSignupRequest))
+                )
+                .andExpect(
+                        status().isOk()
+                )
+                .andDo(restdocs.document(
+                        requestFields(
+                                fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임"),
+                                fieldWithPath("username").type(JsonFieldType.STRING).description("아이디"),
+                                fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
+                        )
+                ));
+    }
+
+    @DisplayName("회원가입 시 입력값이 비어 있으면 예외 메시지와 400 상태 코드를 반환한다.")
+    @ParameterizedTest
+    @MethodSource("memberSignupRequestBlankFields")
+    void memberSignupBlankFields(MemberSignupRequest memberSignupRequest, String field, String message) throws Exception {
+        mockMvc.perform(post("/api/members/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberSignupRequest))
+                )
+                .andExpectAll(
+                        status().isBadRequest(),
+                        jsonPath("$.errorCode").value("1001"),
+                        jsonPath("$.message").value("입력값이 잘못되었습니다."),
+                        jsonPath("$.fields").isArray(),
+                        jsonPath("$.fields[0].field").value(field),
+                        jsonPath("$.fields[0].input").value(""),
+                        jsonPath("$.fields[0].message").value(message)
+                );
+    }
+
+    @DisplayName("회원가입 시 입력값이 정규 표현식에 일치하지 않으면 예외 메시지와 400 상태 코드를 반환한다.")
+    @ParameterizedTest
+    @MethodSource("memberSignupRequestMismatchRegexpFields")
+    void memberSignupMismatchRegexpFields(MemberSignupRequest memberSignupRequest, String field, String input, String message) throws Exception {
+        mockMvc.perform(post("/api/members/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberSignupRequest))
+                )
+                .andExpectAll(
+                        status().isBadRequest(),
+                        jsonPath("$.errorCode").value("1001"),
+                        jsonPath("$.message").value("입력값이 잘못되었습니다."),
+                        jsonPath("$.fields").isArray(),
+                        jsonPath("$.fields[0].field").value(field),
+                        jsonPath("$.fields[0].input").value(input),
+                        jsonPath("$.fields[0].message").value(message)
+                );
+    }
+
+    @DisplayName("회원가입 시 닉네임 또는 아이디가 중복되면 예외 메시지와 409 상태 코드를 반환한다.")
+    @ParameterizedTest
+    @MethodSource("memberSignupRequestDuplicateNicknameAndUsername")
+    void memberSignupDuplicateNicknameOrUsername(Exception duplicateException, String errorCode, String message) throws Exception {
+        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonkun", "yoon1234", "12345678");
+
+        willThrow(duplicateException).given(memberService).memberSignup(any(MemberSignupRequest.class));
+
+        mockMvc.perform(post("/api/members/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberSignupRequest))
+                )
+                .andExpectAll(
+                        status().isConflict(),
+                        jsonPath("$.errorCode").value(errorCode),
+                        jsonPath("$.message").value(message)
+                );
+    }
+
+    // 회원가입 시 MemberSignupRequest 입력값 빈값 검증 반복 테스트 시 사용하는 메서드
+    private static Stream<Arguments> memberSignupRequestBlankFields() {
+        return Stream.of(
+                Arguments.of(
+                        Named.of("닉네임 공백", new MemberSignupRequest("", "yoon1234", "12345678")),
+                        "nickname", "닉네임을 입력해 주세요."
+                ),
+                Arguments.of(
+                        Named.of("아이디 공백", new MemberSignupRequest("yoonkun", "", "12345678")),
+                        "username", "아이디를 입력해 주세요."
+                ),
+                Arguments.of(
+                        Named.of("비밀번호 공백", new MemberSignupRequest("yoonkun", "yoon1234", "")),
+                        "password", "비밀번호를 입력해 주세요."
+                )
+        );
+    }
+
+    // 회원가입 시 MemberSignupRequest 입력값 정규표션식 검증 반복 테스트 시 사용하는 메서드
+    private static Stream<Arguments> memberSignupRequestMismatchRegexpFields() {
+        return Stream.of(
+                Arguments.of(
+                        Named.of("닉네임 정규표현식 불일치", new MemberSignupRequest("@@!@", "yoon1234", "12345678")),
+                        "nickname", "@@!@", "닉네임은 6~10자의 영문 대소문자, 한글, 숫자만 사용할 수 있습니다."
+                ),
+                Arguments.of(
+                        Named.of("아이디 정규표현식 불일치", new MemberSignupRequest("yoonkun", "yo~!#$@", "12345678")),
+                        "username", "yo~!#$@", "아이디는 8~16자의 영문 소문자, 숫자만 사용할 수 있습니다."
+                ),
+                Arguments.of(
+                        Named.of("비밀번호 정규표현식 불일치", new MemberSignupRequest("yoonkun", "yoon1234", "123")),
+                        "password", "123", "비밀번호는 8~16자의 영문 대소문자, 숫자, 특수문자만 사용할 수 있습니다."
+                )
+        );
+    }
+
+    // 회원가입 시 닉네임 또는 아이디 중복 테스트 시 사용하는 메서드
+    private static Stream<Arguments> memberSignupRequestDuplicateNicknameAndUsername() {
+        return Stream.of(
+                Arguments.of(
+                        Named.of("닉네임 중복", new DuplicateNicknameException()), "2001", "사용 중인 닉네임입니다."
+                ),
+                Arguments.of(
+                        Named.of("아이디 중복", new DuplicateUsernameException()), "2002", "사용 중인 아이디입니다."
+                )
+        );
+    }
+
+}

--- a/backend/src/test/java/com/board/domain/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,95 @@
+package com.board.domain.member.repository;
+
+import com.board.domain.member.entity.Member;
+import com.board.domain.member.entity.Role;
+import com.board.global.common.config.JpaAuditingConfig;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("회원 엔티티를 저장한다.")
+    @Test
+    void memberSave() {
+        Member member = Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .password("12345678")
+                .build();
+
+        Member saveMember = memberRepository.save(member);
+
+        assertThat(saveMember.getId()).isNotNull();
+        assertThat(saveMember.getNickname()).isEqualTo("yoonkun");
+        assertThat(saveMember.getUsername()).isEqualTo("yoon1234");
+        assertThat(saveMember.getPassword()).isEqualTo("12345678");
+        assertThat(saveMember.getRole()).isEqualTo(Role.MEMBER);
+    }
+
+    @DisplayName("회원 엔티티 저장 시 필드가 null이면 예외가 발생한다.")
+    @ParameterizedTest
+    @MethodSource("memberNullFields")
+    void memberSaveNullFields(Member member) {
+        assertThatThrownBy(() -> memberRepository.save(member))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @DisplayName("동일한 닉네임이 존재하면 true를 반환한다.")
+    @Test
+    void memberExistsByNickname() {
+        Member member = Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .password("12345678")
+                .build();
+        memberRepository.save(member);
+
+        boolean exists = memberRepository.existsByNickname("yoonkun");
+
+        assertThat(exists).isTrue();
+    }
+
+    @DisplayName("동일한 아이디가 존재하면 true를 반환한다.")
+    @Test
+    void memberExistsByUsername() {
+        Member member = Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .password("12345678")
+                .build();
+        memberRepository.save(member);
+
+        boolean exists = memberRepository.existsByUsername("yoon1234");
+
+        assertThat(exists).isTrue();
+    }
+
+    private static Stream<Arguments> memberNullFields() {
+        return Stream.of(
+                Arguments.of(Named.of("닉네임 NULL", new Member(null, "yoon1234", "12345678"))),
+                Arguments.of(Named.of("아이디 NULL", new Member("yoonkun", null, "12345678"))),
+                Arguments.of(Named.of("비밀번호 NULL", new Member("yoonkun", "yoon1234", null)))
+        );
+    }
+
+}

--- a/backend/src/test/java/com/board/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/board/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,96 @@
+package com.board.domain.member.service;
+
+import com.board.domain.member.dto.MemberSignupRequest;
+import com.board.domain.member.entity.Member;
+import com.board.domain.member.exception.DuplicateNicknameException;
+import com.board.domain.member.exception.DuplicateUsernameException;
+import com.board.domain.member.repository.MemberRepository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @DisplayName("회원가입에 성공하면 회원을 저장한다.")
+    @Test
+    void memberSignup() {
+        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonKun", "yoon1234", "12345678");
+        String encodedPassword = new BCryptPasswordEncoder().encode("12345678");
+        Member member = Member.builder()
+                .nickname("yoonKun")
+                .username("yoon1234")
+                .password(encodedPassword)
+                .build();
+
+        given(memberRepository.existsByNickname(anyString())).willReturn(false);
+        given(memberRepository.existsByUsername(anyString())).willReturn(false);
+        given(passwordEncoder.encode(anyString())).willReturn(encodedPassword);
+        given(memberRepository.save(any(Member.class))).willReturn(member);
+
+        memberService.memberSignup(memberSignupRequest);
+
+        then(memberRepository).should().existsByNickname(anyString());
+        then(memberRepository).should().existsByUsername(anyString());
+        then(passwordEncoder).should().encode(anyString());
+        then(memberRepository).should().save(any(Member.class));
+    }
+
+    @DisplayName("회원가입 시 닉네임이 중복되면 예외가 발생한다.")
+    @Test
+    void memberSignupDuplicateNickname() {
+        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonKun", "yoon1234", "12345678");
+
+        given(memberRepository.existsByNickname(anyString())).willReturn(true);
+
+        assertThatThrownBy(() -> memberService.memberSignup(memberSignupRequest))
+                .isInstanceOf(DuplicateNicknameException.class);
+
+        then(memberRepository).should().existsByNickname(anyString());
+        then(memberRepository).should(never()).existsByUsername(anyString());
+        then(passwordEncoder).should(never()).encode(anyString());
+        then(memberRepository).should(never()).save(any(Member.class));
+    }
+
+    @DisplayName("회원가입 시 아이디가 중복되면 예외가 발생한다.")
+    @Test
+    void memberSignupDuplicateUsername() {
+        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonKun", "yoon1234", "12345678");
+
+        given(memberRepository.existsByNickname(anyString())).willReturn(false);
+        given(memberRepository.existsByUsername(anyString())).willReturn(true);
+
+        assertThatThrownBy(() -> memberService.memberSignup(memberSignupRequest))
+                .isInstanceOf(DuplicateUsernameException.class);
+
+        then(memberRepository).should().existsByNickname(anyString());
+        then(memberRepository).should().existsByUsername(anyString());
+        then(passwordEncoder).should(never()).encode(anyString());
+        then(memberRepository).should(never()).save(any(Member.class));
+    }
+
+}

--- a/backend/src/test/java/com/board/restdocs/RestDocs.java
+++ b/backend/src/test/java/com/board/restdocs/RestDocs.java
@@ -1,0 +1,55 @@
+package com.board.restdocs;
+
+import com.board.global.security.config.SecurityConfig;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@ExtendWith({SpringExtension.class, RestDocumentationExtension.class})
+@Import({SecurityConfig.class, RestDocsConfig.class})
+public abstract class RestDocs {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    protected RestDocumentationResultHandler restdocs;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    protected MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider restDocumentationContextProvider) {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply(documentationConfiguration(restDocumentationContextProvider))
+                .apply(springSecurity())
+                .defaultRequest(request(GET, "/").characterEncoding(StandardCharsets.UTF_8))
+                .alwaysDo(print())
+                .alwaysDo(restdocs) // 모든 API 테스트 케이스에 대한 ascii 문서 생성
+                .build();
+    }
+
+}

--- a/backend/src/test/java/com/board/restdocs/RestDocsConfig.java
+++ b/backend/src/test/java/com/board/restdocs/RestDocsConfig.java
@@ -1,0 +1,36 @@
+package com.board.restdocs;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+@TestConfiguration
+public class RestDocsConfig {
+
+    @Bean
+    public RestDocumentationResultHandler restDocumentationResultHandler() {
+        return MockMvcRestDocumentation.document("{method-name}",
+                Preprocessors.preprocessRequest(
+                        Preprocessors.modifyHeaders()
+                                .remove("Content-Length")
+                                .remove("Host"),
+                        Preprocessors.prettyPrint()
+                ),
+                Preprocessors.preprocessResponse(
+                        Preprocessors.modifyHeaders()
+                                .remove("Content-Length")
+                                .remove("X-Content-Type-Options")
+                                .remove("X-XSS-Protection")
+                                .remove("X-Frame-Options")
+                                .remove("Cache-Control")
+                                .remove("Pragma")
+                                .remove("Vary")
+                                .remove("Expires"),
+                        Preprocessors.prettyPrint()
+                )
+        );
+    }
+
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: false


### PR DESCRIPTION
# 작업 내용

회원가입 기능 및 API를 추가했습니다.

- 회원 컨트롤러, 서비스, 리포지토리를 추가했습니다.
- 유효성 검증 예외(MethodArgumentNotValidException)를 처리하는 핸들러를 추가했습니다.
  - 유효성 검증 시 발생하는 예외에 대한 응답 목록을 ErrorResponse에 추가했습니다.
```json
{
   "errorCode": "1001",
   "message": "입력값이 잘못되었습니다.",
   "fields": [{
       "field": "nickname",
       "input": "",
        "message": "닉네임을 입력해 주세요."
    }]
}
```

<br>

- 잘못된 입력값, 닉네임/아이디 중복 예외 유형을 추가했습니다.
  - INVALID_INPUT_VALUE(1001, 입력값이 잘못되었습니다., 400)
  - DUPLICATE_NICKNAME(2001, 사용 중인 닉네임입니다., 409)
  - DUPLICATE_USERNAME(2002, 사용 중인 아이디입니다., 409)
- 닉네임/아이디 중복 예외를 추가했습니다.
  - DuplicateNicknameException(닉네임 중복 시 발생하는 예외)
  - DuplicateUsernameException(아이디 중복 시 발생하는 예외)
- 스프링 시큐리티 설정을 추가했습니다.
  - 회원가입(/api/members/signup)에 대한 접근 권한을 전부 허용으로 설정했습니다. 그 외 경로에 대해서는 전부 거부로 설정했습니다.
  - csrf와 httpbasic 설정을 비활성화 했습니다.
  - BCryptPasswordEncoder를 빈으로 등록했습니다.
- Rest Docs 설정을 추가했습니다.
- 회원가입 기능 및 API에 대한 테스트를 수행했습니다.
- 테스트 시 사용하는 설정 파일(application.yml)을 추가했습니다.

### 관련 이슈

- close #3