### PR TITLE
댓글 목록조회 api 구현

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -82,6 +82,19 @@ include::{snippets}/post-delete/http-request.adoc[]
 include::{snippets}/post-delete/path-parameters.adoc[]
 include::{snippets}/post-delete/request-headers.adoc[]
 
+== 댓글 목록
+
+*요청*
+
+include::{snippets}/comment-list/http-request.adoc[]
+include::{snippets}/comment-list/path-parameters.adoc[]
+include::{snippets}/comment-list/query-parameters.adoc[]
+
+*응답*
+
+include::{snippets}/comment-list/http-response.adoc[]
+include::{snippets}/comment-list/response-fields.adoc[]
+
 == 댓글 작성
 
 *요청*

--- a/backend/src/main/java/com/backend/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/backend/domain/comment/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.backend.domain.comment.controller;
 
+import com.backend.domain.comment.dto.CommentListResponse;
 import com.backend.domain.comment.dto.CommentModifyRequest;
 import com.backend.domain.comment.dto.CommentWriteRequest;
 import com.backend.domain.comment.service.CommentService;
@@ -12,11 +13,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,6 +28,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController {
 
     private final CommentService commentService;
+
+    @PreAuthorize("permitAll()")
+    @GetMapping("/{postId}/comments")
+    public ResponseEntity<CommentListResponse> commentList(@PathVariable("postId") Long postId,
+                                                           @RequestParam("page") int page) {
+        CommentListResponse commentListResponse = commentService.commentList(postId, page);
+        return ResponseEntity.ok().body(commentListResponse);
+    }
 
     @PreAuthorize("hasRole('MEMBER')")
     @PostMapping("/{postId}/comments/write")

--- a/backend/src/main/java/com/backend/domain/comment/dto/CommentItem.java
+++ b/backend/src/main/java/com/backend/domain/comment/dto/CommentItem.java
@@ -1,0 +1,28 @@
+package com.backend.domain.comment.dto;
+
+import com.backend.domain.comment.entity.Comment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentItem {
+
+    private Long commentId;
+    private String writer;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public CommentItem(Comment comment) {
+        this.commentId = comment.getId();
+        this.writer = comment.getWriter();
+        this.content = comment.getContent();
+        this.createdAt = comment.getCreatedAt();
+    }
+
+}

--- a/backend/src/main/java/com/backend/domain/comment/dto/CommentListResponse.java
+++ b/backend/src/main/java/com/backend/domain/comment/dto/CommentListResponse.java
@@ -1,0 +1,41 @@
+package com.backend.domain.comment.dto;
+
+import com.backend.domain.comment.entity.Comment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentListResponse {
+
+    private List<CommentItem> comments;
+    private int page;
+    private int totalPages;
+    private long totalComments;
+    private boolean first;
+    private boolean last;
+    private boolean prev;
+    private boolean next;
+
+    public CommentListResponse(Page<Comment> commentPage) {
+        this.comments = commentPage.getContent().stream()
+                .map(CommentItem::new)
+                .collect(Collectors.toList());
+        this.page = commentPage.getNumber() + 1;
+        this.totalPages = commentPage.getTotalPages();
+        this.totalComments = commentPage.getTotalElements();
+        this.first = commentPage.isFirst();
+        this.last = commentPage.isLast();
+        this.prev = commentPage.hasPrevious();
+        this.next = commentPage.hasNext();
+    }
+
+}

--- a/backend/src/main/java/com/backend/domain/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/backend/domain/comment/repository/CommentRepository.java
@@ -2,6 +2,8 @@ package com.backend.domain.comment.repository;
 
 import com.backend.domain.comment.entity.Comment;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,5 +14,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("SELECT c FROM Comment AS c WHERE c.post.id = :postId AND c.id = :commentId")
     Optional<Comment> findByPostIdAndCommentId(@Param("postId") Long postId, @Param("commentId") Long commentId);
+
+    Page<Comment> findAllByPostId(Long postId, Pageable pageable);
 
 }

--- a/backend/src/main/java/com/backend/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/backend/domain/comment/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.backend.domain.comment.service;
 
+import com.backend.domain.comment.dto.CommentListResponse;
 import com.backend.domain.comment.dto.CommentModifyRequest;
 import com.backend.domain.comment.dto.CommentWriteRequest;
 import com.backend.domain.comment.entity.Comment;
