### PR TITLE
게시글 목록조회 API 구현

### DIFF
--- a/backend/src/main/java/com/board/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/board/domain/member/service/MemberService.java
@@ -19,18 +19,6 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-    /**
-     * 회원가입 로직을 수행한다.
-     * <p>
-     * 1. 닉네임 중복 검증 <br>
-     * 2. 아이디 중복 검증 <br>
-     * 3. 비밀번호 암호화 <br>
-     * 4. 회원 저장
-     *
-     * @param memberSignupRequest 회원가입 요청 데이터(닉네임, 아이디, 비밀번호)
-     * @throws DuplicateNicknameException 닉네임이 이미 존재하는 경우 발생
-     * @throws DuplicateUsernameException 아이디가 이미 존재하는 경우 발생
-     */
     @Transactional
     public void memberSignup(MemberSignupRequest memberSignupRequest) {
         if (memberRepository.existsByNickname(memberSignupRequest.getNickname())) {

--- a/backend/src/main/java/com/board/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/board/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.board.domain.post.controller;
 
 import com.board.domain.post.dto.PostDetailResponse;
+import com.board.domain.post.dto.PostListResponse;
 import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.service.PostService;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -38,6 +40,12 @@ public class PostController {
     public ResponseEntity<PostDetailResponse> postDetail(@PathVariable("postId") Long postId) {
         PostDetailResponse postDetailResponse = postService.postDetail(postId);
         return ResponseEntity.ok().body(postDetailResponse);
+    }
+
+    @GetMapping
+    public ResponseEntity<PostListResponse> postList(@RequestParam("page") int page) {
+        PostListResponse postListResponse = postService.postList(page);
+        return ResponseEntity.ok().body(postListResponse);
     }
 
     @PutMapping("/{postId}")

--- a/backend/src/main/java/com/board/domain/post/dto/PostListResponse.java
+++ b/backend/src/main/java/com/board/domain/post/dto/PostListResponse.java
@@ -1,0 +1,61 @@
+package com.board.domain.post.dto;
+
+import com.board.domain.post.entity.Post;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostListResponse {
+
+    private List<PostItem> posts;
+    private int page;
+    private int totalPages;
+    private long totalPosts;
+    private boolean first;
+    private boolean last;
+    private boolean prev;
+    private boolean next;
+
+    public PostListResponse(Page<Post> postPage) {
+        this.posts = postPage.getContent().stream()
+                .map(PostItem::new)
+                .collect(Collectors.toList());
+        this.page = postPage.getNumber() + 1;
+        this.totalPages = postPage.getTotalPages();
+        this.totalPosts = postPage.getTotalElements();
+        this.first = postPage.isFirst();
+        this.last = postPage.isLast();
+        this.prev = postPage.hasPrevious();
+        this.next = postPage.hasNext();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PostItem {
+
+        private Long postId;
+        private String title;
+        private String writer;
+        private LocalDateTime createdAt;
+
+        public PostItem(Post post) {
+            this.postId = post.getId();
+            this.title = post.getTitle();
+            this.writer = post.getWriter();
+            this.createdAt = post.getCreatedAt();
+        }
+
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/board/domain/post/service/PostService.java
@@ -4,6 +4,7 @@ import com.board.domain.member.entity.Member;
 import com.board.domain.member.exception.NotFoundMemberException;
 import com.board.domain.member.repository.MemberRepository;
 import com.board.domain.post.dto.PostDetailResponse;
+import com.board.domain.post.dto.PostListResponse;
 import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.entity.Post;
@@ -12,6 +13,10 @@ import com.board.domain.post.repository.PostRepository;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,6 +45,14 @@ public class PostService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(NotFoundPostException::new);
         return new PostDetailResponse(post);
+    }
+
+    @Transactional(readOnly = true)
+    public PostListResponse postList(int page) {
+        page = page <= 0 ? 0 : page - 1;
+        Pageable pageable = PageRequest.of(page, 10, Sort.Direction.DESC, "id");
+        Page<Post> postPage = postRepository.findAll(pageable);
+        return new PostListResponse(postPage);
     }
 
     @Transactional

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -57,7 +57,8 @@ public class SecurityConfig {
                 .addFilterAt(loginAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET,
-                                "/api/posts/*").permitAll()
+                                "/api/posts/*",
+                                "/api/posts").permitAll()
                         .requestMatchers(HttpMethod.POST,
                                 "/api/members/signup").permitAll()
                         .requestMatchers(HttpMethod.POST,

--- a/backend/src/main/java/com/board/global/security/filter/TokenAuthenticationFilter.java
+++ b/backend/src/main/java/com/board/global/security/filter/TokenAuthenticationFilter.java
@@ -82,6 +82,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         MEMBER_SIGNUP(HttpMethod.POST, "/api/members/signup", "ALL"),
         MEMBER_LOGIN(HttpMethod.POST, "/api/auth/login", "ALL"),
         POST_DETAIL(HttpMethod.GET, "/api/posts/*", "ALL"),
+        POST_LIST(HttpMethod.GET, "/api/posts", "ALL"),
 
         // 회원(MEMBER) 권한만 허용
         MEMBER_LOGOUT(HttpMethod.POST, "/api/auth/logout", "MEMBER"),

--- a/backend/src/main/resources/static/docs/index.html
+++ b/backend/src/main/resources/static/docs/index.html
@@ -457,6 +457,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_로그아웃">로그아웃</a></li>
 <li><a href="#_게시글_작성">게시글 작성</a></li>
 <li><a href="#_게시글_상세조회">게시글 상세조회</a></li>
+<li><a href="#_게시글_목록조회">게시글 목록조회</a></li>
 <li><a href="#_게시글_수정">게시글 수정</a></li>
 <li><a href="#_게시글_삭제">게시글 삭제</a></li>
 </ul>
@@ -893,7 +894,7 @@ Content-Type: application/json
   "title" : "title",
   "writer" : "writer",
   "content" : "content",
-  "createdAt" : "2025-02-12T10:17:03.028627"
+  "createdAt" : "2025-02-12T23:00:36.780694"
 }</code></pre>
 </div>
 </div>
@@ -955,12 +956,145 @@ Content-Type: application/json
 </div>
 </div>
 <div class="sect2">
+<h3 id="_게시글_목록조회">게시글 목록조회</h3>
+<div class="sect3">
+<h4 id="_요청_6">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/posts?page=1 HTTP/1.1</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_6">응답</h4>
+<div class="paragraph">
+<p><strong>응답 성공: 게시글 목록조회 성공</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "posts" : [ {
+    "postId" : 1,
+    "title" : "title",
+    "writer" : "writer",
+    "createdAt" : "2025-02-12T23:00:36.740488"
+  } ],
+  "page" : 1,
+  "totalPages" : 1,
+  "totalPosts" : 1,
+  "first" : true,
+  "last" : true,
+  "prev" : false,
+  "next" : false
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>posts</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>posts[0].postId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">글번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>posts[0].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>posts[0].writer</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>posts[0].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 페이지 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>totalPosts</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전체 게시글 개수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>totalPages</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전체 페이지 개수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>first</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">첫째 페이지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>last</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 페이지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>prev</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이전 페이지 존재 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>next</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">다음 페이지 존재 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
 <h3 id="_게시글_수정">게시글 수정</h3>
 <div class="paragraph">
 <p>제목, 내용을 통해 게시글 수정을 진행할 수 있습니다.</p>
 </div>
 <div class="sect3">
-<h4 id="_요청_6">요청</h4>
+<h4 id="_요청_7">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/posts/1 HTTP/1.1
@@ -1038,7 +1172,7 @@ Authorization: Bearer access-token
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_6">응답</h4>
+<h4 id="_응답_7">응답</h4>
 <div class="paragraph">
 <p><strong>응답 성공: 게시글 수정 성공</strong></p>
 </div>
@@ -1088,7 +1222,7 @@ Content-Type: application/json
 <p>게시글 번호를 통해 게시글 삭제를 진행할 수 있습니다.</p>
 </div>
 <div class="sect3">
-<h4 id="_요청_7">요청</h4>
+<h4 id="_요청_8">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/posts/1 HTTP/1.1
@@ -1134,7 +1268,7 @@ Authorization: Bearer access-token</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_7">응답</h4>
+<h4 id="_응답_8">응답</h4>
 <div class="paragraph">
 <p><strong>응답 성공: 게시글 삭제 성공</strong></p>
 </div>
@@ -1179,7 +1313,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1<br>
-Last updated 2025-02-12 10:16:56 +0900
+Last updated 2025-02-12 17:42:55 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
@@ -1,6 +1,8 @@
 package com.board.domain.post.controller;
 
 import com.board.domain.post.dto.PostDetailResponse;
+import com.board.domain.post.dto.PostListResponse;
+import com.board.domain.post.dto.PostListResponse.PostItem;
 import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.exception.NotFoundPostException;
@@ -26,9 +28,11 @@ import org.springframework.security.authentication.AuthenticationServiceExceptio
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -42,6 +46,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -180,6 +185,55 @@ class PostControllerTest extends RestDocs {
                         jsonPath("$.errorCode").value("4003"),
                         jsonPath("$.message").value("게시글이 존재하지 않습니다.")
                 );
+    }
+
+    @DisplayName("게시글 목록조회에 성공하면 게시글 목록과 200 상태 코드를 반환한다.")
+    @Test
+    void postList() throws Exception {
+        List<PostItem> posts = List.of(
+                new PostItem(1L, "title", "writer", LocalDateTime.now())
+        );
+        PostListResponse postListResponse = new PostListResponse(posts, 1, 1, 1, true, true, false, false);
+
+        given(postService.postList(anyInt())).willReturn(postListResponse);
+
+        mockMvc.perform(get("/api/posts")
+                        .param("page", "1")
+                )
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.posts").isArray(),
+                        jsonPath("$.posts[0].postId").value(1),
+                        jsonPath("$.posts[0].title").value("title"),
+                        jsonPath("$.posts[0].writer").value("writer"),
+                        jsonPath("$.posts[0].createdAt").isNotEmpty(),
+                        jsonPath("$.page").value(1),
+                        jsonPath("$.totalPages").value(1),
+                        jsonPath("$.totalPosts").value(1),
+                        jsonPath("$.first").value(true),
+                        jsonPath("$.last").value(true),
+                        jsonPath("$.prev").value(false),
+                        jsonPath("$.next").value(false)
+                )
+                .andDo(restdocs.document(
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("posts").type(JsonFieldType.ARRAY).description("게시글 목록"),
+                                fieldWithPath("posts[0].postId").type(JsonFieldType.NUMBER).description("글번호"),
+                                fieldWithPath("posts[0].title").type(JsonFieldType.STRING).description("제목"),
+                                fieldWithPath("posts[0].writer").type(JsonFieldType.STRING).description("작성자"),
+                                fieldWithPath("posts[0].createdAt").type(JsonFieldType.STRING).description("작성일"),
+                                fieldWithPath("page").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+                                fieldWithPath("totalPosts").type(JsonFieldType.NUMBER).description("전체 게시글 개수"),
+                                fieldWithPath("totalPages").type(JsonFieldType.NUMBER).description("전체 페이지 개수"),
+                                fieldWithPath("first").type(JsonFieldType.BOOLEAN).description("첫째 페이지 여부"),
+                                fieldWithPath("last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                                fieldWithPath("prev").type(JsonFieldType.BOOLEAN).description("이전 페이지 존재 여부"),
+                                fieldWithPath("next").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부")
+                        )
+                ));
     }
 
     @DisplayName("게시글 수정에 성공하면 200 상태 코드를 반환한다.")

--- a/backend/src/test/java/com/board/domain/post/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/post/repository/PostRepositoryTest.java
@@ -13,6 +13,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.util.Optional;
 
@@ -154,6 +158,29 @@ class PostRepositoryTest {
         Post findPost = postRepository.findById(savePost.getId()).get();
 
         postRepository.delete(findPost);
+    }
+
+    @DisplayName("게시글 엔티티 목록을 조회한다.")
+    @Test
+    void postFindAll() {
+        Post post = Post.builder()
+                .title("title")
+                .writer(saveMember.getNickname())
+                .content("content")
+                .member(saveMember)
+                .build();
+        postRepository.save(post);
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.Direction.DESC, "id");
+        Page<Post> postPage = postRepository.findAll(pageable);
+
+        assertThat(postPage.getNumber()).isEqualTo(0);
+        assertThat(postPage.getTotalPages()).isEqualTo(1);
+        assertThat(postPage.getTotalElements()).isEqualTo(1);
+        assertThat(postPage.isFirst()).isTrue();
+        assertThat(postPage.isLast()).isTrue();
+        assertThat(postPage.hasPrevious()).isFalse();
+        assertThat(postPage.hasNext()).isFalse();
     }
 
 }

--- a/backend/src/test/java/com/board/domain/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/board/domain/post/service/PostServiceTest.java
@@ -3,6 +3,7 @@ package com.board.domain.post.service;
 import com.board.domain.member.entity.Member;
 import com.board.domain.member.repository.MemberRepository;
 import com.board.domain.post.dto.PostDetailResponse;
+import com.board.domain.post.dto.PostListResponse;
 import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.entity.Post;
@@ -18,7 +19,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -118,6 +122,29 @@ class PostServiceTest {
                 .isInstanceOf(NotFoundPostException.class);
 
         then(postRepository).should().findById(anyLong());
+    }
+
+    @DisplayName("게시글 목록을 조회한다.")
+    @Test
+    void postList() {
+        List<Post> content = List.of(
+                Post.builder().title("title").writer(member.getNickname()).content("content").member(member).build()
+        );
+        PageImpl<Post> postPage = new PageImpl<>(content);
+
+        given(postRepository.findAll(any(Pageable.class))).willReturn(postPage);
+
+        PostListResponse postListResponse = postService.postList(1);
+
+        assertThat(postListResponse.getPosts().size()).isEqualTo(1);
+        assertThat(postListResponse.getPage()).isEqualTo(1);
+        assertThat(postListResponse.getTotalPosts()).isEqualTo(1);
+        assertThat(postListResponse.getTotalPages()).isEqualTo(1);
+        assertThat(postListResponse.isFirst()).isTrue();
+        assertThat(postListResponse.isLast()).isTrue();
+        assertThat(postListResponse.isPrev()).isFalse();
+        assertThat(postListResponse.isNext()).isFalse();
+        then(postRepository).should().findAll(any(Pageable.class));
     }
 
     @DisplayName("게시글을 수정한다.")


### PR DESCRIPTION
# 작업 내용

- 게시글 목록조회 기능 추가
  - 페이지 번호를 쿼리 스트링으로 전달해 게시글 목록을 조회할 수 있다.
  - 한 페이지 당 최대 10개의 게시글 목록을 게시글 번호 기준 내림차순으로 조회한다.
  - 게시글 목록조회 요청 권한을 전부 허용으로 설정
- 게시글 목록조회 기능 테스트 추가
- API 문서에 게시글 목록조회 API 내용 추가

### 관련 이슈

- close #23