### PR TITLE
댓글 수정 및 삭제 시 작성자 검증 기능 추가

### DIFF
--- a/backend/src/main/java/com/backend/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/backend/domain/comment/controller/CommentController.java
@@ -50,16 +50,18 @@ public class CommentController {
     @PutMapping("/{postId}/comments/{commentId}")
     public ResponseEntity<Void> commentModify(@PathVariable("postId") Long postId,
                                               @PathVariable("commentId") Long commentId,
+                                              @AuthenticationPrincipal String username,
                                               @RequestBody @Valid CommentModifyRequest commentModifyRequest) {
-        commentService.commentModify(postId, commentId, commentModifyRequest);
+        commentService.commentModify(postId, commentId, username, commentModifyRequest);
         return ResponseEntity.ok().build();
     }
 
     @PreAuthorize("hasRole('MEMBER')")
     @DeleteMapping("/{postId}/comments/{commentId}")
     public ResponseEntity<Void> commentDelete(@PathVariable("postId") Long postId,
-                                              @PathVariable("commentId") Long commentId) {
-        commentService.commentDelete(postId, commentId);
+                                              @PathVariable("commentId") Long commentId,
+                                              @AuthenticationPrincipal String username) {
+        commentService.commentDelete(postId, commentId, username);
         return ResponseEntity.ok().build();
     }
 

--- a/backend/src/main/java/com/backend/domain/comment/exception/AccessDeniedCommentException.java
+++ b/backend/src/main/java/com/backend/domain/comment/exception/AccessDeniedCommentException.java
@@ -1,0 +1,12 @@
+package com.backend.domain.comment.exception;
+
+import com.backend.global.error.exception.BoardException;
+import com.backend.global.error.exception.ErrorType;
+
+public class AccessDeniedCommentException extends BoardException {
+
+    public AccessDeniedCommentException() {
+        super(ErrorType.ACCESS_DENIED_COMMENT);
+    }
+
+}

--- a/backend/src/main/java/com/backend/global/error/exception/ErrorType.java
+++ b/backend/src/main/java/com/backend/global/error/exception/ErrorType.java
@@ -22,6 +22,7 @@ public enum ErrorType {
 
     // 403
     ACCESS_DENIED_POST(HttpStatus.FORBIDDEN, "E403001", "다른 사용자의 게시글을 수정/삭제 할 수 없습니다."),
+    ACCESS_DENIED_COMMENT(HttpStatus.FORBIDDEN, "E403002", "다른 사용자의 댓글을 수정/삭제 할 수 없습니다."),
 
     // 404
     NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND, " E404001", "토큰이 존재하지 않습니다."),


### PR DESCRIPTION
## 작업 내용

- 댓글 수정 및 삭제 시 작성자 검증 기능 추가
  - 작성자가 아닌데 수정, 삭제를 시도하면 예외 발생

## 관련 이슈

- close #42

## 참고 사항