### PR TITLE
커스텀 예외 응답 구현

### DIFF
--- a/backend/src/main/java/com/backend/global/error/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/backend/global/error/dto/ErrorResponse.java
@@ -1,0 +1,62 @@
+package com.backend.global.error.dto;
+
+import com.backend.global.error.exception.ErrorType;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Getter;
+
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class ErrorResponse {
+
+    private int status;
+    private String errorCode;
+    private String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<Field> errors;
+
+    private ErrorResponse(ErrorType errorType) {
+        this.status = errorType.getStatus().value();
+        this.errorCode = errorType.getErrorCode();
+        this.message = errorType.getMessage();
+    }
+
+    private ErrorResponse(ErrorType errorType, List<FieldError> fieldErrors) {
+        this(errorType);
+        this.errors = Field.errors(fieldErrors);
+    }
+
+    public static ErrorResponse of(ErrorType errorType) {
+        return new ErrorResponse(errorType);
+    }
+
+    public static ErrorResponse of(ErrorType errorType, List<FieldError> fieldErrors) {
+        return new ErrorResponse(errorType, fieldErrors);
+    }
+
+    @Getter
+    private static class Field {
+
+        private String field;
+        private String message;
+
+        private Field(FieldError fieldError) {
+            this.field = fieldError.getField();
+            this.message = fieldError.getDefaultMessage();
+        }
+
+        private static List<Field> errors(List<FieldError> fieldErrors) {
+            return fieldErrors.stream()
+                    .map(Field::new)
+                    .collect(Collectors.toList());
+        }
+
+    }
+
+}

--- a/backend/src/main/java/com/backend/global/error/exception/ErrorType.java
+++ b/backend/src/main/java/com/backend/global/error/exception/ErrorType.java
@@ -9,14 +9,23 @@ import java.util.Arrays;
 @Getter
 public enum ErrorType {
 
+    // 500
     UN_SUPPORT_ERROR_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "E000000", "지원하지 않는 예외 유형입니다."),
-    INVALID_INPUT(HttpStatus.BAD_REQUEST, "E400001", "입력값이 잘못되었습니다."),
-    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "E409001", "사용 중인 닉네임입니다."),
-    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "E409002", "사용 중인 아이디입니다."),
+
+    // 400
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "E400001", "입력값이 잘못 되었습니다."),
+
+    // 401
     BAD_CREDENTIALS(HttpStatus.UNAUTHORIZED, "E401001", "아이디 또는 비밀번호가 잘못 되었습니다."),
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "E401002", "토큰이 만료되었습니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "E401002", "토큰이 만료 되었습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "E401003", "토큰 형식이 잘못 되었습니다."),
-    NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND," E404001", "토큰을 찾을 수 없습니다.");
+
+    // 404
+    NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND, " E404001", "토큰을 찾을 수 없습니다."),
+
+    // 409
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "E409001", "사용 중인 닉네임입니다."),
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "E409002", "사용 중인 아이디입니다.");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/backend/src/main/java/com/backend/global/error/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/backend/global/error/handler/GlobalExceptionHandler.java
@@ -1,63 +1,28 @@
 package com.backend.global.error.handler;
 
+import com.backend.global.error.dto.ErrorResponse;
 import com.backend.global.error.exception.BoardException;
 import com.backend.global.error.exception.ErrorType;
 
