### PR TITLE
댓글 목록조회 API 구현

### DIFF
--- a/backend/src/main/java/com/board/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/board/domain/comment/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.board.domain.comment.controller;
 
+import com.board.domain.comment.dto.CommentListResponse;
 import com.board.domain.comment.dto.CommentModifyRequest;
 import com.board.domain.comment.dto.CommentWriteRequest;
 import com.board.domain.comment.service.CommentService;
@@ -11,11 +12,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,6 +27,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController {
 
     private final CommentService commentService;
+
+    @GetMapping("/{postId}/comments")
+    public ResponseEntity<CommentListResponse> commentList(@PathVariable("postId") Long postId,
+                                                           @RequestParam("page") int page) {
+        CommentListResponse commentListResponse = commentService.commentList(postId, page);
+        return ResponseEntity.ok().body(commentListResponse);
+    }
 
     @PostMapping("/{postId}/comments/write")
     public ResponseEntity<Void> commentWrite(@PathVariable("postId") Long postId,

--- a/backend/src/main/java/com/board/domain/comment/dto/CommentListResponse.java
+++ b/backend/src/main/java/com/board/domain/comment/dto/CommentListResponse.java
@@ -1,0 +1,62 @@
+package com.board.domain.comment.dto;
+
+import com.board.domain.comment.entity.Comment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentListResponse {
+
+    private List<CommentItem> comments;
+    private int page;
+    private int totalPages;
+    private long totalComments;
+    private boolean first;
+    private boolean last;
+    private boolean prev;
+    private boolean next;
+
+    public CommentListResponse(Page<Comment> commentPage) {
+        this.comments = commentPage.getContent()
+                .stream()
+                .map(CommentItem::new)
+                .collect(Collectors.toList());
+        this.page = commentPage.getNumber() + 1;
+        this.totalPages = commentPage.getTotalPages();
+        this.totalComments = commentPage.getTotalElements();
+        this.first = commentPage.isFirst();
+        this.last = commentPage.isLast();
+        this.prev = commentPage.hasPrevious();
+        this.next = commentPage.hasNext();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CommentItem {
+
+        private Long commentId;
+        private String writer;
+        private String content;
+        private LocalDateTime createdAt;
+
+        public CommentItem(Comment comment) {
+            this.commentId = comment.getId();
+            this.writer = comment.getWriter();
+            this.content = comment.getContent();
+            this.createdAt = comment.getCreatedAt();
+        }
+
+    }
+
+}

--- a/backend/src/main/java/com/board/domain/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/board/domain/comment/repository/CommentRepository.java
@@ -2,6 +2,8 @@ package com.board.domain.comment.repository;
 
 import com.board.domain.comment.entity.Comment;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,5 +11,6 @@ import java.util.Optional;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Optional<Comment> findByPostIdAndId(Long postId, Long commentId);
+    Page<Comment> findAllByPostId(Long postId, Pageable pageable);
 
 }

--- a/backend/src/main/java/com/board/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/board/domain/comment/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.board.domain.comment.service;
 
+import com.board.domain.comment.dto.CommentListResponse;
 import com.board.domain.comment.dto.CommentModifyRequest;
 import com.board.domain.comment.dto.CommentWriteRequest;
 import com.board.domain.comment.entity.Comment;
@@ -15,6 +16,10 @@ import com.board.domain.post.repository.PostRepository;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +30,14 @@ public class CommentService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final CommentRepository commentRepository;
+
+    @Transactional(readOnly = true)
+    public CommentListResponse commentList(Long postId, int page) {
+        page = page <= 0 ? 0 : page - 1;
+        Pageable pageable = PageRequest.of(page, 10, Sort.Direction.DESC, "id");
+        Page<Comment> commentPage = commentRepository.findAllByPostId(postId, pageable);
+        return new CommentListResponse(commentPage);
+    }
 
     @Transactional
     public void commentWrite(Long postId, String username, CommentWriteRequest commentWriteRequest) {

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -58,7 +58,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET,
                                 "/api/posts/*",
-                                "/api/posts").permitAll()
+                                "/api/posts",
+                                "/api/posts/*/comments").permitAll()
                         .requestMatchers(HttpMethod.POST,
                                 "/api/members/signup").permitAll()
                         .requestMatchers(HttpMethod.POST,

--- a/backend/src/main/java/com/board/global/security/filter/TokenAuthenticationFilter.java
+++ b/backend/src/main/java/com/board/global/security/filter/TokenAuthenticationFilter.java
@@ -83,6 +83,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         MEMBER_LOGIN(HttpMethod.POST, "/api/auth/login", "ALL"),
         POST_DETAIL(HttpMethod.GET, "/api/posts/*", "ALL"),
         POST_LIST(HttpMethod.GET, "/api/posts", "ALL"),
+        COMMENT_LIST(HttpMethod.GET, "/api/posts/*/comments", "ALL"),
 
         // 회원(MEMBER) 권한만 허용
         MEMBER_LOGOUT(HttpMethod.POST, "/api/auth/logout", "MEMBER"),

--- a/backend/src/main/resources/static/docs/index.html
+++ b/backend/src/main/resources/static/docs/index.html
@@ -460,6 +460,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_게시글_목록조회">게시글 목록조회</a></li>
 <li><a href="#_게시글_수정">게시글 수정</a></li>
 <li><a href="#_게시글_삭제">게시글 삭제</a></li>
+<li><a href="#_댓글_목록">댓글 목록</a></li>
 <li><a href="#_댓글_작성">댓글 작성</a></li>
 <li><a href="#_댓글_수정">댓글 수정</a></li>
 <li><a href="#_댓글_삭제">댓글 삭제</a></li>
@@ -897,7 +898,7 @@ Content-Type: application/json
   "title" : "title",
   "writer" : "writer",
   "content" : "content",
-  "createdAt" : "2025-02-15T21:46:41.394891"
+  "createdAt" : "2025-02-17T21:54:36.60592"
 }</code></pre>
 </div>
 </div>
@@ -1001,7 +1002,7 @@ Content-Type: application/json
     "postId" : 1,
     "title" : "title",
     "writer" : "writer",
-    "createdAt" : "2025-02-15T21:46:41.35767"
+    "createdAt" : "2025-02-17T21:54:36.576014"
   } ],
   "page" : 1,
   "totalPages" : 1,
