### PR TITLE
댓글 작성 API 구현

### DIFF
--- a/backend/src/main/java/com/board/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/board/domain/comment/controller/CommentController.java
@@ -1,0 +1,33 @@
+package com.board.domain.comment.controller;
+
+import com.board.domain.comment.dto.CommentWriteRequest;
+import com.board.domain.comment.service.CommentService;
+
+import jakarta.validation.Valid;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/{postId}/comments/write")
+    public ResponseEntity<Void> commentWrite(@PathVariable("postId") Long postId,
+                                             @AuthenticationPrincipal String username,
+                                             @RequestBody @Valid CommentWriteRequest commentWriteRequest) {
+        commentService.commentWrite(postId, username, commentWriteRequest);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/comment/dto/CommentWriteRequest.java
+++ b/backend/src/main/java/com/board/domain/comment/dto/CommentWriteRequest.java
@@ -1,0 +1,17 @@
+package com.board.domain.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentWriteRequest {
+
+    @NotBlank(message = "내용을 입력해 주세요.")
+    private String content;
+
+}

--- a/backend/src/main/java/com/board/domain/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/board/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.board.domain.comment.repository;
+
+import com.board.domain.comment.entity.Comment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/backend/src/main/java/com/board/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/board/domain/comment/service/CommentService.java
@@ -1,0 +1,41 @@
+package com.board.domain.comment.service;
+
+import com.board.domain.comment.dto.CommentWriteRequest;
+import com.board.domain.comment.entity.Comment;
+import com.board.domain.comment.repository.CommentRepository;
+
+import com.board.domain.member.entity.Member;
+import com.board.domain.member.exception.NotFoundMemberException;
+import com.board.domain.member.repository.MemberRepository;
+import com.board.domain.post.entity.Post;
+import com.board.domain.post.exception.NotFoundPostException;
+import com.board.domain.post.repository.PostRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public void commentWrite(Long postId, String username, CommentWriteRequest commentWriteRequest) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(NotFoundPostException::new);
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(NotFoundMemberException::new);
+        Comment comment = Comment.builder()
+                .content(commentWriteRequest.getContent())
+                .member(member)
+                .post(post)
+                .build();
+        commentRepository.save(comment);
+    }
+
+}

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -62,7 +62,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST,
                                 "/api/members/signup").permitAll()
                         .requestMatchers(HttpMethod.POST,
-                                "/api/posts/write").hasRole("MEMBER")
+                                "/api/posts/write",
+                                "/api/posts/*/comments/write").hasRole("MEMBER")
                         .requestMatchers(HttpMethod.PUT,
                                 "/api/posts/*").hasRole("MEMBER")
                         .requestMatchers(HttpMethod.DELETE,

--- a/backend/src/main/java/com/board/global/security/filter/TokenAuthenticationFilter.java
+++ b/backend/src/main/java/com/board/global/security/filter/TokenAuthenticationFilter.java
@@ -88,7 +88,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         MEMBER_LOGOUT(HttpMethod.POST, "/api/auth/logout", "MEMBER"),
         POST_WRITE(HttpMethod.POST, "/api/posts/write", "MEMBER"),
         POST_MODIFY(HttpMethod.PUT, "/api/posts/*", "MEMBER"),
-        POST_DELETE(HttpMethod.DELETE, "/api/posts/*", "MEMBER");
+        POST_DELETE(HttpMethod.DELETE, "/api/posts/*", "MEMBER"),
+        COMMENT_WRITE(HttpMethod.POST, "/api/posts/*/comments/write", "MEMBER");
 
         private final HttpMethod httpMethod;
         private final String pattern;

--- a/backend/src/main/resources/static/docs/index.html
+++ b/backend/src/main/resources/static/docs/index.html
@@ -460,6 +460,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_게시글_목록조회">게시글 목록조회</a></li>
 <li><a href="#_게시글_수정">게시글 수정</a></li>
 <li><a href="#_게시글_삭제">게시글 삭제</a></li>
+<li><a href="#_댓글_작성">댓글 작성</a></li>
 </ul>
 </li>
 </ul>
@@ -894,7 +895,7 @@ Content-Type: application/json
   "title" : "title",
   "writer" : "writer",
   "content" : "content",
-  "createdAt" : "2025-02-12T23:00:36.780694"
+  "createdAt" : "2025-02-13T16:10:01.347384"
 }</code></pre>
 </div>
 </div>
