### PR TITLE
게시글 상세조회 api 구현

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -40,3 +40,15 @@ include::{snippets}/member-logout/request-headers.adoc[]
 include::{snippets}/post-write/http-request.adoc[]
 include::{snippets}/post-write/request-headers.adoc[]
 include::{snippets}/post-write/request-fields.adoc[]
+
+== 게시글 상세조회
+
+*요청*
+
+include::{snippets}/post-detail/http-request.adoc[]
+include::{snippets}/post-detail/path-parameters.adoc[]
+
+*응답*
+
+include::{snippets}/post-detail/http-response.adoc[]
+include::{snippets}/post-detail/response-fields.adoc[]

--- a/backend/src/main/java/com/backend/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/backend/domain/post/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.backend.domain.post.controller;
 
+import com.backend.domain.post.dto.PostDetailResponse;
 import com.backend.domain.post.dto.PostWriteRequest;
 import com.backend.domain.post.service.PostService;
 
@@ -10,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,6 +31,13 @@ public class PostController {
                                           @AuthenticationPrincipal String username) {
         postService.postWrite(postWriteRequest, username);
         return ResponseEntity.ok().build();
+    }
+
+    @PreAuthorize("permitAll()")
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostDetailResponse> postDetail(@PathVariable("postId") Long postId) {
+        PostDetailResponse postDetailResponse = postService.postDetail(postId);
+        return ResponseEntity.ok().body(postDetailResponse);
     }
 
 }

--- a/backend/src/main/java/com/backend/domain/post/dto/PostDetailResponse.java
+++ b/backend/src/main/java/com/backend/domain/post/dto/PostDetailResponse.java
@@ -1,0 +1,30 @@
+package com.backend.domain.post.dto;
+
+import com.backend.domain.post.entity.Post;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostDetailResponse {
+
+    private Long postId;
+    private String title;
+    private String writer;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public PostDetailResponse(Post post) {
+        this.postId = post.getId();
+        this.title = post.getTitle();
+        this.writer = post.getWriter();
+        this.content = post.getContent();
+        this.createdAt = post.getCreatedAt();
+    }
+
+}

--- a/backend/src/main/java/com/backend/domain/post/exception/NotFoundPostException.java
+++ b/backend/src/main/java/com/backend/domain/post/exception/NotFoundPostException.java
@@ -1,0 +1,12 @@
+package com.backend.domain.post.exception;
+
+import com.backend.global.error.exception.BoardException;
+import com.backend.global.error.exception.ErrorType;
+
+public class NotFoundPostException extends BoardException {
+
+    public NotFoundPostException() {
+        super(ErrorType.NOT_FOUND_POST);
+    }
+
+}

--- a/backend/src/main/java/com/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/backend/domain/post/service/PostService.java
@@ -3,8 +3,10 @@ package com.backend.domain.post.service;
 import com.backend.domain.member.entity.Member;
 import com.backend.domain.member.exception.NotFoundMemberException;
 import com.backend.domain.member.repository.MemberRepository;
+import com.backend.domain.post.dto.PostDetailResponse;
 import com.backend.domain.post.dto.PostWriteRequest;
 import com.backend.domain.post.entity.Post;
+import com.backend.domain.post.exception.NotFoundPostException;
 import com.backend.domain.post.repository.PostRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -30,6 +32,13 @@ public class PostService {
                 .member(member)
                 .build();
         postRepository.save(post);
+    }
+
+    @Transactional(readOnly = true)
+    public PostDetailResponse postDetail(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(NotFoundPostException::new);
+        return new PostDetailResponse(post);
     }
 
 }

--- a/backend/src/main/java/com/backend/global/error/exception/ErrorType.java
+++ b/backend/src/main/java/com/backend/global/error/exception/ErrorType.java
@@ -22,7 +22,8 @@ public enum ErrorType {
 
     // 404
     NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND, " E404001", "토큰이 존재하지 않습니다."),
-    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "E404001", "회원이 존재하지 않습니다."),
+    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "E404002", "회원이 존재하지 않습니다."),
+    NOT_FOUND_POST(HttpStatus.NOT_FOUND, "E404003", "게시글이 존재하지 않습니다."),
 
     // 409
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "E409001", "사용 중인 닉네임입니다."),

