### PR TITLE
댓글 삭제 API 구현

### DIFF
--- a/backend/src/main/java/com/board/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/board/domain/comment/controller/CommentController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -37,6 +38,13 @@ public class CommentController {
                                               @PathVariable("commentId") Long commentId,
                                               @RequestBody @Valid CommentModifyRequest commentModifyRequest) {
         commentService.commentModify(postId, commentId, commentModifyRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{postId}/comments/{commentId}")
+    public ResponseEntity<Void> commentDelete(@PathVariable("postId") Long postId,
+                                              @PathVariable("commentId") Long commentId) {
+        commentService.commentDelete(postId, commentId);
         return ResponseEntity.ok().build();
     }
 

--- a/backend/src/main/java/com/board/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/board/domain/comment/service/CommentService.java
@@ -47,4 +47,11 @@ public class CommentService {
         comment.modify(commentModifyRequest.getContent());
     }
 
+    @Transactional
+    public void commentDelete(Long postId, Long commentId) {
+        Comment comment = commentRepository.findByPostIdAndId(postId, commentId)
+                .orElseThrow(NotFoundCommentException::new);
+        commentRepository.delete(comment);
+    }
+
 }

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -68,7 +68,8 @@ public class SecurityConfig {
                                 "/api/posts/*",
                                 "/api/posts/*/comments/*").hasRole("MEMBER")
                         .requestMatchers(HttpMethod.DELETE,
-                                "/api/posts/*").hasRole("MEMBER")
+                                "/api/posts/*",
+                                "/api/posts/*/comments/*").hasRole("MEMBER")
                         .anyRequest().denyAll()
                 );
         return httpSecurity.build();

--- a/backend/src/main/java/com/board/global/security/filter/TokenAuthenticationFilter.java
+++ b/backend/src/main/java/com/board/global/security/filter/TokenAuthenticationFilter.java
@@ -90,7 +90,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         POST_MODIFY(HttpMethod.PUT, "/api/posts/*", "MEMBER"),
         POST_DELETE(HttpMethod.DELETE, "/api/posts/*", "MEMBER"),
         COMMENT_WRITE(HttpMethod.POST, "/api/posts/*/comments/write", "MEMBER"),
-        COMMENT_MODIFY(HttpMethod.PUT, "/api/posts/*/comments/*", "MEMBER");
+        COMMENT_MODIFY(HttpMethod.PUT, "/api/posts/*/comments/*", "MEMBER"),
+        COMMENT_DELETE(HttpMethod.DELETE, "/api/posts/*/comments/*", "MEMBER");
 
         private final HttpMethod httpMethod;
         private final String pattern;

--- a/backend/src/main/resources/static/docs/index.html
+++ b/backend/src/main/resources/static/docs/index.html
@@ -462,6 +462,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_게시글_삭제">게시글 삭제</a></li>
 <li><a href="#_댓글_작성">댓글 작성</a></li>
 <li><a href="#_댓글_수정">댓글 수정</a></li>
+<li><a href="#_댓글_삭제">댓글 삭제</a></li>
 </ul>
 </li>
 </ul>
@@ -896,7 +897,7 @@ Content-Type: application/json
   "title" : "title",
   "writer" : "writer",
   "content" : "content",
-  "createdAt" : "2025-02-15T21:25:54.183985"
+  "createdAt" : "2025-02-15T21:46:41.394891"
 }</code></pre>
 </div>
 </div>
@@ -1000,7 +1001,7 @@ Content-Type: application/json
     "postId" : 1,
     "title" : "title",
     "writer" : "writer",
-    "createdAt" : "2025-02-15T21:25:54.143493"
+    "createdAt" : "2025-02-15T21:46:41.35767"
   } ],
   "page" : 1,
   "totalPages" : 1,