-import lombok.Getter;
-
-import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.net.URI;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(BoardException.class)
-    public ResponseEntity<ProblemDetail> handleBoardException(BoardException ex) {
-        ProblemDetail problemDetail = createProblemDetail(ex.getErrorType());
-        return ResponseEntity.of(problemDetail).build();
+    public ResponseEntity<ErrorResponse> handleBoardException(BoardException ex) {
+        ErrorType errorType = ex.getErrorType();
+        ErrorResponse errorResponse = ErrorResponse.of(errorType);
+        return ResponseEntity.status(errorType.getStatus()).body(errorResponse);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ProblemDetail> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
-        ProblemDetail problemDetail = createProblemDetail(ErrorType.INVALID_INPUT);
-        problemDetail.setProperty("errors", Field.errors(ex.getFieldErrors()));
-        return ResponseEntity.of(problemDetail).build();
-    }
-
-    private ProblemDetail createProblemDetail(ErrorType errorType) {
-        ProblemDetail problemDetail = ProblemDetail.forStatus(errorType.getStatus());
-        problemDetail.setType(URI.create(""));
-        problemDetail.setTitle(errorType.getMessage());
-        problemDetail.setDetail("");
-        problemDetail.setProperty("error_code", errorType.getErrorCode());
-        return problemDetail;
-    }
-
-    @Getter
-    private static class Field {
-
-        private String field;
-        private String message;
-
-        private Field(FieldError fieldError) {
-            this.field = fieldError.getField();
-            this.message = fieldError.getDefaultMessage();
-        }
-
-        public static List<Field> errors(List<FieldError> fieldErrors) {
-            return fieldErrors.stream()
-                    .map(Field::new)
-                    .collect(Collectors.toList());
-        }
-
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorType.INVALID_INPUT, ex.getFieldErrors());
+        return ResponseEntity.badRequest().body(errorResponse);
     }
 
 }

--- a/backend/src/main/java/com/backend/global/security/handler/AuthenticationExceptionHandler.java
+++ b/backend/src/main/java/com/backend/global/security/handler/AuthenticationExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.backend.global.security.handler;
 
+import com.backend.global.error.dto.ErrorResponse;
 import com.backend.global.error.exception.ErrorType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -8,7 +9,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.http.MediaType;
-import org.springframework.http.ProblemDetail;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
@@ -26,9 +26,8 @@ public class AuthenticationExceptionHandler implements AuthenticationEntryPoint 
         ErrorType errorType = ErrorType.of(errorCode);
         response.setStatus(errorType.getStatus().value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        ProblemDetail problemDetail = ProblemDetail.forStatus(errorType.getStatus());
-        problemDetail.setProperty("error_code", errorType.getErrorCode());
-        objectMapper.writeValue(response.getOutputStream(), problemDetail);
+        ErrorResponse errorResponse = ErrorResponse.of(errorType);
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
     }
 
 }

--- a/backend/src/test/java/com/backend/domain/auth/util/JwtUtilTest.java
+++ b/backend/src/test/java/com/backend/domain/auth/util/JwtUtilTest.java
@@ -2,19 +2,32 @@ package com.backend.domain.auth.util;
 
 import com.backend.domain.member.entity.Member;
 
+import com.backend.global.error.exception.ErrorType;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.AuthenticationServiceException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 class JwtUtilTest {
 
     @Autowired
     private JwtUtil jwtUtil;
+
+    @Value("${jwt.secret-key}")
+    private String secretKey;
 
     @DisplayName("access token을 생성한다.")
     @Test
@@ -36,6 +49,46 @@ class JwtUtilTest {
         String refreshToken = jwtUtil.createRefreshToken();
 
         assertThat(refreshToken).isNotNull();
+    }
+
+    @DisplayName("access token에서 claims을 추출한다.")
+    @Test
+    void extractClaims() {
+        Member member = Member.builder()
+                .nickname("yoonkun")
+                .username("yoon1234")
+                .password("12345678")
+                .build();
+        String accesStoken = jwtUtil.createAccesStoken(member);
+
+        Claims claims = jwtUtil.extractClaims(accesStoken);
+
+        assertThat(claims.get("username", String.class)).isEqualTo("yoon1234");
+        assertThat(claims.get("authority", String.class)).isEqualTo("ROLE_MEMBER");
+    }
+
+    @DisplayName("토큰이 만료되면 예외가 발생한다.")
+    @Test
+    void expiredToken() {
+        Date iat = new Date();
+        Date exp = new Date(iat.getTime() - 1);
+        String expiredToken = Jwts.builder()
+                .issuedAt(iat)
+                .expiration(exp)
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)), Jwts.SIG.HS256)
+                .compact();
+
+        assertThatThrownBy(() -> jwtUtil.validateToken(expiredToken))
+                .isInstanceOf(AuthenticationServiceException.class)
+                .hasMessage(ErrorType.EXPIRED_TOKEN.getErrorCode());
+    }
+
+    @DisplayName("토큰 형식이 잘못되면 예외가 발생한다.")
+    @Test
+    void invalidToken() {
+        assertThatThrownBy(() -> jwtUtil.validateToken("wrong-token"))
+                .isInstanceOf(AuthenticationServiceException.class)
+                .hasMessage(ErrorType.INVALID_TOKEN.getErrorCode());
     }
 
 }

