### PR TITLE
회원가입 api 구현

### DIFF
--- a/backend/src/main/java/com/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/backend/domain/member/controller/MemberController.java
@@ -1,0 +1,31 @@
+package com.backend.domain.member.controller;
+
+import com.backend.domain.member.dto.MemberSignupRequest;
+import com.backend.domain.member.service.MemberService;
+
+import jakarta.validation.Valid;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PreAuthorize("permitAll()")
+    @PostMapping("/signup")
+    public ResponseEntity<Void> memberSignup(@RequestBody @Valid MemberSignupRequest memberSignupRequest) {
+        memberService.memberSignup(memberSignupRequest);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/backend/src/main/java/com/backend/domain/member/dto/MemberSignupRequest.java
+++ b/backend/src/main/java/com/backend/domain/member/dto/MemberSignupRequest.java
@@ -1,0 +1,23 @@
+package com.backend.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberSignupRequest {
+
+    @NotBlank(message = "닉네임을 입력해 주세요.")
+    private String nickname;
+
+    @NotBlank(message = "아이디를 입력해 주세요.")
+    private String username;
+
+    @NotBlank(message = "비밀번호를 입력해 주세요.")
+    private String password;
+
+}

--- a/backend/src/main/java/com/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/backend/domain/member/entity/Member.java
@@ -1,0 +1,46 @@
+package com.backend.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Builder
+    public Member(String nickname, String username, String password) {
+        this.nickname = nickname;
+        this.username = username;
+        this.password = password;
+        this.role = Role.MEMBER;
+    }
+
+}

--- a/backend/src/main/java/com/backend/domain/member/entity/Role.java
+++ b/backend/src/main/java/com/backend/domain/member/entity/Role.java
@@ -1,0 +1,16 @@
+package com.backend.domain.member.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Role {
+
+    MEMBER("ROLE_MEMBER");
+
+    private final String authority;
+
+    Role(String authority) {
+        this.authority = authority;
+    }
+
+}

--- a/backend/src/main/java/com/backend/domain/member/exception/DuplicateNicknameException.java
+++ b/backend/src/main/java/com/backend/domain/member/exception/DuplicateNicknameException.java
@@ -1,0 +1,12 @@
+package com.backend.domain.member.exception;
+
+import com.backend.global.error.exception.BoardException;
+import com.backend.global.error.exception.ErrorType;
+
+public class DuplicateNicknameException extends BoardException {
+
+    public DuplicateNicknameException() {
+        super(ErrorType.DUPLICATE_NICKNAME);
+    }
+
+}

--- a/backend/src/main/java/com/backend/domain/member/exception/DuplicateUsernameException.java
+++ b/backend/src/main/java/com/backend/domain/member/exception/DuplicateUsernameException.java
@@ -1,0 +1,12 @@
+package com.backend.domain.member.exception;
+
+import com.backend.global.error.exception.BoardException;
+import com.backend.global.error.exception.ErrorType;
+
+public class DuplicateUsernameException extends BoardException {
+
+    public DuplicateUsernameException() {
+        super(ErrorType.DUPLICATE_USERNAME);
+    }
+
+}

--- a/backend/src/main/java/com/backend/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/backend/domain/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.backend.domain.member.repository;
+
+import com.backend.domain.member.entity.Member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    boolean existsByNickname(String nickname);
+    boolean existsByUsername(String username);
+
+}

--- a/backend/src/main/java/com/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/backend/domain/member/service/MemberService.java
@@ -1,0 +1,39 @@
+package com.backend.domain.member.service;
+
+import com.backend.domain.member.dto.MemberSignupRequest;
+import com.backend.domain.member.entity.Member;
+import com.backend.domain.member.exception.DuplicateNicknameException;
+import com.backend.domain.member.exception.DuplicateUsernameException;
+import com.backend.domain.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void memberSignup(MemberSignupRequest memberSignupRequest) {
+        if (memberRepository.existsByNickname(memberSignupRequest.getNickname())) {
+            throw new DuplicateNicknameException();
+        }
+        if (memberRepository.existsByUsername(memberSignupRequest.getUsername())) {
+            throw new DuplicateUsernameException();
+        }
+        String encodedPassword = passwordEncoder.encode(memberSignupRequest.getPassword());
+        Member member = Member.builder()
+                .nickname(memberSignupRequest.getNickname())
+                .username(memberSignupRequest.getUsername())
+                .password(encodedPassword)
+                .build();
+        memberRepository.save(member);
+    }
+
+}

