### PR TITLE
게시글 상세조회 API 구현

### DIFF
--- a/backend/src/main/java/com/board/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/board/domain/post/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.board.domain.post.controller;
 
+import com.board.domain.post.dto.PostDetailResponse;
 import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.service.PostService;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -30,6 +32,12 @@ public class PostController {
                                           @RequestBody @Valid PostWriteRequest postWriteRequest) {
         postService.postWrite(username, postWriteRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostDetailResponse> postDetail(@PathVariable("postId") Long postId) {
+        PostDetailResponse postDetailResponse = postService.postDetail(postId);
+        return ResponseEntity.ok().body(postDetailResponse);
     }
 
     @PutMapping("/{postId}")

--- a/backend/src/main/java/com/board/domain/post/dto/PostDetailResponse.java
+++ b/backend/src/main/java/com/board/domain/post/dto/PostDetailResponse.java
@@ -1,0 +1,30 @@
+package com.board.domain.post.dto;
+
+import com.board.domain.post.entity.Post;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostDetailResponse {
+
+    private Long postId;
+    private String title;
+    private String writer;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public PostDetailResponse(Post post) {
+        this.postId = post.getId();
+        this.title = post.getTitle();
+        this.writer = post.getWriter();
+        this.content = post.getContent();
+        this.createdAt = post.getCreatedAt();
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/board/domain/post/service/PostService.java
@@ -3,6 +3,7 @@ package com.board.domain.post.service;
 import com.board.domain.member.entity.Member;
 import com.board.domain.member.exception.NotFoundMemberException;
 import com.board.domain.member.repository.MemberRepository;
+import com.board.domain.post.dto.PostDetailResponse;
 import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.entity.Post;
@@ -32,6 +33,13 @@ public class PostService {
                 .content(postWriteRequest.getContent())
                 .build();
         postRepository.save(post);
+    }
+
+    @Transactional(readOnly = true)
+    public PostDetailResponse postDetail(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(NotFoundPostException::new);
+        return new PostDetailResponse(post);
     }
 
     @Transactional

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -56,6 +56,8 @@ public class SecurityConfig {
                 .addFilterBefore(tokenAuthenticationFilter(), LogoutFilter.class)
                 .addFilterAt(loginAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/posts/*").permitAll()
                         .requestMatchers(HttpMethod.POST,
                                 "/api/members/signup").permitAll()
                         .requestMatchers(HttpMethod.POST,

--- a/backend/src/main/java/com/board/global/security/filter/TokenAuthenticationFilter.java
+++ b/backend/src/main/java/com/board/global/security/filter/TokenAuthenticationFilter.java
@@ -67,7 +67,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     /**
      * 특정 요청 경로에 대해 필터링 여부를 결정한다.
      *
-     * @param request request 현재 HTTP 요청 객체
+     * @param request 현재 HTTP 요청 객체
      * @return true면 필터가 동작하지 않으며 false면 필터가 동작한다.
      */
     @Override
@@ -78,12 +78,13 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     @Getter
     private enum RequestPath {
 
-        // Member
+        // 전부 허용
         MEMBER_SIGNUP(HttpMethod.POST, "/api/members/signup", "ALL"),
         MEMBER_LOGIN(HttpMethod.POST, "/api/auth/login", "ALL"),
-        MEMBER_LOGOUT(HttpMethod.POST, "/api/auth/logout", "MEMBER"),
+        POST_DETAIL(HttpMethod.GET, "/api/posts/*", "ALL"),
 
-        // Post
+        // 회원(MEMBER) 권한만 허용
+        MEMBER_LOGOUT(HttpMethod.POST, "/api/auth/logout", "MEMBER"),
         POST_WRITE(HttpMethod.POST, "/api/posts/write", "MEMBER"),
         POST_MODIFY(HttpMethod.PUT, "/api/posts/*", "MEMBER"),
         POST_DELETE(HttpMethod.DELETE, "/api/posts/*", "MEMBER");

--- a/backend/src/main/resources/static/docs/index.html
+++ b/backend/src/main/resources/static/docs/index.html
@@ -456,6 +456,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_로그인">로그인</a></li>
 <li><a href="#_로그아웃">로그아웃</a></li>
 <li><a href="#_게시글_작성">게시글 작성</a></li>
+<li><a href="#_게시글_상세조회">게시글 상세조회</a></li>
 <li><a href="#_게시글_수정">게시글 수정</a></li>
 <li><a href="#_게시글_삭제">게시글 삭제</a></li>
 </ul>
@@ -846,12 +847,120 @@ Content-Type: application/json
 </div>
 </div>
 <div class="sect2">
+<h3 id="_게시글_상세조회">게시글 상세조회</h3>
+<div class="paragraph">
+<p>게시글 번호를 통해 게시글을 상세조회 할 수 있습니다.</p>
+</div>
+<div class="sect3">
+<h4 id="_요청_5">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/posts/1 HTTP/1.1</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/posts/{postId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_5">응답</h4>
+<div class="paragraph">
+<p><strong>응답 성공: 게시글 상세조회 성공</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "postId" : 1,
+  "title" : "title",
+  "writer" : "writer",
+  "content" : "content",
+  "createdAt" : "2025-02-12T10:17:03.028627"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">글번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>writer</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성일</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><strong>응답 실패: 게시글이 존재하지 않는 경우</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 404 Not Found
+Content-Type: application/json
+
+{
+  "errorCode" : "4003",
+  "message" : "게시글이 존재하지 않습니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
 <h3 id="_게시글_수정">게시글 수정</h3>
 <div class="paragraph">
 <p>제목, 내용을 통해 게시글 수정을 진행할 수 있습니다.</p>
 </div>
 <div class="sect3">
-<h4 id="_요청_5">요청</h4>
+<h4 id="_요청_6">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/posts/1 HTTP/1.1
@@ -865,7 +974,7 @@ Authorization: Bearer access-token
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /api/posts/{postId}</caption>
+<caption class="title">Table 2. /api/posts/{postId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -929,7 +1038,7 @@ Authorization: Bearer access-token
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_5">응답</h4>
+<h4 id="_응답_6">응답</h4>
 <div class="paragraph">
 <p><strong>응답 성공: 게시글 수정 성공</strong></p>
 </div>
@@ -979,7 +1088,7 @@ Content-Type: application/json
 <p>게시글 번호를 통해 게시글 삭제를 진행할 수 있습니다.</p>
 </div>
 <div class="sect3">
-<h4 id="_요청_6">요청</h4>
+<h4 id="_요청_7">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/posts/1 HTTP/1.1
@@ -987,7 +1096,7 @@ Authorization: Bearer access-token</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 2. /api/posts/{postId}</caption>
+<caption class="title">Table 3. /api/posts/{postId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -1025,7 +1134,7 @@ Authorization: Bearer access-token</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_6">응답</h4>
+<h4 id="_응답_7">응답</h4>
 <div class="paragraph">
 <p><strong>응답 성공: 게시글 삭제 성공</strong></p>
 </div>
@@ -1070,7 +1179,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1<br>
-Last updated 2025-02-11 18:34:34 +0900
+Last updated 2025-02-12 10:16:56 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
@@ -1,5 +1,6 @@
 package com.board.domain.post.controller;
 
+import com.board.domain.post.dto.PostDetailResponse;
 import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.exception.NotFoundPostException;
@@ -24,6 +25,7 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -37,9 +39,11 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.headerWit
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -132,6 +136,49 @@ class PostControllerTest extends RestDocs {
                         status().isUnauthorized(),
                         jsonPath("$.errorCode").value(errorCode),
                         jsonPath("$.message").value(message)
+                );
+    }
+
+    @DisplayName("게시글 상세조회에 성공하면 게시글 정보와 200 상태 코드를 반환한다.")
+    @Test
+    void postDetail() throws Exception {
+        PostDetailResponse postDetailResponse = new PostDetailResponse(1L, "title", "writer", "content", LocalDateTime.now());
+
+        given(postService.postDetail(anyLong())).willReturn(postDetailResponse);
+
+        mockMvc.perform(get("/api/posts/{postId}", 1))
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.postId").value(1),
+                        jsonPath("$.title").value("title"),
+                        jsonPath("$.writer").value("writer"),
+                        jsonPath("$.content").value("content"),
+                        jsonPath("$.createdAt").isNotEmpty()
+                )
+                .andDo(restdocs.document(
+                        pathParameters(
+                                parameterWithName("postId").description("게시글 번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("postId").type(JsonFieldType.NUMBER).description("글번호"),
+                                fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
+                                fieldWithPath("writer").type(JsonFieldType.STRING).description("작성자"),
+                                fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
+                                fieldWithPath("createdAt").type(JsonFieldType.STRING).description("작성일")
+                        )
+                ));
+    }
+
+    @DisplayName("게시글 상세조회 시 게시글이 존재하지 않으면 예외 응답과 404 상태 코드를 반환한다.")
+    @Test
+    void postDetailNotFoundPost() throws Exception {
+        willThrow(new NotFoundPostException()).given(postService).postDetail(anyLong());
+
+        mockMvc.perform(get("/api/posts/{postId}", 1))
+                .andExpectAll(
+                        status().isNotFound(),
+                        jsonPath("$.errorCode").value("4003"),
+                        jsonPath("$.message").value("게시글이 존재하지 않습니다.")
                 );
     }
 

--- a/backend/src/test/java/com/board/domain/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/board/domain/post/service/PostServiceTest.java
@@ -2,6 +2,7 @@ package com.board.domain.post.service;
 
 import com.board.domain.member.entity.Member;
 import com.board.domain.member.repository.MemberRepository;
+import com.board.domain.post.dto.PostDetailResponse;
 import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.entity.Post;
@@ -20,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -85,6 +87,37 @@ class PostServiceTest {
 
         then(memberRepository).should().findByUsername(anyString());
         then(postRepository).should(never()).save(any(Post.class));
+    }
+
+    @DisplayName("게시글을 상세조회 한다.")
+    @Test
+    void postDetail() {
+        Post post = Post.builder()
+                .title("title")
+                .writer(member.getNickname())
+                .content("content")
+                .member(member)
+                .build();
+
+        given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
+
+        PostDetailResponse postDetailResponse = postService.postDetail(1L);
+
+        assertThat(postDetailResponse.getTitle()).isEqualTo("title");
+        assertThat(postDetailResponse.getWriter()).isEqualTo("yoonkun");
+        assertThat(postDetailResponse.getContent()).isEqualTo("content");
+        then(postRepository).should().findById(anyLong());
+    }
+
+    @DisplayName("게시글 상세조회 시 게시글이 존재하지 않으면 예외가 발생한다.")
+    @Test
+    void postDetailNotFoundPost() {
+        willThrow(new NotFoundPostException()).given(postRepository).findById(anyLong());
+
+        assertThatThrownBy(() -> postService.postDetail(1L))
+                .isInstanceOf(NotFoundPostException.class);
+
+        then(postRepository).should().findById(anyLong());
     }
 
     @DisplayName("게시글을 수정한다.")


### PR DESCRIPTION
# 작업 내용

- 게시글 상세조회 기능 추가
  - 게시글 상세조회 시 게시글이 존재하지 않으면 예외(NotFoundPostException) 발생
  - 게시글 상세조회 요청 권한을 전부 허용으로 설정
- 게시글 상세조회 기능 테스트 추가
- API 문서에 게시글 상세조회 API 내용 추가

### 관련 이슈

- close #21