@@ -998,7 +999,7 @@ Content-Type: application/json
     "postId" : 1,
     "title" : "title",
     "writer" : "writer",
-    "createdAt" : "2025-02-12T23:00:36.740488"
+    "createdAt" : "2025-02-13T16:10:01.314191"
   } ],
   "page" : 1,
   "totalPages" : 1,
@@ -1307,13 +1308,146 @@ Content-Type: application/json
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_댓글_작성">댓글 작성</h3>
+<div class="sect3">
+<h4 id="_요청_9">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/posts/1/comments/write HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access-token
+
+{
+  "content" : "comment"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 4. /api/posts/{postId}/comments/write</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 번호</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인증을 위한 Bearer 액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">내용</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_9">응답</h4>
+<div class="paragraph">
+<p><strong>응답 성공: 댓글 작성 성공</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>응답 실패: access token 만료 및 잘못된 형식</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+
+{
+  "errorCode" : "3003",
+  "message" : "토큰 형식이 잘못되었습니다."
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>응답 실패: 게시글이 존재하지 않는 경우</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 404 Not Found
+Content-Type: application/json
+
+{
+  "errorCode" : "4003",
+  "message" : "게시글이 존재하지 않습니다."
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>응답 실패: 입력값이 빈값인 경우</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "errorCode" : "1001",
+  "message" : "입력값이 잘못되었습니다.",
+  "fields" : [ {
+    "field" : "content",
+    "input" : "",
+    "message" : "내용을 입력해 주세요."
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1<br>
-Last updated 2025-02-12 17:42:55 +0900
+Last updated 2025-02-13 16:09:50 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/test/java/com/board/domain/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/board/domain/comment/controller/CommentControllerTest.java
@@ -1,0 +1,161 @@
+package com.board.domain.comment.controller;
+
+import com.board.domain.comment.dto.CommentWriteRequest;
+import com.board.domain.comment.service.CommentService;
+import com.board.domain.post.exception.NotFoundPostException;
+import com.board.restdocs.RestDocs;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CommentController.class)
+class CommentControllerTest extends RestDocs {
+
+    @MockitoBean
+    private CommentService commentService;
+
+    @DisplayName("댓글 작성에 성공하면 200 상태 코드를 반환한다.")
+    @Test
+    void commentWrite() throws Exception {
+        CommentWriteRequest commentWriteRequest = new CommentWriteRequest("comment");
+        Claims claims = Jwts.claims()
+                .subject("yoon1234")
+                .add("authority", "ROLE_MEMBER")
+                .build();
+
+        given(tokenService.getClaims(anyString())).willReturn(claims);
+        willDoNothing().given(commentService).commentWrite(anyLong(), anyString(), any(CommentWriteRequest.class));
+
+        mockMvc.perform(post("/api/posts/{postId}/comments/write", 1)
+                        .header("Authorization", "Bearer access-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(commentWriteRequest))
+                )
+                .andExpect(
+                        status().isOk()
+                )
+                .andDo(restdocs.document(
+                        pathParameters(
+                                parameterWithName("postId").description("게시글 번호")
+                        ),
+                        requestHeaders(
+                                headerWithName("Authorization").description("인증을 위한 Bearer 액세스 토큰")
+                        ),
+                        requestFields(
+                                fieldWithPath("content").type(JsonFieldType.STRING).description("내용")
+                        )
+                ));
+    }
+
+    @DisplayName("댓글 작성 시 내용이 공백이면 예외 응답과 400 상태 코드를 반환한다.")
+    @Test
+    void commentWriteBlankContent() throws Exception {
+        CommentWriteRequest commentWriteRequest = new CommentWriteRequest("");
+        Claims claims = Jwts.claims()
+                .subject("yoon1234")
+                .add("authority", "ROLE_MEMBER")
+                .build();
+
+        given(tokenService.getClaims(anyString())).willReturn(claims);
+
+        mockMvc.perform(post("/api/posts/{postId}/comments/write", 1)
+                        .header("Authorization", "Bearer access-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(commentWriteRequest))
+                )
+                .andExpectAll(
+                        status().isBadRequest(),
+                        jsonPath("$.errorCode").value("1001"),
+                        jsonPath("$.message").value("입력값이 잘못되었습니다."),
+                        jsonPath("$.fields").isArray(),
+                        jsonPath("$.fields[0].field").value("content"),
+                        jsonPath("$.fields[0].input").value(""),
+                        jsonPath("$.fields[0].message").value("내용을 입력해 주세요.")
+                );
+    }
+
+    @DisplayName("댓글 작성 시 게시글이 존재하지 않으면 예외 응답과 404 상태 코드를 반환한다.")
+    @Test
+    void commentWriteNotFoundPost() throws Exception {
+        CommentWriteRequest commentWriteRequest = new CommentWriteRequest("comment");
+        Claims claims = Jwts.claims()
+                .subject("yoon1234")
+                .add("authority", "ROLE_MEMBER")
+                .build();
+
+        given(tokenService.getClaims(anyString())).willReturn(claims);
+        willThrow(new NotFoundPostException()).given(commentService).commentWrite(anyLong(), anyString(), any(CommentWriteRequest.class));
+
+        mockMvc.perform(post("/api/posts/{postId}/comments/write", 1)
+                        .header("Authorization", "Bearer access-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(commentWriteRequest))
+                )
+                .andExpectAll(
+                        status().isNotFound(),
+                        jsonPath("$.errorCode").value("4003"),
+                        jsonPath("$.message").value("게시글이 존재하지 않습니다.")
+                );
+    }
+
+    @DisplayName("댓글 작성 시 액세스 토큰이 만료되거나 형식이 잘못되면 예외 응답과 401 상태 코드를 반환한다.")
+    @ParameterizedTest
+    @MethodSource("expiredAndInvalidAccessToken")
+    void commentWriteExpiredAndInvalidAccessToken(String errorCode, String message) throws Exception {
+        CommentWriteRequest commentWriteRequest = new CommentWriteRequest("comment");
+
+        willThrow(new AuthenticationServiceException(errorCode)).given(tokenService).getClaims(anyString());
+
+        mockMvc.perform(post("/api/posts/{postId}/comments/write", 1)
+                        .header("Authorization", "Bearer access-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(commentWriteRequest))
+                )
+                .andExpectAll(
+                        status().isUnauthorized(),
+                        jsonPath("$.errorCode").value(errorCode),
+                        jsonPath("$.message").value(message)
+                );
+    }
+
+    // 액세스 토큰 만료 및 잘못된 형식 검증 반복 테스트 시 사용하는 메서드
+    private static Stream<Arguments> expiredAndInvalidAccessToken() {
+        return Stream.of(
+                Arguments.of(Named.of("액세스 토큰 만료", "3002"), "토큰이 만료되었습니다."),
+                Arguments.of(Named.of("액세스 토큰 잘못된 형식", "3003"), "토큰 형식이 잘못되었습니다.")
+        );
+    }
+
+}

--- a/backend/src/test/java/com/board/domain/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/comment/repository/CommentRepositoryTest.java
@@ -1,0 +1,126 @@
+package com.board.domain.comment.repository;
+
+import com.board.domain.comment.entity.Comment;
+import com.board.domain.member.entity.Member;
+import com.board.domain.member.repository.MemberRepository;
+import com.board.domain.post.entity.Post;
+import com.board.domain.post.repository.PostRepository;
+import com.board.global.common.config.JpaAuditingConfig;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class CommentRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    private Member saveMember;
+    private Post savePost;
+
+    @BeforeEach
+    void setUp() {
+        saveMember = memberRepository.save(Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .password("12345678")
+                .build());
+        savePost = postRepository.save(Post.builder()
+                .title("title")
+                .writer(saveMember.getNickname())
+                .content("content")
+                .member(saveMember)
+                .build());
+    }
+
+    @DisplayName("댓글 엔티티를 저장한다.")
+    @Test
+    void commentSave() {
+        Comment comment = Comment.builder()
+                .writer(saveMember.getNickname())
+                .content("comment")
+                .member(saveMember)
+                .post(savePost)
+                .build();
+
+        Comment saveComment = commentRepository.save(comment);
+
+        assertThat(saveComment.getId()).isNotNull();
+        assertThat(saveComment.getWriter()).isEqualTo("yoonkun");
+        assertThat(saveComment.getContent()).isEqualTo("comment");
+    }
+
+    @DisplayName("댓글 엔티티 저장 시 writer 필드가 null이면 예외가 발생한다.")
+    @Test
+    void commentSaveNullWriter() {
+        Comment comment = Comment.builder()
+                .writer(null)
+                .content("comment")
+                .member(saveMember)
+                .post(savePost)
+                .build();
+
+        assertThatThrownBy(() -> commentRepository.save(comment))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @DisplayName("댓글 엔티티 저장 시 content 필드가 null이면 예외가 발생한다.")
+    @Test
+    void commentSaveNullContent() {
+        Comment comment = Comment.builder()
+                .writer(saveMember.getNickname())
+                .content(null)
+                .member(saveMember)
+                .post(savePost)
+                .build();
+
+        assertThatThrownBy(() -> commentRepository.save(comment))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @DisplayName("댓글 엔티티 저장 시 member 필드가 null이면 예외가 발생한다.")
+    @Test
+    void commentSaveNullMember() {
+        Comment comment = Comment.builder()
+                .writer(saveMember.getNickname())
+                .content("comment")
+                .member(null)
+                .post(savePost)
+                .build();
+
+        assertThatThrownBy(() -> commentRepository.save(comment))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @DisplayName("댓글 엔티티 저장 시 post 필드가 null이면 예외가 발생한다.")
+    @Test
+    void commentSaveNullPost() {
+        Comment comment = Comment.builder()
+                .writer(saveMember.getNickname())
+                .content("comment")
+                .member(saveMember)
+                .post(null)
+                .build();
+
+        assertThatThrownBy(() -> commentRepository.save(comment))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+}

--- a/backend/src/test/java/com/board/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/board/domain/comment/service/CommentServiceTest.java
@@ -1,0 +1,121 @@
+package com.board.domain.comment.service;
+
+import com.board.domain.comment.dto.CommentWriteRequest;
+import com.board.domain.comment.entity.Comment;
+import com.board.domain.comment.repository.CommentRepository;
+import com.board.domain.member.entity.Member;
+import com.board.domain.member.exception.NotFoundMemberException;
+import com.board.domain.member.repository.MemberRepository;
+import com.board.domain.post.entity.Post;
+import com.board.domain.post.exception.NotFoundPostException;
+import com.board.domain.post.repository.PostRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @InjectMocks
+    private CommentService commentService;
+
+    private Post post;
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .password("12345678")
+                .build();
+        post = Post.builder()
+                .title("title")
+                .writer(member.getNickname())
+                .content("content")
+                .member(member)
+                .build();
+    }
+
+    @DisplayName("댓글을 작성한다.")
+    @Test
+    void commentWrite() {
+        CommentWriteRequest commentWriteRequest = new CommentWriteRequest("comment");
+        Comment comment = Comment.builder()
+                .writer(member.getNickname())
+                .content(commentWriteRequest.getContent())
+                .member(member)
+                .post(post)
+                .build();
+
+        given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
+        given(memberRepository.findByUsername(anyString())).willReturn(Optional.of(member));
+        given(commentRepository.save(any(Comment.class))).willReturn(comment);
+
+        commentService.commentWrite(1L, "yoon1234", commentWriteRequest);
+
+        then(postRepository).should().findById(anyLong());
+        then(memberRepository).should().findByUsername(anyString());
+        then(commentRepository).should().save(any(Comment.class));
+
+    }
+
+    @DisplayName("댓글 작성 시 게시글이 존재하지 않을 경우 예외가 발생한다.")
+    @Test
+    void commentWriteNotFoundPost() {
+        CommentWriteRequest commentWriteRequest = new CommentWriteRequest("comment");
+
+        willThrow(new NotFoundPostException()).given(postRepository).findById(anyLong());
+
+        assertThatThrownBy(() -> commentService.commentWrite(1L, "yoon1234", commentWriteRequest))
+                .isInstanceOf(NotFoundPostException.class);
+
+        then(postRepository).should().findById(anyLong());
+        then(memberRepository).should(never()).findByUsername(anyString());
+        then(commentRepository).should(never()).save(any(Comment.class));
+    }
+
+    @DisplayName("댓글 작성 시 회원이 존재하지 않을 경우 예외가 발생한다.")
+    @Test
+    void commentWriteNotFoundMember() {
+        CommentWriteRequest commentWriteRequest = new CommentWriteRequest("comment");
+
+        given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
+        willThrow(new NotFoundMemberException()).given(memberRepository).findByUsername(anyString());
+
+        assertThatThrownBy(() -> commentService.commentWrite(1L, "yoon1234", commentWriteRequest))
+                .isInstanceOf(NotFoundMemberException.class);
+
+        then(postRepository).should().findById(anyLong());
+        then(memberRepository).should().findByUsername(anyString());
+        then(commentRepository).should(never()).save(any(Comment.class));
+    }
+
+}

--- a/backend/src/test/java/com/board/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/board/domain/member/controller/MemberControllerTest.java
@@ -6,10 +6,8 @@ import com.board.domain.member.exception.DuplicateNicknameException;
 import com.board.domain.member.exception.DuplicateUsernameException;
 import com.board.domain.member.service.MemberService;
 import com.board.domain.token.dto.TokenResponse;
-import com.board.domain.token.service.TokenService;
 import com.board.global.security.dto.AuthPrincipal;
 import com.board.global.security.dto.MemberLoginRequest;
-import com.board.global.security.service.MemberUserDetailsService;
 import com.board.restdocs.RestDocs;
 
 import io.jsonwebtoken.Claims;
@@ -49,12 +47,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = MemberController.class)
 class MemberControllerTest extends RestDocs {
-
-    @MockitoBean
-    private MemberUserDetailsService memberUserDetailsService;
-
-    @MockitoBean
-    private TokenService tokenService;
 
     @MockitoBean
     private MemberService memberService;

--- a/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/board/domain/post/controller/PostControllerTest.java
@@ -7,8 +7,6 @@ import com.board.domain.post.dto.PostModifyRequest;
 import com.board.domain.post.dto.PostWriteRequest;
 import com.board.domain.post.exception.NotFoundPostException;
 import com.board.domain.post.service.PostService;
-import com.board.domain.token.service.TokenService;
-import com.board.global.security.service.MemberUserDetailsService;
 import com.board.restdocs.RestDocs;
 
 import io.jsonwebtoken.Claims;
@@ -56,12 +54,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = PostController.class)
 class PostControllerTest extends RestDocs {
-
-    @MockitoBean
-    private MemberUserDetailsService memberUserDetailsService;
-
-    @MockitoBean
-    private TokenService tokenService;
 
     @MockitoBean
     private PostService postService;

--- a/backend/src/test/java/com/board/restdocs/RestDocs.java
+++ b/backend/src/test/java/com/board/restdocs/RestDocs.java
@@ -1,6 +1,8 @@
 package com.board.restdocs;
 
+import com.board.domain.token.service.TokenService;
 import com.board.global.security.config.SecurityConfig;
+import com.board.global.security.service.MemberUserDetailsService;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -12,6 +14,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -37,6 +40,12 @@ public abstract class RestDocs {
 
     @Autowired
     protected ObjectMapper objectMapper;
+
+    @MockitoBean
+    protected MemberUserDetailsService memberUserDetailsService;
+
+    @MockitoBean
+    protected TokenService tokenService;
 
     protected MockMvc mockMvc;
 


### PR DESCRIPTION
# 작업 내용

- 댓글 작성 기능 추가
  - 댓글 작성 시 게시글이 존재하지 않으면 예외(NotFoundPostException) 발생
  - 댓글 작성 시 회원이 존재하지 않으면 예외(NotFoundMemberException) 발생
  - 댓글 작성 요청 권한을 회원(MEMBER)로 설정
- 댓글 작성 기능 테스트 추가
- API 문서에 댓글 작성 API 내용 추가

### 관련 이슈

- close #25