--- a/backend/src/main/java/com/backend/global/common/config/JpaAuditingConfig.java
+++ b/backend/src/main/java/com/backend/global/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.backend.global.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/backend/src/main/java/com/backend/global/common/entity/BaseEntity.java
+++ b/backend/src/main/java/com/backend/global/common/entity/BaseEntity.java
@@ -1,0 +1,28 @@
+package com.backend.global.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+
+import lombok.Getter;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/backend/src/main/java/com/backend/global/error/exception/ErrorType.java
+++ b/backend/src/main/java/com/backend/global/error/exception/ErrorType.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorType {
 
-    ;
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "E400001", "입력값이 잘못되었습니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "E409001", "사용 중인 닉네임입니다."),
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "E409002", "사용 중인 아이디입니다.");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/backend/src/main/java/com/backend/global/error/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/backend/global/error/handler/GlobalExceptionHandler.java
@@ -3,25 +3,61 @@ package com.backend.global.error.handler;
 import com.backend.global.error.exception.BoardException;
 import com.backend.global.error.exception.ErrorType;
 
+import lombok.Getter;
+
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(BoardException.class)
     public ResponseEntity<ProblemDetail> handleBoardException(BoardException ex) {
-        ErrorType errorType = ex.getErrorType();
+        ProblemDetail problemDetail = createProblemDetail(ex.getErrorType());
+        return ResponseEntity.of(problemDetail).build();
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ProblemDetail> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        ProblemDetail problemDetail = createProblemDetail(ErrorType.INVALID_INPUT);
+        problemDetail.setProperty("errors", Field.errors(ex.getFieldErrors()));
+        return ResponseEntity.of(problemDetail).build();
+    }
+
+    private ProblemDetail createProblemDetail(ErrorType errorType) {
         ProblemDetail problemDetail = ProblemDetail.forStatus(errorType.getStatus());
         problemDetail.setType(URI.create(""));
         problemDetail.setTitle(errorType.getMessage());
         problemDetail.setDetail("");
         problemDetail.setProperty("error_code", errorType.getErrorCode());
-        return ResponseEntity.of(problemDetail).build();
+        return problemDetail;
+    }
+
+    @Getter
+    private static class Field {
+
+        private String field;
+        private String message;
+
+        private Field(FieldError fieldError) {
+            this.field = fieldError.getField();
+            this.message = fieldError.getDefaultMessage();
+        }
+
+        public static List<Field> errors(List<FieldError> fieldErrors) {
+            return fieldErrors.stream()
+                    .map(Field::new)
+                    .collect(Collectors.toList());
+        }
+
     }
 
 }

