### PR TITLE
게시글 검색 api 구현

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -65,6 +65,17 @@ include::{snippets}/post-list/query-parameters.adoc[]
 include::{snippets}/post-list/http-response.adoc[]
 include::{snippets}/post-list/response-fields.adoc[]
 
+== 게시글 검색
+
+*요청*
+
+include::{snippets}/post-list-search/http-request.adoc[]
+include::{snippets}/post-list-search/query-parameters.adoc[]
+
+*응답*
+
+include::{snippets}/post-list-search/http-response.adoc[]
+
 == 게시글 수정
 
 *요청*

--- a/backend/src/main/java/com/backend/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/backend/domain/post/controller/PostController.java
@@ -48,7 +48,16 @@ public class PostController {
     @PreAuthorize("permitAll()")
     @GetMapping
     public ResponseEntity<PostListResponse> postList(@RequestParam("page") int page) {
-        PostListResponse postListResponse = postService.postListResponse(page);
+        PostListResponse postListResponse = postService.postList(page);
+        return ResponseEntity.ok().body(postListResponse);
+    }
+
+    @PreAuthorize("permitAll()")
+    @GetMapping("/search")
+    public ResponseEntity<PostListResponse> postListSearch(@RequestParam("type") String type,
+                                                           @RequestParam("keyword") String keyword,
+                                                           @RequestParam("page") int page) {
+        PostListResponse postListResponse = postService.postListSearch(type, keyword, page);
         return ResponseEntity.ok().body(postListResponse);
     }
 

--- a/backend/src/main/java/com/backend/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/backend/domain/post/repository/PostRepository.java
@@ -7,11 +7,37 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    @Query(value = "SELECT new com.backend.domain.post.dto.PostItem(p.id, p.title, p.writer, p.createdAt, COUNT(c.id)) FROM Post AS p " +
-            "LEFT JOIN Comment AS c ON p.id = c.post.id GROUP BY p.id ORDER BY p.id DESC", countQuery = "SELECT COUNT(p) FROM Post AS p")
-    Page<PostItem> findAllPosts(Pageable pageable);
+    @Query(
+            value = "SELECT new com.backend.domain.post.dto.PostItem(p.id, p.title, p.writer, p.createdAt, COUNT(c.id)) " +
+                    "FROM Post AS p " +
+                    "LEFT JOIN Comment AS c ON p.id = c.post.id " +
+                    "GROUP BY p.id " +
+                    "ORDER BY p.id DESC"
+    )
+    Page<PostItem> findAllPost(Pageable pageable);
+
+    @Query(
+            value = "SELECT new com.backend.domain.post.dto.PostItem(p.id, p.title, p.writer, p.createdAt, COUNT(c.id)) " +
+                    "FROM Post AS p " +
+                    "LEFT JOIN Comment AS c ON p.id = c.post.id " +
+                    "WHERE p.title LIKE %:keyword% " +
+                    "GROUP BY p.id " +
+                    "ORDER BY p.id DESC"
+    )
+    Page<PostItem> findAllPostByTitle(@Param("keyword") String keyword, Pageable pageable);
+
+    @Query(
+            value = "SELECT new com.backend.domain.post.dto.PostItem(p.id, p.title, p.writer, p.createdAt, COUNT(c.id)) " +
+                    "FROM Post AS p " +
+                    "LEFT JOIN Comment AS c ON p.id = c.post.id " +
+                    "WHERE p.writer LIKE %:keyword% " +
+                    "GROUP BY p.id " +
+                    "ORDER BY p.id DESC"
+    )
+    Page<PostItem> findAllPostByWriter(@Param("keyword") String keyword, Pageable pageable);
 
 }