--- a/backend/src/test/java/com/backend/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/backend/domain/member/controller/MemberControllerTest.java
@@ -1,5 +1,6 @@
 package com.backend.domain.member.controller;
 
+import com.backend.domain.auth.service.TokenService;
 import com.backend.domain.member.dto.MemberSignupRequest;
 import com.backend.domain.member.exception.DuplicateNicknameException;
 import com.backend.domain.member.exception.DuplicateUsernameException;
@@ -12,10 +13,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
-
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -27,8 +28,8 @@ import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willDoNothing;
-
 import static org.mockito.BDDMockito.willThrow;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -43,6 +44,9 @@ class MemberControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockitoBean
+    private TokenService tokenService;
 
     @MockitoBean
     private MemberService memberService;
@@ -72,10 +76,9 @@ class MemberControllerTest {
                 )
                 .andExpectAll(
                         status().isBadRequest(),
-                        jsonPath("$.title").value("입력값이 잘못되었습니다."),
                         jsonPath("$.status").value(400),
-                        jsonPath("$.instance").value("/api/members/signup"),
-                        jsonPath("$.error_code").value("E400001"),
+                        jsonPath("$.errorCode").value("E400001"),
+                        jsonPath("$.message").value("입력값이 잘못 되었습니다."),
                         jsonPath("$.errors").isArray(),
                         jsonPath("$.errors[0].field").isNotEmpty(),
                         jsonPath("$.errors[0].message").isNotEmpty()
@@ -104,10 +107,9 @@ class MemberControllerTest {
                 )
                 .andExpectAll(
                         status().isConflict(),
-                        jsonPath("$.title").value("사용 중인 닉네임입니다."),
                         jsonPath("$.status").value(409),
-                        jsonPath("$.instance").value("/api/members/signup"),
-                        jsonPath("$.error_code").value("E409001")
+                        jsonPath("$.errorCode").value("E409001"),
+                        jsonPath("$.message").value("사용 중인 닉네임입니다.")
                 )
                 .andDo(print());
     }
@@ -125,10 +127,9 @@ class MemberControllerTest {
                 )
                 .andExpectAll(
                         status().isConflict(),
-                        jsonPath("$.title").value("사용 중인 아이디입니다."),
                         jsonPath("$.status").value(409),
-                        jsonPath("$.instance").value("/api/members/signup"),
-                        jsonPath("$.error_code").value("E409002")
+                        jsonPath("$.errorCode").value("E409002"),
+                        jsonPath("$.message").value("사용 중인 아이디입니다.")
                 )
                 .andDo(print());
     }


### PR DESCRIPTION
## 작업 내용

- 커스텀 예외 응답 클래스 추가
- 예외 처리 핸들러 응답 형식을 커스텀 예외 응답 클래스로 수정
- 컨트롤러 테스트 예외 테스트 케이스의 예외 응답 검증 수정
- 토큰 추출 및 검증 테스트 추가

## 관련 이슈

- close #15

## 참고 사항