### PR TITLE
댓글 수정 API 구현

### DIFF
--- a/backend/src/main/java/com/board/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/board/domain/comment/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.board.domain.comment.controller;
 
+import com.board.domain.comment.dto.CommentModifyRequest;
 import com.board.domain.comment.dto.CommentWriteRequest;
 import com.board.domain.comment.service.CommentService;
 
@@ -11,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +29,14 @@ public class CommentController {
                                              @AuthenticationPrincipal String username,
                                              @RequestBody @Valid CommentWriteRequest commentWriteRequest) {
         commentService.commentWrite(postId, username, commentWriteRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/{postId}/comments/{commentId}")
+    public ResponseEntity<Void> commentModify(@PathVariable("postId") Long postId,
+                                              @PathVariable("commentId") Long commentId,
+                                              @RequestBody @Valid CommentModifyRequest commentModifyRequest) {
+        commentService.commentModify(postId, commentId, commentModifyRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/backend/src/main/java/com/board/domain/comment/dto/CommentModifyRequest.java
+++ b/backend/src/main/java/com/board/domain/comment/dto/CommentModifyRequest.java
@@ -1,0 +1,17 @@
+package com.board.domain.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentModifyRequest {
+
+    @NotBlank(message = "내용을 입력해 주세요.")
+    private String content;
+
+}

--- a/backend/src/main/java/com/board/domain/comment/entity/Comment.java
+++ b/backend/src/main/java/com/board/domain/comment/entity/Comment.java
@@ -49,4 +49,8 @@ public class Comment extends BaseEntity {
         this.post = post;
     }
 
+    public void modify(String content) {
+        this.content = content;
+    }
+
 }

--- a/backend/src/main/java/com/board/domain/comment/exception/NotFoundCommentException.java
+++ b/backend/src/main/java/com/board/domain/comment/exception/NotFoundCommentException.java
@@ -1,0 +1,12 @@
+package com.board.domain.comment.exception;
+
+import com.board.global.error.exception.APIException;
+import com.board.global.error.exception.ErrorType;
+
+public class NotFoundCommentException extends APIException {
+
+    public NotFoundCommentException() {
+        super(ErrorType.NOT_FOUND_COMMENT);
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/board/domain/comment/repository/CommentRepository.java
@@ -4,5 +4,10 @@ import com.board.domain.comment.entity.Comment;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    Optional<Comment> findByPostIdAndId(Long postId, Long commentId);
+
 }

--- a/backend/src/main/java/com/board/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/board/domain/comment/service/CommentService.java
@@ -1,7 +1,9 @@
 package com.board.domain.comment.service;
 
+import com.board.domain.comment.dto.CommentModifyRequest;
 import com.board.domain.comment.dto.CommentWriteRequest;
 import com.board.domain.comment.entity.Comment;
+import com.board.domain.comment.exception.NotFoundCommentException;
 import com.board.domain.comment.repository.CommentRepository;
 
 import com.board.domain.member.entity.Member;
@@ -36,6 +38,13 @@ public class CommentService {
                 .post(post)
                 .build();
         commentRepository.save(comment);
+    }
+
+    @Transactional
+    public void commentModify(Long postId, Long commentId, CommentModifyRequest commentModifyRequest) {
+        Comment comment = commentRepository.findByPostIdAndId(postId, commentId)
+                .orElseThrow(NotFoundCommentException::new);
+        comment.modify(commentModifyRequest.getContent());
     }
 
 }

--- a/backend/src/main/java/com/board/global/error/exception/ErrorType.java
+++ b/backend/src/main/java/com/board/global/error/exception/ErrorType.java
@@ -24,6 +24,7 @@ public enum ErrorType {
     NOT_FOUND_TOKEN("4001", "토큰이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     NOT_FOUND_MEMBER("4002", "회원이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     NOT_FOUND_POST("4003", "게시글이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    NOT_FOUND_COMMENT("4004", "댓글이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
 
     // HTTP 409 Conflict
     DUPLICATE_NICKNAME("2001", "사용 중인 닉네임입니다.", HttpStatus.CONFLICT),

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -65,7 +65,8 @@ public class SecurityConfig {
                                 "/api/posts/write",
                                 "/api/posts/*/comments/write").hasRole("MEMBER")
                         .requestMatchers(HttpMethod.PUT,
-                                "/api/posts/*").hasRole("MEMBER")
+                                "/api/posts/*",
+                                "/api/posts/*/comments/*").hasRole("MEMBER")
                         .requestMatchers(HttpMethod.DELETE,
                                 "/api/posts/*").hasRole("MEMBER")
                         .anyRequest().denyAll()

--- a/backend/src/main/java/com/board/global/security/filter/TokenAuthenticationFilter.java
+++ b/backend/src/main/java/com/board/global/security/filter/TokenAuthenticationFilter.java
@@ -89,7 +89,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         POST_WRITE(HttpMethod.POST, "/api/posts/write", "MEMBER"),
         POST_MODIFY(HttpMethod.PUT, "/api/posts/*", "MEMBER"),
         POST_DELETE(HttpMethod.DELETE, "/api/posts/*", "MEMBER"),
-        COMMENT_WRITE(HttpMethod.POST, "/api/posts/*/comments/write", "MEMBER");
+        COMMENT_WRITE(HttpMethod.POST, "/api/posts/*/comments/write", "MEMBER"),
+        COMMENT_MODIFY(HttpMethod.PUT, "/api/posts/*/comments/*", "MEMBER");
 
         private final HttpMethod httpMethod;
         private final String pattern;

--- a/backend/src/main/resources/static/docs/index.html
+++ b/backend/src/main/resources/static/docs/index.html
@@ -461,6 +461,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_게시글_수정">게시글 수정</a></li>
 <li><a href="#_게시글_삭제">게시글 삭제</a></li>
 <li><a href="#_댓글_작성">댓글 작성</a></li>
+<li><a href="#_댓글_수정">댓글 수정</a></li>
 </ul>
 </li>
 </ul>
@@ -895,7 +896,7 @@ Content-Type: application/json
   "title" : "title",
   "writer" : "writer",
   "content" : "content",
-  "createdAt" : "2025-02-13T16:10:01.347384"
+  "createdAt" : "2025-02-15T21:25:54.183985"
 }</code></pre>
 </div>
 </div>
@@ -999,7 +1000,7 @@ Content-Type: application/json
     "postId" : 1,
     "title" : "title",
     "writer" : "writer",
-    "createdAt" : "2025-02-13T16:10:01.314191"
+    "createdAt" : "2025-02-15T21:25:54.143493"
   } ],
   "page" : 1,
   "totalPages" : 1,
@@ -1441,13 +1442,150 @@ Content-Type: application/json
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_댓글_수정">댓글 수정</h3>
+<div class="sect3">
+<h4 id="_요청_10">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/posts/1/comments/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access-token
+
+{
+  "content" : "comment"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 5. /api/posts/{postId}/comments/{commentId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>commentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 번호</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인증을 위한 Bearer 액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">내용</p></td>
+</tr>
+</tbody>
+</table>
+<div class="sect4">
+<h5 id="_응답_10">응답</h5>
+<div class="paragraph">
+<p><strong>응답 성공: 댓글 수정 성공</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>응답 실패: access token 만료 및 잘못된 형식</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+
+{
+  "errorCode" : "3003",
+  "message" : "토큰 형식이 잘못되었습니다."
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>응답 실패: 댓글이 존재하지 않는 경우</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 404 Not Found
+Content-Type: application/json
+
+{
+  "errorCode" : "4004",
+  "message" : "댓글이 존재하지 않습니다."
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>응답 실패: 입력값이 빈값인 경우</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "errorCode" : "1001",
+  "message" : "입력값이 잘못되었습니다.",
+  "fields" : [ {
+    "field" : "content",
+    "input" : "",
+    "message" : "내용을 입력해 주세요."
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1<br>
-Last updated 2025-02-13 16:09:50 +0900
+Last updated 2025-02-15 21:25:46 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/test/java/com/board/domain/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/board/domain/comment/controller/CommentControllerTest.java
@@ -1,6 +1,8 @@
 package com.board.domain.comment.controller;
 
+import com.board.domain.comment.dto.CommentModifyRequest;
 import com.board.domain.comment.dto.CommentWriteRequest;
+import com.board.domain.comment.exception.NotFoundCommentException;
 import com.board.domain.comment.service.CommentService;
 import com.board.domain.post.exception.NotFoundPostException;
 import com.board.restdocs.RestDocs;
@@ -37,6 +39,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -142,6 +145,112 @@ class CommentControllerTest extends RestDocs {
                         .header("Authorization", "Bearer access-token")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(commentWriteRequest))
+                )
+                .andExpectAll(
+                        status().isUnauthorized(),
+                        jsonPath("$.errorCode").value(errorCode),
+                        jsonPath("$.message").value(message)
+                );
+    }
+
+    @DisplayName("댓글 수정에 성공하면 200 상태 코드를 반환한다.")
+    @Test
+    void commentModify() throws Exception {
+        CommentModifyRequest commentModifyRequest = new CommentModifyRequest("comment");
+        Claims claims = Jwts.claims()
+                .subject("yoon1234")
+                .add("authority", "ROLE_MEMBER")
+                .build();
+
+        given(tokenService.getClaims(anyString())).willReturn(claims);
+        willDoNothing().given(commentService).commentModify(anyLong(), anyLong(), any(CommentModifyRequest.class));
+
+        mockMvc.perform(put("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                        .header("Authorization", "Bearer access-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(commentModifyRequest))
+                )
+                .andExpectAll(
+                        status().isOk()
+                )
+                .andDo(restdocs.document(
+                        pathParameters(
+                                parameterWithName("postId").description("게시글 번호"),
+                                parameterWithName("commentId").description("댓글 번호")
+                        ),
+                        requestHeaders(
+                                headerWithName("Authorization").description("인증을 위한 Bearer 액세스 토큰")
+                        ),
+                        requestFields(
+                                fieldWithPath("content").type(JsonFieldType.STRING).description("내용")
+                        )
+                ));
+    }
+
+    @DisplayName("댓글 수정 시 내용이 공백이면 예외 응답과 400 상태 코드를 반환한다.")
+    @Test
+    void commentModifyBlankContent() throws Exception {
+        CommentModifyRequest commentModifyRequest = new CommentModifyRequest("");
+
+        Claims claims = Jwts.claims()
+                .subject("yoon1234")
+                .add("authority", "ROLE_MEMBER")
+                .build();
+
+        given(tokenService.getClaims(anyString())).willReturn(claims);
+
+        mockMvc.perform(put("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                        .header("Authorization", "Bearer access-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(commentModifyRequest))
+                )
+                .andExpectAll(
+                        status().isBadRequest(),
+                        jsonPath("$.errorCode").value("1001"),
+                        jsonPath("$.message").value("입력값이 잘못되었습니다."),
+                        jsonPath("$.fields").isArray(),
+                        jsonPath("$.fields[0].field").value("content"),
+                        jsonPath("$.fields[0].input").value(""),
+                        jsonPath("$.fields[0].message").value("내용을 입력해 주세요.")
+                );
+    }
+
+    @DisplayName("댓글 수정 시 댓글이 존재하지 않으면 예외 응답과 404 상태 코드를 반환한다.")
+    @Test
+    void commentModifyNotFoundComment() throws Exception {
+        CommentModifyRequest commentModifyRequest = new CommentModifyRequest("comment");
+        Claims claims = Jwts.claims()
+                .subject("yoon1234")
+                .add("authority", "ROLE_MEMBER")
+                .build();
+
+        given(tokenService.getClaims(anyString())).willReturn(claims);
+        willThrow(new NotFoundCommentException()).given(commentService).commentModify(anyLong(), anyLong(), any(CommentModifyRequest.class));
+
+        mockMvc.perform(put("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                        .header("Authorization", "Bearer access-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(commentModifyRequest))
+                )
+                .andExpectAll(
+                        status().isNotFound(),
+                        jsonPath("$.errorCode").value("4004"),
+                        jsonPath("$.message").value("댓글이 존재하지 않습니다.")
+                );
+    }
+
+    @DisplayName("댓글 수정 시 액세스 토큰이 만료되거나 형식이 잘못되면 예외 응답과 401 상태 코드를 반환한다.")
+    @ParameterizedTest
+    @MethodSource("expiredAndInvalidAccessToken")
+    void commentModifyExpiredAndInvalidAccessToken(String errorCode, String message) throws Exception {
+        CommentModifyRequest commentModifyRequest = new CommentModifyRequest("comment");
+
+        willThrow(new AuthenticationServiceException(errorCode)).given(tokenService).getClaims(anyString());
+
+        mockMvc.perform(put("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                        .header("Authorization", "Bearer access-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(commentModifyRequest))
                 )
                 .andExpectAll(
                         status().isUnauthorized(),

--- a/backend/src/test/java/com/board/domain/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/comment/repository/CommentRepositoryTest.java
@@ -16,6 +16,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -121,6 +123,32 @@ class CommentRepositoryTest {
 
         assertThatThrownBy(() -> commentRepository.save(comment))
                 .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @DisplayName("게시글 기본 키와 댓글 기본 키로 댓글 엔티티를 조회한다.")
+    @Test
+    void commentFindByPostIdAndId() {
+        Comment comment = Comment.builder()
+                .writer(saveMember.getNickname())
+                .content("comment")
+                .member(saveMember)
+                .post(savePost)
+                .build();
+        Comment saveComment = commentRepository.save(comment);
+
+        Optional<Comment> findComment = commentRepository.findByPostIdAndId(savePost.getId(), saveComment.getId());
+
+        assertThat(findComment).isNotEmpty();
+        assertThat(findComment.get().getWriter()).isEqualTo("yoonkun");
+        assertThat(findComment.get().getContent()).isEqualTo("comment");
+    }
+
+    @DisplayName("게시글 기본 키와 댓글 기본 키에 해당하는 댓글 엔티티가 존재하지 않으면 빈 Optional 객체를 반환한다.")
+    @Test
+    void commentFindByPostIdAndIdNotFoundComment() {
+        Optional<Comment> findComment = commentRepository.findByPostIdAndId(1L, 1L);
+
+        assertThat(findComment).isEmpty();
     }
 
 }

--- a/backend/src/test/java/com/board/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/board/domain/comment/service/CommentServiceTest.java
@@ -1,7 +1,9 @@
 package com.board.domain.comment.service;
 
+import com.board.domain.comment.dto.CommentModifyRequest;
 import com.board.domain.comment.dto.CommentWriteRequest;
 import com.board.domain.comment.entity.Comment;
+import com.board.domain.comment.exception.NotFoundCommentException;
 import com.board.domain.comment.repository.CommentRepository;
 import com.board.domain.member.entity.Member;
 import com.board.domain.member.exception.NotFoundMemberException;
@@ -116,6 +118,37 @@ class CommentServiceTest {
         then(postRepository).should().findById(anyLong());
         then(memberRepository).should().findByUsername(anyString());
         then(commentRepository).should(never()).save(any(Comment.class));
+    }
+
+    @DisplayName("댓글을 수정한다.")
+    @Test
+    void commentModify() {
+        CommentModifyRequest commentModifyRequest = new CommentModifyRequest("comment");
+        Comment comment = Comment.builder()
+                .writer(member.getNickname())
+                .content("comment")
+                .member(member)
+                .post(post)
+                .build();
+
+        given(commentRepository.findByPostIdAndId(anyLong(), anyLong())).willReturn(Optional.of(comment));
+
+        commentService.commentModify(1L, 1L, commentModifyRequest);
+
+        then(commentRepository).should().findByPostIdAndId(anyLong(), anyLong());
+    }
+
+    @DisplayName("댓글 수정 시 댓글이 존재하지 않으면 예외가 발생한다.")
+    @Test
+    void commentModifyNotFoundComment() {
+        CommentModifyRequest commentModifyRequest = new CommentModifyRequest("comment");
+
+        willThrow(new NotFoundCommentException()).given(commentRepository).findByPostIdAndId(anyLong(), anyLong());
+
+        assertThatThrownBy(() -> commentService.commentModify(1L, 1L, commentModifyRequest))
+                .isInstanceOf(NotFoundCommentException.class);
+
+        then(commentRepository).should().findByPostIdAndId(anyLong(), anyLong());
     }
 
 }


### PR DESCRIPTION
# 작업 내용

- 댓글 수정 기능 추가
  - 댓글 수정 시 댓글이 존재하지 않으면 예외(NotFoundCommentException) 발생
  - 댓글 수정 요청 권한을 회원(MEMBER)으로 설정
- 댓글 수정 기능 테스트 추가
- API 문서에 댓글 수정 API 내용 추가

### 관련 이슈

- close #27