--- a/backend/src/main/java/com/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/backend/domain/post/service/PostService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,9 +48,22 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public PostListResponse postListResponse(int page) {
+    public PostListResponse postList(int page) {
         page = page <= 0 ? 0 : page - 1;
-        Page<PostItem> postPage = postRepository.findAllPosts(PageRequest.of(page, 10));
+        Page<PostItem> postPage = postRepository.findAllPost(PageRequest.of(page, 10));
+        return new PostListResponse(postPage);
+    }
+
+    @Transactional(readOnly = true)
+    public PostListResponse postListSearch(String type, String keyword, int page) {
+        page = page <= 0 ? 0 : page - 1;
+        Pageable pageable = PageRequest.of(page, 10);
+        Page<PostItem> postPage = Page.empty();
+        if (type.equals("title")) {
+            postPage = postRepository.findAllPostByTitle(keyword, pageable);
+        } else if (type.equals("writer")) {
+            postPage = postRepository.findAllPostByWriter(keyword, pageable);
+        }
         return new PostListResponse(postPage);
     }
 

--- a/backend/src/main/java/com/backend/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/backend/global/security/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET,
                                 "/api/posts",
+                                "/api/posts/search",
                                 "/api/posts/*",
                                 "/api/posts/*/comments").permitAll()
                         .requestMatchers(HttpMethod.POST,

--- a/backend/src/main/java/com/backend/global/security/filter/AuthenticationFilter.java
+++ b/backend/src/main/java/com/backend/global/security/filter/AuthenticationFilter.java
@@ -67,6 +67,7 @@ public class AuthenticationFilter extends OncePerRequestFilter {
         MEMBER_LOGIN(HttpMethod.POST, "/api/auth/login", Authority.PERMIT_ALL),
         POST_DETAIL(HttpMethod.GET, "/api/posts/*", Authority.PERMIT_ALL),
         POST_LIST(HttpMethod.GET, "/api/posts", Authority.PERMIT_ALL),
+        POST_LIST_SEARCH(HttpMethod.GET, "/api/posts/search", Authority.PERMIT_ALL),
         COMMENT_LIST(HttpMethod.GET, "/api/posts/*/comments", Authority.PERMIT_ALL),
 
         // ROLE_MEMBER

--- a/backend/src/main/resources/static/docs/index.html
+++ b/backend/src/main/resources/static/docs/index.html
@@ -456,6 +456,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_게시글_작성">게시글 작성</a></li>
 <li><a href="#_게시글_상세조회">게시글 상세조회</a></li>
 <li><a href="#_게시글_목록조회">게시글 목록조회</a></li>
+<li><a href="#_게시글_검색">게시글 검색</a></li>
 <li><a href="#_게시글_수정">게시글 수정</a></li>
 <li><a href="#_게시글_삭제">게시글 삭제</a></li>
 <li><a href="#_댓글_목록">댓글 목록</a></li>
@@ -742,7 +743,7 @@ Content-Type: application/json
   "title" : "title",
   "writer" : "writer",
   "content" : "content",
-  "createdAt" : "2025-03-09T00:33:22.937867"
+  "createdAt" : "2025-03-12T19:10:24.780715"
 }</code></pre>
 </div>
 </div>
@@ -831,7 +832,7 @@ Content-Type: application/json
     "postId" : 1,
     "title" : "title",
     "writer" : "writer",
-    "createdAt" : "2025-03-09T00:33:22.907774",
+    "createdAt" : "2025-03-12T19:10:24.758377",
     "commentCount" : 5
   } ],
   "page" : 1,
@@ -925,6 +926,71 @@ Content-Type: application/json
 </tr>
 </tbody>
 </table>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_게시글_검색">게시글 검색</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>요청</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/posts/search?type=title&amp;keyword=ti&amp;page=1 HTTP/1.1</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>type</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">검색 유형</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>keyword</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">검색 단어</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 번호</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><strong>응답</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "posts" : [ {
+    "postId" : 1,
+    "title" : "title",
+    "writer" : "writer",
+    "createdAt" : "2025-03-12T19:10:24.705075",
+    "commentCount" : 5
+  } ],
+  "page" : 1,
+  "totalPages" : 1,
+  "totalPosts" : 1,
+  "first" : true,
+  "last" : true,
+  "prev" : false,
+  "next" : false
+}</code></pre>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -1122,7 +1188,7 @@ Content-Type: application/json
     "commentId" : 1,
     "writer" : "writer",
     "content" : "comment",
-    "createdAt" : "2025-03-09T00:33:21.856719"
+    "createdAt" : "2025-03-12T19:10:24.007641"
   } ],
   "page" : 1,
   "totalPages" : 1,
@@ -1429,7 +1495,7 @@ Authorization: Bearer access-token</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1<br>
-Last updated 2025-03-06 15:47:24 +0900
+Last updated 2025-03-12 19:08:50 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/test/java/com/backend/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/backend/domain/post/controller/PostControllerTest.java
@@ -220,7 +220,7 @@ class PostControllerTest extends ControllerTest {
         );
         PostListResponse postListResponse = new PostListResponse(posts, 1, 1, 1, true, true, false, false);
 
