### PR TITLE
토큰 검증 필터 구현

### DIFF
--- a/backend/src/main/java/com/board/domain/token/service/TokenService.java
+++ b/backend/src/main/java/com/board/domain/token/service/TokenService.java
@@ -6,6 +6,7 @@ import com.board.domain.token.repository.TokenRepository;
 import com.board.domain.member.entity.Member;
 import com.board.domain.token.util.JwtUtil;
 
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -26,6 +27,10 @@ public class TokenService {
                 .build();
         tokenRepository.save(token);
         return new TokenResponse(accessToken, refreshToken);
+    }
+
+    public Claims getClaims(String token) {
+        return jwtUtil.getClaims(token);
     }
 
 }

--- a/backend/src/main/java/com/board/domain/token/util/JwtUtil.java
+++ b/backend/src/main/java/com/board/domain/token/util/JwtUtil.java
@@ -1,9 +1,14 @@
 package com.board.domain.token.util;
 
+import com.board.global.error.exception.ErrorType;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -46,6 +51,24 @@ public class JwtUtil {
                 .issuedAt(iat)
                 .expiration(exp)
                 .compact();
+    }
+
+    public Claims getClaims(String token) {
+        return extractClaims(token);
+    }
+
+    private Claims extractClaims(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException ex) {
+            throw new AuthenticationServiceException(ErrorType.EXPIRED_TOKEN.getErrorCode());
+        } catch (IllegalArgumentException | JwtException ex) {
+            throw new AuthenticationServiceException(ErrorType.INVALID_TOKEN.getErrorCode());
+        }
     }
 
 }

--- a/backend/src/main/java/com/board/global/error/exception/ErrorType.java
+++ b/backend/src/main/java/com/board/global/error/exception/ErrorType.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 
 import org.springframework.http.HttpStatus;
 
+import java.util.Arrays;
+
 @Getter
 public enum ErrorType {
 
@@ -15,6 +17,8 @@ public enum ErrorType {
 
     // HTTP 401 Unauthorized
     BAD_CRDENTIALS("3001", "아이디 또는 비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    EXPIRED_TOKEN("3002", "토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_TOKEN("3003", "토큰 형식이 잘못되었습니다.", HttpStatus.UNAUTHORIZED),
 
     // HTTP 409 Conflict
     DUPLICATE_NICKNAME("2001", "사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
@@ -28,6 +32,13 @@ public enum ErrorType {
         this.errorCode = errorCode;
         this.message = message;
         this.httpStatus = httpStatus;
+    }
+
+    public static ErrorType of(String errorCode) {
+        return Arrays.stream(ErrorType.values())
+                .filter((errorType) -> errorType.errorCode.equals(errorCode))
+                .findFirst()
+                .orElse(UNSUPPORTED_ERROR_TYPE);
     }
 
 }

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -2,8 +2,10 @@ package com.board.global.security.config;
 
 import com.board.domain.token.service.TokenService;
 import com.board.global.security.filter.LoginAuthenticationFilter;
+import com.board.global.security.filter.TokenAuthenticationFilter;
 import com.board.global.security.handler.LoginFailureHandler;
 import com.board.global.security.handler.LoginSuccessHandler;
+import com.board.global.security.handler.TokenAuthenticationEntryPoint;
 import com.board.global.security.service.MemberUserDetailsService;
 
 import lombok.RequiredArgsConstructor;
@@ -20,12 +22,13 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-@EnableWebSecurity
+@EnableWebSecurity(debug = true)
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
@@ -81,6 +84,16 @@ public class SecurityConfig {
         provider.setUserDetailsService(memberUserDetailsService);
         provider.setPasswordEncoder(passwordEncoder());
         return new ProviderManager(provider);
+    }
+
+    @Bean
+    public TokenAuthenticationFilter tokenAuthenticationFilter() {
+        return new TokenAuthenticationFilter(tokenService, authenticationEntryPoint());
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        return new TokenAuthenticationEntryPoint();
     }
 
 }

--- a/backend/src/main/java/com/board/global/security/filter/TokenAuthenticationFilter.java
+++ b/backend/src/main/java/com/board/global/security/filter/TokenAuthenticationFilter.java
@@ -1,0 +1,103 @@
+package com.board.global.security.filter;
+
+import com.board.domain.token.service.TokenService;
+
+import io.jsonwebtoken.Claims;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
+
+@RequiredArgsConstructor
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+
+    private final TokenService tokenService;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            System.out.println("TokenAuthenticationFilter RUN!!!!");
+            String token = parseToken(request);
+            Claims payload = tokenService.getClaims(token);
+            Authentication authentication = createAuthentication(payload);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            filterChain.doFilter(request, response);
+        } catch (AuthenticationException ex) {
+            SecurityContextHolder.clearContext();
+            authenticationEntryPoint.commence(request, response, ex);
+        }
+    }
+
+    private String parseToken(HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        if (StringUtils.hasText(authHeader) && authHeader.startsWith("Bearer")) {
+            return authHeader.substring(7);
+        }
+        return null;
+    }
+
+    private Authentication createAuthentication(Claims payload) {
+        String username = payload.getSubject();
+        String authority = payload.get("authority", String.class);
+        return UsernamePasswordAuthenticationToken
+                .authenticated(username, null, AuthorityUtils.createAuthorityList(authority));
+    }
+
+    /**
+     * 특정 요청 경로에 대해 필터링 여부를 결정한다.
+     *
+     * @param request request 현재 HTTP 요청 객체
+     * @return true면 필터가 동작하지 않으며 false면 필터가 동작한다.
+     */
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return RequestPath.isShouldNotFilter(request);
+    }
+
+    @Getter
+    private enum RequestPath {
+
+        MEMBER_SIGNUP(HttpMethod.POST, "/api/members/signup", "ALL"),
+        MEMBER_LOGIN(HttpMethod.POST, "/api/auth/login", "ALL");
+
+        private final HttpMethod httpMethod;
+        private final String pattern;
+        private final String authority;
+
+        RequestPath(HttpMethod httpMethod, String pattern, String authority) {
+            this.httpMethod = httpMethod;
+            this.pattern = pattern;
+            this.authority = authority;
+        }
+
+        private static boolean isShouldNotFilter(HttpServletRequest request) {
+            return Arrays.stream(RequestPath.values())
+                    .anyMatch((requestPath) -> requestPath.authority.equals("ALL") &&
+                            antMatcher(requestPath.httpMethod, requestPath.pattern).matches(request));
+        }
+
+    }
+
+}

--- a/backend/src/main/java/com/board/global/security/handler/TokenAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/board/global/security/handler/TokenAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package com.board.global.security.handler;
+
+import com.board.global.error.dto.ErrorResponse;
+import com.board.global.error.exception.ErrorType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+public class TokenAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        String errorCode = authException.getMessage();
+        ErrorType errorType = ErrorType.of(errorCode);
+        ErrorResponse errorResponse = ErrorResponse.of(errorType);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+
+}


### PR DESCRIPTION
# 작업 내용

클라이언트에서 토큰이 포함된 요청을 보냈을 때 해당 토큰을 검증하는 필터를 추가했습니다.

- 토큰의 만료 및 잘못된 형식인지를 검사하며 만료되거나 잘못된 형식일 경우 예외가 발생합니다.
  - 예외 발생 시 예외 처리 핸들러(TokenAuthenticationEntryPoint )에서 예외를 응답합니다.
- 토큰의 Payload를 추출하고 만료 및 잘못된 유형인지 검증하는 기능을 추가했습니다.

### 관련 이슈

- close #12 