@@ -14,6 +15,10 @@ import com.backend.domain.post.repository.PostRepository;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +29,14 @@ public class CommentService {
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
+
+    @Transactional(readOnly = true)
+    public CommentListResponse commentList(Long postId, int page) {
+        page = page <= 0 ? 0 : page - 1;
+        Pageable pageable = PageRequest.of(page, 10, Sort.Direction.ASC, "id");
+        Page<Comment> commentPage = commentRepository.findAllByPostId(postId, pageable);
+        return new CommentListResponse(commentPage);
+    }
 
     @Transactional
     public void commentWrite(Long postId, String username, CommentWriteRequest commentWriteRequest) {

--- a/backend/src/main/java/com/backend/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/backend/global/security/config/SecurityConfig.java
@@ -43,7 +43,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET,
                                 "/api/posts",
-                                "/api/posts/*").permitAll()
+                                "/api/posts/*",
+                                "/api/posts/*/comments").permitAll()
                         .requestMatchers(HttpMethod.POST,
                                 "/api/members/signup",
                                 "/api/auth/login").permitAll()

--- a/backend/src/main/java/com/backend/global/security/filter/AuthenticationFilter.java
+++ b/backend/src/main/java/com/backend/global/security/filter/AuthenticationFilter.java
@@ -67,6 +67,7 @@ public class AuthenticationFilter extends OncePerRequestFilter {
         MEMBER_LOGIN(HttpMethod.POST, "/api/auth/login", Authority.PERMIT_ALL),
         POST_DETAIL(HttpMethod.GET, "/api/posts/*", Authority.PERMIT_ALL),
         POST_LIST(HttpMethod.GET, "/api/posts", Authority.PERMIT_ALL),
+        COMMENT_LIST(HttpMethod.GET, "/api/posts/*/comments", Authority.PERMIT_ALL),
 
         // ROLE_MEMBER
         MEMBER_LOGOUT(HttpMethod.POST, "/api/auth/logout", Authority.ROLE_MEMBER),

--- a/backend/src/main/resources/static/docs/index.html
+++ b/backend/src/main/resources/static/docs/index.html
@@ -458,6 +458,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_게시글_목록조회">게시글 목록조회</a></li>
 <li><a href="#_게시글_수정">게시글 수정</a></li>
 <li><a href="#_게시글_삭제">게시글 삭제</a></li>
+<li><a href="#_댓글_목록">댓글 목록</a></li>
 <li><a href="#_댓글_작성">댓글 작성</a></li>
 <li><a href="#_댓글_수정">댓글 수정</a></li>
 <li><a href="#_댓글_삭제">댓글 삭제</a></li>
@@ -741,7 +742,7 @@ Content-Type: application/json
   "title" : "title",
   "writer" : "writer",
   "content" : "content",
-  "createdAt" : "2025-03-05T16:27:52.023399"
+  "createdAt" : "2025-03-06T15:44:45.444282"
 }</code></pre>
 </div>
 </div>
@@ -830,7 +831,7 @@ Content-Type: application/json
     "postId" : 1,
     "title" : "title",
     "writer" : "writer",
-    "createdAt" : "2025-03-05T16:27:51.994051"
+    "createdAt" : "2025-03-06T15:44:45.421486"
   } ],
   "page" : 1,
   "totalPages" : 1,
@@ -1055,6 +1056,157 @@ Authorization: Bearer access-token</code></pre>
 </div>
 </div>
 <div class="sect1">
+<h2 id="_댓글_목록">댓글 목록</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>요청</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/posts/1/comments?page=1 HTTP/1.1</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 4. /api/posts/{postId}/comments</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 번호</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 번호</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><strong>응답</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "comments" : [ {
+    "commentId" : 1,
+    "writer" : "writer",
+    "content" : "comment",
+    "createdAt" : "2025-03-06T15:44:44.448892"
+  } ],
+  "page" : 1,
+  "totalPages" : 1,
+  "totalComments" : 1,
+  "first" : true,
+  "last" : true,
+  "prev" : false,
+  "next" : false
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments[0].commentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments[0].writer</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments[0].content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments[0].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 페이지 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>totalPages</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전체 페이지 개수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>totalComments</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전체 댓글 개수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>first</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">첫번째 페이지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>last</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 페이지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>prev</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">다음 페이지 존재 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>next</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이전 페이지 존재 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect1">
 <h2 id="_댓글_작성">댓글 작성</h2>
 <div class="sectionbody">
 <div class="paragraph">