@@ -1311,9 +1312,161 @@ Content-Type: application/json
 </div>
 </div>
 <div class="sect2">
-<h3 id="_댓글_작성">댓글 작성</h3>
+<h3 id="_댓글_목록">댓글 목록</h3>
 <div class="sect3">
 <h4 id="_요청_9">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/posts/1/comments?page=1 HTTP/1.1</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 4. /api/posts/{postId}/comments</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 번호</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_9">응답</h4>
+<div class="paragraph">
+<p><strong>응답 성공: 댓글 목록조회 성공</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "comments" : [ {
+    "commentId" : 1,
+    "writer" : "writer",
+    "content" : "comment",
+    "createdAt" : "2025-02-17T21:54:34.695662"
+  } ],
+  "page" : 1,
+  "totalPages" : 1,
+  "totalComments" : 1,
+  "first" : true,
+  "last" : true,
+  "prev" : false,
+  "next" : false
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments[0].commentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments[0].writer</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments[0].content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments[0].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 페이지 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>totalComments</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전체 댓글 개수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>totalPages</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전체 페이지 개수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>first</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">첫째 페이지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>last</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 페이지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>prev</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이전 페이지 존재 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>next</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">다음 페이지 존재 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_댓글_작성">댓글 작성</h3>
+<div class="sect3">
+<h4 id="_요청_10">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/posts/1/comments/write HTTP/1.1
@@ -1326,7 +1479,7 @@ Authorization: Bearer access-token
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 4. /api/posts/{postId}/comments/write</caption>
+<caption class="title">Table 5. /api/posts/{postId}/comments/write</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -1385,7 +1538,7 @@ Authorization: Bearer access-token
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_9">응답</h4>
+<h4 id="_응답_10">응답</h4>
 <div class="paragraph">
 <p><strong>응답 성공: 댓글 작성 성공</strong></p>
 </div>
@@ -1446,7 +1599,7 @@ Content-Type: application/json
 <div class="sect2">
 <h3 id="_댓글_수정">댓글 수정</h3>
 <div class="sect3">