-        given(postService.postListResponse(anyInt())).willReturn(postListResponse);
+        given(postService.postList(anyInt())).willReturn(postListResponse);
 
         mockMvc.perform(get("/api/posts")
                         .param("page", "1")
@@ -244,6 +244,62 @@ class PostControllerTest extends ControllerTest {
                 .andDo(restdocs)
                 .andDo(restdocs.document(
                         queryParameters(
+                                parameterWithName("page").description("페이지 번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("posts").type(JsonFieldType.ARRAY).description("게시글 목록"),
+                                fieldWithPath("posts[0].postId").type(JsonFieldType.NUMBER).description("글번호"),
+                                fieldWithPath("posts[0].title").type(JsonFieldType.STRING).description("제목"),
+                                fieldWithPath("posts[0].writer").type(JsonFieldType.STRING).description("작성자"),
+                                fieldWithPath("posts[0].createdAt").type(JsonFieldType.STRING).description("작성일"),
+                                fieldWithPath("posts[0].commentCount").type(JsonFieldType.NUMBER).description("댓글 개수"),
+                                fieldWithPath("page").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+                                fieldWithPath("totalPages").type(JsonFieldType.NUMBER).description("전체 페이지 개수"),
+                                fieldWithPath("totalPosts").type(JsonFieldType.NUMBER).description("전체 게시글 개수"),
+                                fieldWithPath("first").type(JsonFieldType.BOOLEAN).description("첫번째 페이지 여부"),
+                                fieldWithPath("last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                                fieldWithPath("prev").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+                                fieldWithPath("next").type(JsonFieldType.BOOLEAN).description("이전 페이지 존재 여부")
+                        )
+                ));
+    }
+
+    @DisplayName("제목으로 게시글 목록을 조회에 성공하면 200을 응답한다.")
+    @Test
+    void postListSearch() throws Exception {
+        List<PostItem> posts = List.of(
+                new PostItem(1L, "title", "writer", LocalDateTime.now(), 5)
+        );
+        PostListResponse postListResponse = new PostListResponse(posts, 1, 1, 1, true, true, false, false);
+
+        given(postService.postListSearch(anyString(), anyString(), anyInt())).willReturn(postListResponse);
+
+        mockMvc.perform(get("/api/posts/search")
+                        .param("type", "title")
+                        .param("keyword", "ti")
+                        .param("page", "1")
+                )
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.posts").isArray(),
+                        jsonPath("$.posts[0].postId").value(1),
+                        jsonPath("$.posts[0].title").value("title"),
+                        jsonPath("$.posts[0].writer").value("writer"),
+                        jsonPath("$.posts[0].createdAt").isNotEmpty(),
+                        jsonPath("$.posts[0].commentCount").value(5),
+                        jsonPath("$.page").value(1),
+                        jsonPath("$.totalPages").value(1),
+                        jsonPath("$.totalPosts").value(1),
+                        jsonPath("$.first").value(true),
+                        jsonPath("$.last").value(true),
+                        jsonPath("$.prev").value(false),
+                        jsonPath("$.next").value(false)
+                )
+                .andDo(restdocs)
+                .andDo(restdocs.document(
+                        queryParameters(
+                                parameterWithName("type").description("검색 유형"),
+                                parameterWithName("keyword").description("검색 단어"),
                                 parameterWithName("page").description("페이지 번호")
                         ),
                         responseFields(

--- a/backend/src/test/java/com/backend/domain/post/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/com/backend/domain/post/repository/PostRepositoryTest.java
@@ -126,7 +126,53 @@ class PostRepositoryTest {
                 .build();
         postRepository.save(post);
 
-        Page<PostItem> postPage = postRepository.findAllPosts(PageRequest.of(0, 10));
+        Page<PostItem> postPage = postRepository.findAllPost(PageRequest.of(0, 10));
+
+        assertThat(postPage.getContent()).isNotNull();
+        assertThat(postPage.getNumber()).isEqualTo(0);
+        assertThat(postPage.getTotalElements()).isEqualTo(1);
+        assertThat(postPage.getTotalPages()).isEqualTo(1);
+        assertThat(postPage.isFirst()).isTrue();
+        assertThat(postPage.isLast()).isTrue();
+        assertThat(postPage.hasPrevious()).isFalse();
+        assertThat(postPage.hasNext()).isFalse();
+    }
+
+    @DisplayName("제목으로 게시글 목록을 검색한다.")
+    @Test
+    void postFindAllPostByTitle() {
+        Post post = Post.builder()
+                .title("title")
+                .writer(member.getNickname())
+                .content("content")
+                .member(member)
+                .build();
+        postRepository.save(post);
+
+        Page<PostItem> postPage = postRepository.findAllPostByTitle("ti", PageRequest.of(0, 10));
+
+        assertThat(postPage.getContent()).isNotNull();
+        assertThat(postPage.getNumber()).isEqualTo(0);
+        assertThat(postPage.getTotalElements()).isEqualTo(1);
+        assertThat(postPage.getTotalPages()).isEqualTo(1);
+        assertThat(postPage.isFirst()).isTrue();
+        assertThat(postPage.isLast()).isTrue();
+        assertThat(postPage.hasPrevious()).isFalse();
+        assertThat(postPage.hasNext()).isFalse();
+    }
+
+    @DisplayName("작성자로 게시글 목록을 검색한다.")
+    @Test
+    void postFindAllPostByWriter() {
+        Post post = Post.builder()
+                .title("title")
+                .writer(member.getNickname())
+                .content("content")
+                .member(member)
+                .build();
+        postRepository.save(post);
+
+        Page<PostItem> postPage = postRepository.findAllPostByWriter("yo", PageRequest.of(0, 10));
 
         assertThat(postPage.getContent()).isNotNull();
         assertThat(postPage.getNumber()).isEqualTo(0);

--- a/backend/src/test/java/com/backend/domain/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/backend/domain/post/service/PostServiceTest.java
@@ -134,9 +134,9 @@ class PostServiceTest {
         );
         PageImpl<PostItem> postPage = new PageImpl<>(content);
 
-        given(postRepository.findAllPosts(any(Pageable.class))).willReturn(postPage);
+        given(postRepository.findAllPost(any(Pageable.class))).willReturn(postPage);
 
-        PostListResponse postListResponse = postService.postListResponse(1);
+        PostListResponse postListResponse = postService.postList(1);
 
         assertThat(postListResponse.getPosts()).isNotNull();
         assertThat(postListResponse.getPage()).isEqualTo(1);
@@ -146,7 +146,30 @@ class PostServiceTest {
         assertThat(postListResponse.isLast()).isTrue();
         assertThat(postListResponse.isPrev()).isFalse();
         assertThat(postListResponse.isNext()).isFalse();
-        then(postRepository).should().findAllPosts(any(Pageable.class));
+        then(postRepository).should().findAllPost(any(Pageable.class));
+    }
+
+    @DisplayName("게시글을 검색한다.")
+    @Test
+    void postListSearch() {
+        List<PostItem> content = List.of(
+                new PostItem(1L, "title", "writer", LocalDateTime.now(), 5)
+        );
+        PageImpl<PostItem> postPage = new PageImpl<>(content);
+
+        given(postRepository.findAllPostByTitle(anyString(), any(Pageable.class))).willReturn(postPage);
+
+        PostListResponse postListResponse = postService.postListSearch("title", "ti", 1);
+
+        assertThat(postListResponse.getPosts()).isNotNull();
+        assertThat(postListResponse.getPage()).isEqualTo(1);
+        assertThat(postListResponse.getTotalPosts()).isEqualTo(1);
+        assertThat(postListResponse.getTotalPages()).isEqualTo(1);
+        assertThat(postListResponse.isFirst()).isTrue();
+        assertThat(postListResponse.isLast()).isTrue();
+        assertThat(postListResponse.isPrev()).isFalse();
+        assertThat(postListResponse.isNext()).isFalse();
+        then(postRepository).should().findAllPostByTitle(anyString(), any(Pageable.class));
     }
 
     @DisplayName("게시글을 수정한다.")


### PR DESCRIPTION
## 작업 내용

- 게시글 검색 기능 추가
  - 게시글 검색 요청 권한 전부 허용 설정
  - 검색 유형: 제목 또는 작성자
- 게시글 검색 기능 테스트 추가
- API 문서에 게시글 검색 API 내용 추가

## 관련 이슈

- close #38

## 참고 사항