@@ -1579,13 +1580,105 @@ Content-Type: application/json
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_댓글_삭제">댓글 삭제</h3>
+<div class="sect3">
+<h4 id="_요청_11">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/posts/1/comments/1 HTTP/1.1
+Authorization: Bearer access-token</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 6. /api/posts/{postId}/comments/{commentId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>commentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 번호</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인증을 위한 Bearer 액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_11">응답</h4>
+<div class="paragraph">
+<p><strong>응답 성공: 댓글 삭제 성공</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>응답 실패: access token 만료 및 잘못된 형식</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+
+{
+  "errorCode" : "3003",
+  "message" : "토큰 형식이 잘못되었습니다."
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>응답 실패: 댓글이 존재하지 않는 경우</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 404 Not Found
+Content-Type: application/json
+
+{
+  "errorCode" : "4004",
+  "message" : "댓글이 존재하지 않습니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1<br>
-Last updated 2025-02-15 21:25:46 +0900
+Last updated 2025-02-15 21:46:34 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/test/java/com/board/domain/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/board/domain/comment/controller/CommentControllerTest.java
@@ -38,6 +38,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -251,6 +252,71 @@ class CommentControllerTest extends RestDocs {
                         .header("Authorization", "Bearer access-token")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(commentModifyRequest))
+                )
+                .andExpectAll(
+                        status().isUnauthorized(),
+                        jsonPath("$.errorCode").value(errorCode),
+                        jsonPath("$.message").value(message)
+                );
+    }
+
+    @DisplayName("댓글 삭제에 성공하면 200 상태 코드를 반환한다.")
+    @Test
+    void commentDelete() throws Exception {
+        Claims claims = Jwts.claims()
+                .subject("yoon1234")
+                .add("authority", "ROLE_MEMBER")
+                .build();
+
+        given(tokenService.getClaims(anyString())).willReturn(claims);
+        willDoNothing().given(commentService).commentDelete(anyLong(), anyLong());
+
+        mockMvc.perform(delete("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                        .header("Authorization", "Bearer access-token")
+                )
+                .andExpect(
+                        status().isOk()
+                )
+                .andDo(restdocs.document(
+                        pathParameters(
+                                parameterWithName("postId").description("게시글 번호"),
+                                parameterWithName("commentId").description("댓글 번호")
+                        ),
+                        requestHeaders(
+                                headerWithName("Authorization").description("인증을 위한 Bearer 액세스 토큰")
+                        )
+                ));
+    }
+
+    @DisplayName("댓글 삭제 시 댓글이 존재하지 않으면 예외 응답과 404 상태 코드를 반환한다.")
+    @Test
+    void commentDeleteNotFoundComment() throws Exception {
+        Claims claims = Jwts.claims()
+                .subject("yoon1234")
+                .add("authority", "ROLE_MEMBER")
+                .build();
+
+        given(tokenService.getClaims(anyString())).willReturn(claims);
+        willThrow(new NotFoundCommentException()).given(commentService).commentDelete(anyLong(), anyLong());
+
+        mockMvc.perform(delete("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                        .header("Authorization", "Bearer access-token")
+                )
+                .andExpectAll(
+                        status().isNotFound(),
+                        jsonPath("$.errorCode").value("4004"),
+                        jsonPath("$.message").value("댓글이 존재하지 않습니다.")
+                );
+    }
+
+    @DisplayName("댓글 삭제 시 액세스 토큰이 만료되거나 형식이 잘못되면 예외 응답과 401 상태 코드를 반환한다.")
+    @ParameterizedTest
+    @MethodSource("expiredAndInvalidAccessToken")
+    void commentDeleteExpiredAndInvalidAccessToken(String errorCode, String message) throws Exception {
+        willThrow(new AuthenticationServiceException(errorCode)).given(tokenService).getClaims(anyString());
+
+        mockMvc.perform(delete("/api/posts/{postId}/comments/{commentId}", 1, 1)
+                        .header("Authorization", "Bearer access-token")
                 )
                 .andExpectAll(
                         status().isUnauthorized(),

--- a/backend/src/test/java/com/board/domain/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/comment/repository/CommentRepositoryTest.java
@@ -151,4 +151,20 @@ class CommentRepositoryTest {
         assertThat(findComment).isEmpty();
     }
 
+    @DisplayName("댓글 엔티티를 삭제한다.")
+    @Test
+    void commentDelete() {
+        Comment comment = Comment.builder()
+                .writer(saveMember.getNickname())
+                .content("comment")
+                .member(saveMember)
+                .post(savePost)
+                .build();
+        Comment saveComment = commentRepository.save(comment);
+
+        Optional<Comment> findComment = commentRepository.findByPostIdAndId(savePost.getId(), saveComment.getId());
+
+        commentRepository.delete(findComment.get());
+    }
+
 }

--- a/backend/src/test/java/com/board/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/board/domain/comment/service/CommentServiceTest.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 
@@ -149,6 +150,37 @@ class CommentServiceTest {
                 .isInstanceOf(NotFoundCommentException.class);
 
         then(commentRepository).should().findByPostIdAndId(anyLong(), anyLong());
+    }
+
+    @DisplayName("댓글을 삭제한다.")
+    @Test
+    void commentDelete() {
+        Comment comment = Comment.builder()
+                .writer(member.getNickname())
+                .content("comment")
+                .member(member)
+                .post(post)
+                .build();
+
+        given(commentRepository.findByPostIdAndId(anyLong(), anyLong())).willReturn(Optional.of(comment));
+        willDoNothing().given(commentRepository).delete(any(Comment.class));
+
+        commentService.commentDelete(1L, 1L);
+
+        then(commentRepository).should().findByPostIdAndId(anyLong(), anyLong());
+        then(commentRepository).should().delete(any(Comment.class));
+    }
+
+    @DisplayName("댓글 삭제 시 댓글이 존재하지 않으면 예외가 발생한다.")
+    @Test
+    void commentDeleteNotFoundComment() {
+        willThrow(new NotFoundCommentException()).given(commentRepository).findByPostIdAndId(anyLong(), anyLong());
+
+        assertThatThrownBy(() -> commentService.commentDelete(1L, 1L))
+                .isInstanceOf(NotFoundCommentException.class);
+
+        then(commentRepository).should().findByPostIdAndId(anyLong(), anyLong());
+        then(commentRepository).should(never()).delete(any(Comment.class));
     }
 
 }


### PR DESCRIPTION
# 작업 내용

- 댓글 삭제 기능 추가
  - 댓글 삭제 요청 권한 회원(MEMBER)으로 설정
 - 댓글 삭제 기능 테스트 추가
 - API 문서에 댓글 삭제 API 내용 추가

### 관련 이슈

- close #28