-<h4 id="_요청_10">요청</h4>
+<h4 id="_요청_11">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/posts/1/comments/1 HTTP/1.1
@@ -1459,7 +1612,7 @@ Authorization: Bearer access-token
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 5. /api/posts/{postId}/comments/{commentId}</caption>
+<caption class="title">Table 6. /api/posts/{postId}/comments/{commentId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -1521,7 +1674,7 @@ Authorization: Bearer access-token
 </tbody>
 </table>
 <div class="sect4">
-<h5 id="_응답_10">응답</h5>
+<h5 id="_응답_11">응답</h5>
 <div class="paragraph">
 <p><strong>응답 성공: 댓글 수정 성공</strong></p>
 </div>
@@ -1583,7 +1736,7 @@ Content-Type: application/json
 <div class="sect2">
 <h3 id="_댓글_삭제">댓글 삭제</h3>
 <div class="sect3">
-<h4 id="_요청_11">요청</h4>
+<h4 id="_요청_12">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/posts/1/comments/1 HTTP/1.1
@@ -1591,7 +1744,7 @@ Authorization: Bearer access-token</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 6. /api/posts/{postId}/comments/{commentId}</caption>
+<caption class="title">Table 7. /api/posts/{postId}/comments/{commentId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -1633,7 +1786,7 @@ Authorization: Bearer access-token</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_11">응답</h4>
+<h4 id="_응답_12">응답</h4>
 <div class="paragraph">
 <p><strong>응답 성공: 댓글 삭제 성공</strong></p>
 </div>
@@ -1678,7 +1831,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1<br>
-Last updated 2025-02-15 21:46:34 +0900
+Last updated 2025-02-17 21:54:24 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/test/java/com/board/domain/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/board/domain/comment/controller/CommentControllerTest.java
@@ -1,5 +1,7 @@
 package com.board.domain.comment.controller;
 
+import com.board.domain.comment.dto.CommentListResponse;
+import com.board.domain.comment.dto.CommentListResponse.CommentItem;
 import com.board.domain.comment.dto.CommentModifyRequest;
 import com.board.domain.comment.dto.CommentWriteRequest;
 import com.board.domain.comment.exception.NotFoundCommentException;
@@ -23,9 +25,12 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -36,9 +41,12 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.headerWit
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -49,6 +57,58 @@ class CommentControllerTest extends RestDocs {
 
     @MockitoBean
     private CommentService commentService;
+
+    @DisplayName("댓글 목록조회에 성공하면 댓글 목록과 200 상태 코드를 반환한다.")
+    @Test
+    void commentList() throws Exception {
+        List<CommentItem> comments = List.of(
+                new CommentItem(1L, "writer", "comment", LocalDateTime.now())
+        );
+        CommentListResponse commentListResponse = new CommentListResponse(comments, 1, 1, 1, true, true, false, false);
+
+        given(commentService.commentList(anyLong(), anyInt())).willReturn(commentListResponse);
+
+        mockMvc.perform(get("/api/posts/{postId}/comments", 1)
+                        .param("page", "1")
+                )
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.comments").isArray(),
+                        jsonPath("$.comments[0].commentId").value(1),
+                        jsonPath("$.comments[0].writer").value("writer"),
+                        jsonPath("$.comments[0].content").value("comment"),
+                        jsonPath("$.comments[0].createdAt").isNotEmpty(),
+                        jsonPath("$.page").value(1),
+                        jsonPath("$.totalPages").value(1),
+                        jsonPath("$.totalComments").value(1),
+                        jsonPath("$.first").value(true),
+                        jsonPath("$.last").value(true),
+                        jsonPath("$.prev").value(false),
+                        jsonPath("$.next").value(false)
+                )
+                .andDo(restdocs.document(
+                        pathParameters(
+                                parameterWithName("postId").description("게시글 번호")
+                        ),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("comments").type(JsonFieldType.ARRAY).description("댓글 목록"),
+                                fieldWithPath("comments[0].commentId").type(JsonFieldType.NUMBER).description("댓글번호"),
+                                fieldWithPath("comments[0].writer").type(JsonFieldType.STRING).description("작성자"),
+                                fieldWithPath("comments[0].content").type(JsonFieldType.STRING).description("내용"),
+                                fieldWithPath("comments[0].createdAt").type(JsonFieldType.STRING).description("작성일"),
+                                fieldWithPath("page").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+                                fieldWithPath("totalComments").type(JsonFieldType.NUMBER).description("전체 댓글 개수"),
+                                fieldWithPath("totalPages").type(JsonFieldType.NUMBER).description("전체 페이지 개수"),
+                                fieldWithPath("first").type(JsonFieldType.BOOLEAN).description("첫째 페이지 여부"),
+                                fieldWithPath("last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                                fieldWithPath("prev").type(JsonFieldType.BOOLEAN).description("이전 페이지 존재 여부"),
+                                fieldWithPath("next").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부")
+                        )
+                ));
+    }
 
     @DisplayName("댓글 작성에 성공하면 200 상태 코드를 반환한다.")
     @Test

--- a/backend/src/test/java/com/board/domain/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/board/domain/comment/repository/CommentRepositoryTest.java
@@ -15,6 +15,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.util.Optional;
 
@@ -165,6 +169,30 @@ class CommentRepositoryTest {
         Optional<Comment> findComment = commentRepository.findByPostIdAndId(savePost.getId(), saveComment.getId());
 
         commentRepository.delete(findComment.get());
+    }
+
+    @DisplayName("게시글 기본키를 외래키로 가지고 있는 댓글 엔티티 목록을 조회한다.")
+    @Test
+    void commentFindAllByPostId() {
+        Comment comment = Comment.builder()
+                .writer(saveMember.getNickname())
+                .content("comment")
+                .member(saveMember)
+                .post(savePost)
+                .build();
+        commentRepository.save(comment);
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.Direction.DESC, "id");
+        Page<Comment> commentPage = commentRepository.findAllByPostId(savePost.getId(), pageable);
+
+        assertThat(commentPage.getContent().size()).isEqualTo(1);
+        assertThat(commentPage.getNumber()).isEqualTo(0);
+        assertThat(commentPage.getTotalPages()).isEqualTo(1);
+        assertThat(commentPage.getTotalElements()).isEqualTo(1);
+        assertThat(commentPage.isFirst()).isTrue();
+        assertThat(commentPage.isLast()).isTrue();
+        assertThat(commentPage.hasPrevious()).isFalse();
+        assertThat(commentPage.hasNext()).isFalse();
     }
 
 }