--- a/backend/src/main/java/com/backend/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/backend/global/security/config/SecurityConfig.java
@@ -42,7 +42,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/members/signup",
-                                "/api/auth/login").permitAll()
+                                "/api/auth/login",
+                                "/api/posts/*").permitAll()
                         .requestMatchers(
                                 "/api/auth/logout",
                                 "/api/posts/write").hasRole("MEMBER")

--- a/backend/src/main/java/com/backend/global/security/filter/AuthenticationFilter.java
+++ b/backend/src/main/java/com/backend/global/security/filter/AuthenticationFilter.java
@@ -65,7 +65,8 @@ public class AuthenticationFilter extends OncePerRequestFilter {
         MEMBER_SIGNUP(HttpMethod.POST, "/api/members/signup", Authority.PERMIT_ALL),
         MEMBER_LOGIN(HttpMethod.POST, "/api/auth/login", Authority.PERMIT_ALL),
         MEMBER_LOGOUT(HttpMethod.POST, "/api/auth/logout", Authority.ROLE_MEMBER),
-        POST_WRITE(HttpMethod.POST, "/api/posts/write", Authority.ROLE_MEMBER);
+        POST_WRITE(HttpMethod.POST, "/api/posts/write", Authority.ROLE_MEMBER),
+        POST_DETAIL(HttpMethod.GET, "/api/posts/*", Authority.PERMIT_ALL);
 
         enum Authority {
             PERMIT_ALL, ROLE_MEMBER

--- a/backend/src/main/resources/static/docs/index.html
+++ b/backend/src/main/resources/static/docs/index.html
@@ -454,6 +454,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_로그인">로그인</a></li>
 <li><a href="#_로그아웃">로그아웃</a></li>
 <li><a href="#_게시글_작성">게시글 작성</a></li>
+<li><a href="#_게시글_상세조회">게시글 상세조회</a></li>
 </ul>
 </div>
 </div>
@@ -691,11 +692,101 @@ Authorization: Bearer access-token
 </table>
 </div>
 </div>
+<div class="sect1">
+<h2 id="_게시글_상세조회">게시글 상세조회</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>요청</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/posts/1 HTTP/1.1</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/posts/{postId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 번호</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><strong>응답</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "postId" : 1,
+  "title" : "title",
+  "writer" : "writer",
+  "content" : "content",
+  "createdAt" : "2025-03-02T22:16:52.190148"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>writer</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성일</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1<br>
-Last updated 2025-03-02 14:40:49 +0900
+Last updated 2025-03-02 22:16:44 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/test/java/com/backend/domain/post/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/com/backend/domain/post/repository/PostRepositoryTest.java
@@ -18,6 +18,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -74,6 +75,25 @@ class PostRepositoryTest {
                 Arguments.of(Named.of("content 필드 null", new Post("title", "writer", null, member))),
                 Arguments.of(Named.of("member 필드 null", new Post("title", "writer", "content", null)))
         );
+    }
+
+    @DisplayName("기본키로 게시글을 조회한다.")
+    @Test
+    void postFindById() {
+        Post post = Post.builder()
+                .title("title")
+                .writer(member.getNickname())
+                .content("content")
+                .member(member)
+                .build();
+        Post savePost = postRepository.save(post);
+
+        Optional<Post> findPost = postRepository.findById(savePost.getId());
+
+        assertThat(findPost).isNotEmpty();
+        assertThat(findPost.get().getTitle()).isEqualTo("title");
+        assertThat(findPost.get().getWriter()).isEqualTo("yoonkun");
+        assertThat(findPost.get().getContent()).isEqualTo("content");
     }
 
 


### PR DESCRIPTION
## 작업 내용

- 게시글 상세조회 기능 추가
  - 게시글 상세조회 요청 권한 전부 허용 설정
- 게시글 상세조회 기능 테스트 추가
- 게시판 API 문서에 게시글 상세조회 API 내용 추가

## 관련 이슈

- close #19

## 참고 사항