### PR TITLE
게시글 목록 응답에 댓글 개수 포함

### DIFF
--- a/backend/src/main/java/com/backend/domain/post/dto/PostItem.java
+++ b/backend/src/main/java/com/backend/domain/post/dto/PostItem.java
@@ -1,28 +1,28 @@
 package com.backend.domain.post.dto;
 
-import com.backend.domain.post.entity.Post;
-
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
+@ToString
 public class PostItem {
 
     private Long postId;
     private String title;
     private String writer;
     private LocalDateTime createdAt;
+    private long commentCount;
 
-    public PostItem(Post post) {
-        this.postId = post.getId();
-        this.title = post.getTitle();
-        this.writer = post.getWriter();
-        this.createdAt = post.getCreatedAt();
+    public PostItem(Long postId, String title, String writer, LocalDateTime createdAt, long commentCount) {
+        this.postId = postId;
+        this.title = title;
+        this.writer = writer;
+        this.createdAt = createdAt;
+        this.commentCount = commentCount;
     }
 
 }

--- a/backend/src/main/java/com/backend/domain/post/dto/PostListResponse.java
+++ b/backend/src/main/java/com/backend/domain/post/dto/PostListResponse.java
@@ -1,7 +1,5 @@
 package com.backend.domain.post.dto;
 
-import com.backend.domain.post.entity.Post;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +7,6 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
@@ -25,10 +22,8 @@ public class PostListResponse {
     private boolean prev;
     private boolean next;
 
-    public PostListResponse(Page<Post> postPage) {
-        this.posts = postPage.getContent().stream()
-                .map(PostItem::new)
-                .collect(Collectors.toList());
+    public PostListResponse(Page<PostItem> postPage) {
+        this.posts = postPage.getContent();
         this.page = postPage.getNumber() + 1;
         this.totalPages = postPage.getTotalPages();
         this.totalPosts = postPage.getTotalElements();

--- a/backend/src/main/java/com/backend/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/backend/domain/post/repository/PostRepository.java
@@ -1,8 +1,17 @@
 package com.backend.domain.post.repository;
 
+import com.backend.domain.post.dto.PostItem;
 import com.backend.domain.post.entity.Post;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @Query(value = "SELECT new com.backend.domain.post.dto.PostItem(p.id, p.title, p.writer, p.createdAt, COUNT(c.id)) FROM Post AS p " +
+            "LEFT JOIN Comment AS c ON p.id = c.post.id GROUP BY p.id ORDER BY p.id DESC", countQuery = "SELECT COUNT(p) FROM Post AS p")
+    Page<PostItem> findAllPosts(Pageable pageable);
+
 }

--- a/backend/src/main/java/com/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/backend/domain/post/service/PostService.java
@@ -4,6 +4,7 @@ import com.backend.domain.member.entity.Member;
 import com.backend.domain.member.exception.NotFoundMemberException;
 import com.backend.domain.member.repository.MemberRepository;
 import com.backend.domain.post.dto.PostDetailResponse;
+import com.backend.domain.post.dto.PostItem;
 import com.backend.domain.post.dto.PostListResponse;
 import com.backend.domain.post.dto.PostModifyRequest;
 import com.backend.domain.post.dto.PostWriteRequest;
@@ -15,8 +16,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,8 +49,7 @@ public class PostService {
     @Transactional(readOnly = true)
     public PostListResponse postListResponse(int page) {
         page = page <= 0 ? 0 : page - 1;
-        Pageable pageable = PageRequest.of(page, 10, Sort.Direction.DESC, "id");
-        Page<Post> postPage = postRepository.findAll(pageable);
+        Page<PostItem> postPage = postRepository.findAllPosts(PageRequest.of(page, 10));
         return new PostListResponse(postPage);
     }
 

--- a/backend/src/main/resources/static/docs/index.html
+++ b/backend/src/main/resources/static/docs/index.html
@@ -742,7 +742,7 @@ Content-Type: application/json
   "title" : "title",
   "writer" : "writer",
   "content" : "content",
-  "createdAt" : "2025-03-06T15:44:45.444282"
+  "createdAt" : "2025-03-09T00:33:22.937867"
 }</code></pre>
 </div>
 </div>
@@ -831,7 +831,8 @@ Content-Type: application/json
     "postId" : 1,
     "title" : "title",
     "writer" : "writer",
-    "createdAt" : "2025-03-06T15:44:45.421486"
+    "createdAt" : "2025-03-09T00:33:22.907774",
+    "commentCount" : 5
   } ],
   "page" : 1,
   "totalPages" : 1,
@@ -881,6 +882,11 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>posts[0].createdAt</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">작성일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>posts[0].commentCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 개수</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
@@ -1116,7 +1122,7 @@ Content-Type: application/json
     "commentId" : 1,
     "writer" : "writer",
     "content" : "comment",
-    "createdAt" : "2025-03-06T15:44:44.448892"
+    "createdAt" : "2025-03-09T00:33:21.856719"
   } ],
   "page" : 1,
   "totalPages" : 1,