--- a/backend/src/main/java/com/backend/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/backend/global/security/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.backend.global.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@EnableMethodSecurity
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST,
+                                "/api/members/signup").permitAll()
+                );
+        return httpSecurity.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/backend/src/test/java/com/backend/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/backend/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,136 @@
+package com.backend.domain.member.controller;
+
+import com.backend.domain.member.dto.MemberSignupRequest;
+import com.backend.domain.member.exception.DuplicateNicknameException;
+import com.backend.domain.member.exception.DuplicateUsernameException;
+import com.backend.domain.member.service.MemberService;
+
+import com.backend.global.security.config.SecurityConfig;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willDoNothing;
+
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = MemberController.class)
+@Import(SecurityConfig.class)
+class MemberControllerTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MemberService memberService;
+
+    @DisplayName("회원가입에 성공하면 200을 응답한다.")
+    @Test
+    void memberSignup() throws Exception {
+        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonkun", "yoon1234", "12345678");
+
+        willDoNothing().given(memberService).memberSignup(any(MemberSignupRequest.class));
+
+        mockMvc.perform(post("/api/members/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberSignupRequest))
+                )
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @DisplayName("회원가입 시 입력값이 유효하지 않으면 400을 응답한다.")
+    @ParameterizedTest
+    @MethodSource("invalidInputMemberSignupRequest")
+    void memberSignupInvalidInput(MemberSignupRequest memberSignupRequest) throws Exception {
+        mockMvc.perform(post("/api/members/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberSignupRequest))
+                )
+                .andExpectAll(
+                        status().isBadRequest(),
+                        jsonPath("$.title").value("입력값이 잘못되었습니다."),
+                        jsonPath("$.status").value(400),
+                        jsonPath("$.instance").value("/api/members/signup"),
+                        jsonPath("$.error_code").value("E400001"),
+                        jsonPath("$.errors").isArray(),
+                        jsonPath("$.errors[0].field").isNotEmpty(),
+                        jsonPath("$.errors[0].message").isNotEmpty()
+                )
+                .andDo(print());
+    }
+
+    private static Stream<Object> invalidInputMemberSignupRequest() {
+        return Stream.of(
+                Arguments.of(Named.of("닉네임 공백", new MemberSignupRequest("", "yoon1234", "12345678"))),
+                Arguments.of(Named.of("아이디 공백", new MemberSignupRequest("yoonkun", "", "12345678"))),
+                Arguments.of(Named.of("비밀번호 공백", new MemberSignupRequest("yoonkun", "yoon1234", "")))
+        );
+    }
+
+    @DisplayName("회원가입 시 닉네임이 중복되면 409를 응답한다.")
+    @Test
+    void memberSignupDuplicateNickname() throws Exception {
+        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonkun", "yoon1234", "12345678");
+
+        willThrow(new DuplicateNicknameException()).given(memberService).memberSignup(any(MemberSignupRequest.class));
+
+        mockMvc.perform(post("/api/members/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberSignupRequest))
+                )
+                .andExpectAll(
+                        status().isConflict(),
+                        jsonPath("$.title").value("사용 중인 닉네임입니다."),
+                        jsonPath("$.status").value(409),
+                        jsonPath("$.instance").value("/api/members/signup"),
+                        jsonPath("$.error_code").value("E409001")
+                )
+                .andDo(print());
+    }
+
+    @DisplayName("회원가입 시 아이디가 중복되면 409를 응답한다.")
+    @Test
+    void memberSignupDuplicateUsername() throws Exception {
+        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonkun", "yoon1234", "12345678");
+
+        willThrow(new DuplicateUsernameException()).given(memberService).memberSignup(any(MemberSignupRequest.class));
+
+        mockMvc.perform(post("/api/members/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberSignupRequest))
+                )
+                .andExpectAll(
+                        status().isConflict(),
+                        jsonPath("$.title").value("사용 중인 아이디입니다."),
+                        jsonPath("$.status").value(409),
+                        jsonPath("$.instance").value("/api/members/signup"),
+                        jsonPath("$.error_code").value("E409002")
+                )
+                .andDo(print());
+    }
+
+}

--- a/backend/src/test/java/com/backend/domain/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/backend/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,145 @@
+package com.backend.domain.member.repository;
+
+import com.backend.domain.member.entity.Member;
+import com.backend.global.common.config.JpaAuditingConfig;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("회원을 저장한다.")
+    @Test
+    void memberSave() {
+        Member member = Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .password("12345678")
+                .build();
+
+        Member saveMember = memberRepository.save(member);
+
+        assertThat(saveMember.getId()).isNotNull();
+    }
+
+    @DisplayName("회원 저장 시 필드가 null이면 예외가 발생한다.")
+    @ParameterizedTest
+    @MethodSource("nullFieldsMember")
+    void memberSaveNullFields(Member member) {
+        assertThatThrownBy(() -> memberRepository.save(member))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    private static Stream<Object> nullFieldsMember() {
+        return Stream.of(
+                Arguments.of(Named.of("nickname 필드 null", new Member(null, "yoon1234", "12345678"))),
+                Arguments.of(Named.of("username 필드 null", new Member("yoonkun", null, "12345678"))),
+                Arguments.of(Named.of("password 필드 null", new Member("yoonkun", "yoon1234", null)))
+        );
+    }
+
+    @DisplayName("동일한 닉네임을 가진 회원을 저장하면 예외가 발생한다.")
+    @Test
+    void memberSaveUniqueNickname() {
+        Member memberA = Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .password("12345678")
+                .build();
+        Member memberB = Member.builder()
+                .nickname("yoonkun")
+                .username("yoon5678")
+                .password("12345678")
+                .build();
+        memberRepository.save(memberA);
+
+        assertThatThrownBy(() -> memberRepository.save(memberB))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @DisplayName("동일한 아이디를 가진 회원을 저장하면 예외가 발생한다.")
+    @Test
+    void memberSaveUniqueUsername() {
+        Member memberA = Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .password("12345678")
+                .build();
+        Member memberB = Member.builder()
+                .nickname("yoonyoon")
+                .username("yoon1234")
+                .password("12345678")
+                .build();
+
+        memberRepository.save(memberA);
+
+        assertThatThrownBy(() -> memberRepository.save(memberB))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @DisplayName("동일한 닉네임이 존재하면 true를 반환한다.")
+    @Test
+    void memberExistsByNickname() {
+        Member member = Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .password("12345678")
+                .build();
+        memberRepository.save(member);
+
+        boolean exists = memberRepository.existsByNickname("yoonkun");
+
+        assertThat(exists).isTrue();
+    }
+
+    @DisplayName("동일한 닉네임이 존재하지 않으면 flase를 반환한다.")
+    @Test
+    void memberNotExistsByNickname() {
+        boolean exists = memberRepository.existsByNickname("yoonkun");
+
+        assertThat(exists).isFalse();
+    }
+
+    @DisplayName("동일한 아이디가 존재하면 true를 반환한다.")
+    @Test
+    void memberExistsByUsername() {
+        Member member = Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .password("12345678")
+                .build();
+        memberRepository.save(member);
+
+        boolean exists = memberRepository.existsByUsername("yoon1234");
+
+        assertThat(exists).isTrue();
+    }
+
+    @DisplayName("동일한 아이디가 존재하지 않으면 flase를 반환한다.")
+    @Test
+    void memberNotExistsByUsername() {
+        boolean exists = memberRepository.existsByUsername("yoon1234");
+
+        assertThat(exists).isFalse();
+    }
+
+}

--- a/backend/src/test/java/com/backend/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/backend/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,96 @@
+package com.backend.domain.member.service;
+
+import com.backend.domain.member.dto.MemberSignupRequest;
+import com.backend.domain.member.entity.Member;
+import com.backend.domain.member.exception.DuplicateNicknameException;
+import com.backend.domain.member.exception.DuplicateUsernameException;
+import com.backend.domain.member.repository.MemberRepository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @DisplayName("회원가입을 한다.")
+    @Test
+    void memberSignup() {
+        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonkun", "yoon1234", "12345678");
+        String encodedPassword = new BCryptPasswordEncoder().encode(memberSignupRequest.getPassword());
+        Member member = Member.builder()
+                .nickname(memberSignupRequest.getNickname())
+                .username(memberSignupRequest.getUsername())
+                .password(encodedPassword)
+                .build();
+
+        given(memberRepository.existsByNickname(anyString())).willReturn(false);
+        given(memberRepository.existsByUsername(anyString())).willReturn(false);
+        given(passwordEncoder.encode(anyString())).willReturn(encodedPassword);
+        given(memberRepository.save(any(Member.class))).willReturn(member);
+
+        memberService.memberSignup(memberSignupRequest);
+
+        then(memberRepository).should().existsByNickname(anyString());
+        then(memberRepository).should().existsByUsername(anyString());
+        then(passwordEncoder).should().encode(anyString());
+        then((memberRepository)).should().save(any(Member.class));
+    }
+
+    @DisplayName("회원가입 시 닉네임이 중복되면 예외가 발생한다.")
+    @Test
+    void memberSignupDuplicateNickname() {
+        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonkun", "yoon1234", "12345678");
+
+        given(memberRepository.existsByNickname(anyString())).willReturn(true);
+
+        assertThatThrownBy(() -> memberService.memberSignup(memberSignupRequest))
+                .isInstanceOf(DuplicateNicknameException.class);
+
+        then(memberRepository).should().existsByNickname(anyString());
+        then(memberRepository).should(never()).existsByUsername(anyString());
+        then(passwordEncoder).should(never()).encode(anyString());
+        then((memberRepository)).should(never()).save(any(Member.class));
+    }
+
+    @DisplayName("회원가입 시 아이디가 중복되면 예외가 발생한다.")
+    @Test
+    void memberSignupDuplicateUsername() {
+        MemberSignupRequest memberSignupRequest = new MemberSignupRequest("yoonkun", "yoon1234", "12345678");
+
+        given(memberRepository.existsByNickname(anyString())).willReturn(false);
+        given(memberRepository.existsByUsername(anyString())).willReturn(true);
+
+        assertThatThrownBy(() -> memberService.memberSignup(memberSignupRequest))
+                .isInstanceOf(DuplicateUsernameException.class);
+
+        then(memberRepository).should().existsByNickname(anyString());
+        then(memberRepository).should().existsByUsername(anyString());
+        then(passwordEncoder).should(never()).encode(anyString());
+        then((memberRepository)).should(never()).save(any(Member.class));
+    }
+
+}


### PR DESCRIPTION
## 작업 내용

- 회원가입 기능 추가
  - 닉네임/아이디 중복 추가
- 회원가입 기능 테스트 추가
- 시큐리티 설정 추가
  - 회원가입 요청 권한 전부 허용으로 설정
- 입력값 예외 처리 핸들러 구현

## 관련 이슈

- close #3
- close #6 

## 참고 사항