@@ -1072,7 +1224,7 @@ Authorization: Bearer access-token
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 4. /api/posts/{postId}/comments/write</caption>
+<caption class="title">Table 5. /api/posts/{postId}/comments/write</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -1149,7 +1301,7 @@ Authorization: Bearer access-token
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 5. /api/posts/{postId}/comments/{commentId}</caption>
+<caption class="title">Table 6. /api/posts/{postId}/comments/{commentId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -1225,7 +1377,7 @@ Authorization: Bearer access-token</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 6. /api/posts/{postId}/comments/{commentId}</caption>
+<caption class="title">Table 7. /api/posts/{postId}/comments/{commentId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -1271,7 +1423,7 @@ Authorization: Bearer access-token</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1<br>
-Last updated 2025-03-05 16:27:43 +0900
+Last updated 2025-03-06 15:44:31 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/test/java/com/backend/domain/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/backend/domain/comment/repository/CommentRepositoryTest.java
@@ -19,6 +19,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -121,6 +124,29 @@ class CommentRepositoryTest {
         Optional<Comment> findComment = commentRepository.findByPostIdAndCommentId(savePost.getId(), saveComment.getId());
 
         commentRepository.delete(findComment.get());
+    }
+
+    @DisplayName("게시글 기본키를 외래키로 가지고 있는 댓글 목록을 조회한다.")
+    @Test
+    void commentFindAllByPostId() {
+        Comment comment = Comment.builder()
+                .writer("yoonkun")
+                .content("comment")
+                .member(saveMember)
+                .post(savePost)
+                .build();
+        commentRepository.save(comment);
+
+        Page<Comment> commentPage = commentRepository.findAllByPostId(savePost.getId(), PageRequest.of(0, 10, Sort.Direction.ASC, "id"));
+
+        assertThat(commentPage.getContent()).isNotEmpty();
+        assertThat(commentPage.getNumber()).isEqualTo(0);
+        assertThat(commentPage.getTotalPages()).isEqualTo(1);
+        assertThat(commentPage.getTotalElements()).isEqualTo(1);
+        assertThat(commentPage.isFirst()).isTrue();
+        assertThat(commentPage.isLast()).isTrue();
+        assertThat(commentPage.hasPrevious()).isFalse();
+        assertThat(commentPage.hasNext()).isFalse();
     }
 
 }

--- a/backend/src/test/java/com/backend/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/backend/domain/comment/service/CommentServiceTest.java
@@ -1,5 +1,6 @@
 package com.backend.domain.comment.service;
 
+import com.backend.domain.comment.dto.CommentListResponse;
 import com.backend.domain.comment.dto.CommentModifyRequest;
 import com.backend.domain.comment.dto.CommentWriteRequest;
 import com.backend.domain.comment.entity.Comment;
@@ -20,9 +21,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -64,6 +69,29 @@ class CommentServiceTest {
                 .content("content")
                 .member(member)
                 .build();
+    }
+
+    @DisplayName("댓글 목록을 조회한다.")
+    @Test
+    void commentList() {
+        List<Comment> content = List.of(
+                new Comment("writer", "comment", member, post)
+        );
+        PageImpl<Comment> commentPage = new PageImpl<>(content);
+
+        given(commentRepository.findAllByPostId(anyLong(), any(Pageable.class))).willReturn(commentPage);
+
+        CommentListResponse commentListResponse = commentService.commentList(1L, 1);
+
+        assertThat(commentListResponse.getComments()).isNotEmpty();
+        assertThat(commentListResponse.getPage()).isEqualTo(1);
+        assertThat(commentListResponse.getTotalComments()).isEqualTo(1);
+        assertThat(commentListResponse.getTotalPages()).isEqualTo(1);
+        assertThat(commentListResponse.isFirst()).isTrue();
+        assertThat(commentListResponse.isLast()).isTrue();
+        assertThat(commentListResponse.isPrev()).isFalse();
+        assertThat(commentListResponse.isNext()).isFalse();
+        then(commentRepository).should().findAllByPostId(anyLong(), any(Pageable.class));
     }
 
     @DisplayName("댓글을 작성한다.")


### PR DESCRIPTION
## 작업 내용

- 댓글 목록조회 기능 추가
  - 댓글 목록조회 요청 권한 전부 허용 설정
- 댓글 목록조회 테스트 추가
- 게시판 API 문서에 댓글 목록조회 API 내용 추가

## 관련 이슈

- close #31

## 참고 사항