--- a/backend/src/test/java/com/board/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/board/domain/comment/service/CommentServiceTest.java
@@ -1,5 +1,6 @@
 package com.board.domain.comment.service;
 
+import com.board.domain.comment.dto.CommentListResponse;
 import com.board.domain.comment.dto.CommentModifyRequest;
 import com.board.domain.comment.dto.CommentWriteRequest;
 import com.board.domain.comment.entity.Comment;
@@ -20,9 +21,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -65,6 +70,29 @@ class CommentServiceTest {
                 .content("content")
                 .member(member)
                 .build();
+    }
+
+    @DisplayName("댓글 목록을 조회한다.")
+    @Test
+    void commentList() {
+        List<Comment> content = List.of(
+                Comment.builder().writer("writer").content("comment").build()
+        );
+        PageImpl<Comment> commentPage = new PageImpl<>(content);
+
+        given(commentRepository.findAllByPostId(anyLong(), any(Pageable.class))).willReturn(commentPage);
+
+        CommentListResponse commentListResponse = commentService.commentList(1L, 1);
+
+        assertThat(commentListResponse.getComments().size()).isEqualTo(1);
+        assertThat(commentListResponse.getPage()).isEqualTo(1);
+        assertThat(commentListResponse.getTotalComments()).isEqualTo(1);
+        assertThat(commentListResponse.getTotalPages()).isEqualTo(1);
+        assertThat(commentListResponse.isFirst()).isTrue();
+        assertThat(commentListResponse.isLast()).isTrue();
+        assertThat(commentListResponse.isPrev()).isFalse();
+        assertThat(commentListResponse.isNext()).isFalse();
+        then(commentRepository).should().findAllByPostId(anyLong(), any(Pageable.class));
     }
 
     @DisplayName("댓글을 작성한다.")


### PR DESCRIPTION
# 작업 내용

- 특정 게시글에 속한 댓글 목록조회 기능 추가
  - 댓글 목록조회 요청 권한은 전부 허용으로 설정
- 댓글 목록조회 기능 테스트 추가
- API 문서에 댓글 목록조회 API 내용 추가 

### 관련 이슈

- close #29