@@ -1423,7 +1429,7 @@ Authorization: Bearer access-token</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1<br>
-Last updated 2025-03-06 15:44:31 +0900
+Last updated 2025-03-06 15:47:24 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/test/java/com/backend/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/backend/domain/post/controller/PostControllerTest.java
@@ -216,7 +216,7 @@ class PostControllerTest extends ControllerTest {
     @Test
     void postList() throws Exception {
         List<PostItem> posts = List.of(
-                new PostItem(1L, "title", "writer", LocalDateTime.now())
+                new PostItem(1L, "title", "writer", LocalDateTime.now(), 5)
         );
         PostListResponse postListResponse = new PostListResponse(posts, 1, 1, 1, true, true, false, false);
 
@@ -232,6 +232,7 @@ class PostControllerTest extends ControllerTest {
                         jsonPath("$.posts[0].title").value("title"),
                         jsonPath("$.posts[0].writer").value("writer"),
                         jsonPath("$.posts[0].createdAt").isNotEmpty(),
+                        jsonPath("$.posts[0].commentCount").value(5),
                         jsonPath("$.page").value(1),
                         jsonPath("$.totalPages").value(1),
                         jsonPath("$.totalPosts").value(1),
@@ -251,6 +252,7 @@ class PostControllerTest extends ControllerTest {
                                 fieldWithPath("posts[0].title").type(JsonFieldType.STRING).description("제목"),
                                 fieldWithPath("posts[0].writer").type(JsonFieldType.STRING).description("작성자"),
                                 fieldWithPath("posts[0].createdAt").type(JsonFieldType.STRING).description("작성일"),
+                                fieldWithPath("posts[0].commentCount").type(JsonFieldType.NUMBER).description("댓글 개수"),
                                 fieldWithPath("page").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
                                 fieldWithPath("totalPages").type(JsonFieldType.NUMBER).description("전체 페이지 개수"),
                                 fieldWithPath("totalPosts").type(JsonFieldType.NUMBER).description("전체 게시글 개수"),

--- a/backend/src/test/java/com/backend/domain/post/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/com/backend/domain/post/repository/PostRepositoryTest.java
@@ -2,6 +2,7 @@ package com.backend.domain.post.repository;
 
 import com.backend.domain.member.entity.Member;
 import com.backend.domain.member.repository.MemberRepository;
+import com.backend.domain.post.dto.PostItem;
 import com.backend.domain.post.entity.Post;
 import com.backend.global.common.config.JpaAuditingConfig;
 
@@ -19,8 +20,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -116,9 +115,9 @@ class PostRepositoryTest {
         postRepository.delete(findPost);
     }
 
-    @DisplayName("게시글 목록을 조회한다.")
+    @DisplayName("댓글 개수가 포함된 게시글 목록을 PostItem DTO 형식으로 조회한다.")
     @Test
-    void postFindAll() {
+    void postFindAllPostWithCommentCount() {
         Post post = Post.builder()
                 .title("title")
                 .writer(member.getNickname())
@@ -127,8 +126,7 @@ class PostRepositoryTest {
                 .build();
         postRepository.save(post);
 
-        Pageable pageable = PageRequest.of(0, 10, Sort.Direction.DESC, "id");
-        Page<Post> postPage = postRepository.findAll(pageable);
+        Page<PostItem> postPage = postRepository.findAllPosts(PageRequest.of(0, 10));
 
         assertThat(postPage.getContent()).isNotNull();
         assertThat(postPage.getNumber()).isEqualTo(0);

--- a/backend/src/test/java/com/backend/domain/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/backend/domain/post/service/PostServiceTest.java
@@ -4,6 +4,7 @@ import com.backend.domain.member.entity.Member;
 import com.backend.domain.member.exception.NotFoundMemberException;
 import com.backend.domain.member.repository.MemberRepository;
 import com.backend.domain.post.dto.PostDetailResponse;
+import com.backend.domain.post.dto.PostItem;
 import com.backend.domain.post.dto.PostListResponse;
 import com.backend.domain.post.dto.PostModifyRequest;
 import com.backend.domain.post.dto.PostWriteRequest;
@@ -22,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -127,12 +129,12 @@ class PostServiceTest {
     @DisplayName("게시글 목록을 조회한다.")
     @Test
     void postList() {
-        List<Post> content = List.of(
-                new Post("title", "writer", "content", member)
+        List<PostItem> content = List.of(
+                new PostItem(1L, "title", "writer", LocalDateTime.now(), 5)
         );
-        PageImpl<Post> postPage = new PageImpl<>(content);
+        PageImpl<PostItem> postPage = new PageImpl<>(content);
 
-        given(postRepository.findAll(any(Pageable.class))).willReturn(postPage);
+        given(postRepository.findAllPosts(any(Pageable.class))).willReturn(postPage);
 
         PostListResponse postListResponse = postService.postListResponse(1);
 
@@ -144,7 +146,7 @@ class PostServiceTest {
         assertThat(postListResponse.isLast()).isTrue();
         assertThat(postListResponse.isPrev()).isFalse();
         assertThat(postListResponse.isNext()).isFalse();
-        then(postRepository).should().findAll(any(Pageable.class));
+        then(postRepository).should().findAllPosts(any(Pageable.class));
     }
 
     @DisplayName("게시글을 수정한다.")


### PR DESCRIPTION
## 작업 내용

- 게시글 목록 응답에 각 게시글에 작성된 댓글 개수를 포함하도록 변경
- 게시글 목록조회 테스트 수정
- 게시글 목록조회 API에 댓글 개수 내용 추가

## 관련 이슈

- close #36

## 참고 사항